### PR TITLE
Fix a typo with the package manifest

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.0.0"),
-        .package(url: "https://github.com/apple/swift-metrics.git", from: "1.0.0-a"),
+        .package(url: "https://github.com/apple/swift-metrics.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
     ],
     targets: [


### PR DESCRIPTION
Fixes a typo with the Package.swift manifest. This was causing issues with the new Beta tag for Vapor