### PR TITLE
add data type to bind

### DIFF
--- a/Sources/PostgresNIO/Connection/PostgresClient+Query.swift
+++ b/Sources/PostgresNIO/Connection/PostgresClient+Query.swift
@@ -90,7 +90,7 @@ private final class PostgresParameterizedQuery: PostgresRequest {
         let parse = PostgresMessage.Parse(
             statementName: "",
             query: self.query,
-            parameterTypes: []
+            parameterTypes: self.binds.map { $0.type }
         )
         let describe = PostgresMessage.Describe(
             command: .statement,

--- a/Sources/PostgresNIO/Data/PostgresData+String.swift
+++ b/Sources/PostgresNIO/Data/PostgresData+String.swift
@@ -46,6 +46,8 @@ extension PostgresData {
                 return self.double?.description
             case .int2, .int4, .int8:
                 return self.int?.description
+            case .bpchar:
+                return self.character?.description
             default:
                 return nil
             }
@@ -54,6 +56,27 @@ extension PostgresData {
                 return nil
             }
             return string
+        }
+    }
+    
+    public var character: Character? {
+        guard var value = self.value else {
+            return nil
+        }
+        
+        switch self.formatCode {
+        case .binary:
+            switch self.type {
+            case .bpchar:
+                guard let byte = value.readInteger(as: UInt8.self) else {
+                    return nil
+                }
+                return Character(UnicodeScalar(byte))
+            default:
+                return nil
+            }
+        case .text:
+            return nil
         }
     }
 }

--- a/Sources/PostgresNIO/Data/PostgresData+UUID.swift
+++ b/Sources/PostgresNIO/Data/PostgresData+UUID.swift
@@ -17,7 +17,19 @@ extension PostgresData {
             return nil
         }
         
-        return value.readUUID()
+        switch self.formatCode {
+        case .binary:
+            switch self.type {
+            case .uuid:
+                return value.readUUID()
+            case .varchar, .text:
+                return self.string.flatMap { UUID(uuidString: $0) }
+            default:
+                return nil
+            }
+        case .text:
+            return nil
+        }
     }
 }
 

--- a/Sources/PostgresNIO/Message/PostgresMessage+Parse.swift
+++ b/Sources/PostgresNIO/Message/PostgresMessage+Parse.swift
@@ -17,7 +17,7 @@ extension PostgresMessage {
         /// Note that this is not an indication of the number of parameters that might appear in the
         /// query string, only the number that the frontend wants to prespecify types for.
         /// Specifies the object ID of the parameter data type. Placing a zero here is equivalent to leaving the type unspecified.
-        public var parameterTypes: [PostgresFormatCode]
+        public var parameterTypes: [PostgresDataType]
         
         /// Serializes this message into a byte buffer.
         public func serialize(into buffer: inout ByteBuffer) {

--- a/Tests/PostgresNIOTests/NIOPostgresTests.swift
+++ b/Tests/PostgresNIOTests/NIOPostgresTests.swift
@@ -578,7 +578,7 @@ final class NIOPostgresTests: XCTestCase {
 
     }
 
-    func testBindChar() throws {
+    func testBindCharString() throws {
         // https://github.com/vapor/postgres-nio/issues/53
         let query = """
         SELECT $1::char as "char"
@@ -587,7 +587,17 @@ final class NIOPostgresTests: XCTestCase {
         defer { try! conn.close().wait() }
         let rows = try conn.query(query, [.init(string: "f")]).wait()
         XCTAssertEqual(rows[0].column("char")?.string, "f")
+    }
 
+    func testBindCharUInt8() throws {
+        // https://github.com/vapor/postgres-nio/issues/53
+        let query = """
+        SELECT $1::char as "char"
+        """
+        let conn = try PostgresConnection.test(on: eventLoop).wait()
+        defer { try! conn.close().wait() }
+        let rows = try conn.query(query, [.init(uint8: 42)]).wait()
+        XCTAssertEqual(rows[0].column("char")?.string, "*")
     }
     
     // MARK: Performance

--- a/Tests/PostgresNIOTests/XCTestManifests.swift
+++ b/Tests/PostgresNIOTests/XCTestManifests.swift
@@ -7,6 +7,8 @@ extension NIOPostgresTests {
     // to regenerate.
     static let __allTests__NIOPostgresTests = [
         ("testAverageLengthNumeric", testAverageLengthNumeric),
+        ("testBindCharString", testBindCharString),
+        ("testBindCharUInt8", testBindCharUInt8),
         ("testBindDate", testBindDate),
         ("testBindInteger", testBindInteger),
         ("testBoolSerialize", testBoolSerialize),


### PR DESCRIPTION
Adds data type to `PostgresMessage.Parse` plus test to ensure `String` / `UInt8` can convert to `CHAR`. 