### PR TITLE
array of double fixes

### DIFF
--- a/Sources/PostgresNIO/Data/PostgresData+Double.swift
+++ b/Sources/PostgresNIO/Data/PostgresData+Double.swift
@@ -1,8 +1,8 @@
 extension PostgresData {
     public init(double: Double) {
         var buffer = ByteBufferAllocator().buffer(capacity: 0)
-        buffer.writeString(double.description)
-        self.init(type: .float8, formatCode: .text, value: buffer)
+        buffer.writeDouble(double)
+        self.init(type: .float8, formatCode: .binary, value: buffer)
     }
     
     public var double: Double? {

--- a/Sources/PostgresNIO/Data/PostgresData.swift
+++ b/Sources/PostgresNIO/Data/PostgresData.swift
@@ -56,6 +56,14 @@ public struct PostgresData: CustomStringConvertible, CustomDebugStringConvertibl
             description = self.uuid?.description
         case .uuidArray:
             description = self.array(of: UUID.self)?.description
+        case .int8Array:
+            description = self.array(of: Int.self)?.description
+        case .float8Array:
+            description = self.array(of: Double.self)?.description
+        case .float4Array:
+            description = self.array(of: Float.self)?.description
+        case .jsonb:
+            description = String(decoding: value.readableBytesView, as: UTF8.self)
         default:
             description = nil
         }

--- a/Sources/PostgresNIO/Utilities/NIOUtils.swift
+++ b/Sources/PostgresNIO/Utilities/NIOUtils.swift
@@ -74,6 +74,14 @@ internal extension ByteBuffer {
         return self.readInteger(as: UInt64.self).map { Double(bitPattern: $0) }
     }
 
+    mutating func writeFloat(_ float: Float) {
+        self.writeInteger(float.bitPattern)
+    }
+
+    mutating func writeDouble(_ double: Double) {
+        self.writeInteger(double.bitPattern)
+    }
+
     mutating func readUUID() -> UUID? {
         guard self.readableBytes >= MemoryLayout<UUID>.size else {
             return nil

--- a/Tests/PostgresNIOTests/PostgresNIOTests.swift
+++ b/Tests/PostgresNIOTests/PostgresNIOTests.swift
@@ -2,7 +2,7 @@ import Logging
 import PostgresNIO
 import XCTest
 
-final class NIOPostgresTests: XCTestCase {
+final class PostgresNIOTests: XCTestCase {
     private var group: EventLoopGroup!
     private var eventLoop: EventLoop {
         return self.group.next()
@@ -853,6 +853,20 @@ final class NIOPostgresTests: XCTestCase {
             }
         }
     }
+
+    func testDoubleArraySerialization() throws {
+        let conn = try PostgresConnection.test(on: eventLoop).wait()
+        defer { try! conn.close().wait() }
+        let doubles: [Double] = [3.14, 42]
+        let rows = try conn.query("""
+        select
+            $1::double precision[] as doubles
+        """, [
+            .init(array: doubles)
+        ]).wait()
+        XCTAssertEqual(rows[0].column("doubles")?.array(of: Double.self), doubles)
+    }
+
 }
 
 


### PR DESCRIPTION
Fixes `PostgresData(double:)` to correctly serialize double bit pattern. 