### PR TITLE
char(n) (BPCHAR) length fix

### DIFF
--- a/Sources/PostgresNIO/Data/PostgresData+Int.swift
+++ b/Sources/PostgresNIO/Data/PostgresData+Int.swift
@@ -116,7 +116,9 @@ private extension PostgresData {
         case .binary:
             switch self.type {
             case .char, .bpchar:
-                assert(value.readableBytes == 1)
+                guard value.readableBytes == 1 else {
+                    return nil
+                }
                 guard let uint8 = value.getInteger(at: value.readerIndex, as: UInt8.self) else {
                     return nil
                 }

--- a/Sources/PostgresNIO/Data/PostgresData+String.swift
+++ b/Sources/PostgresNIO/Data/PostgresData+String.swift
@@ -47,7 +47,7 @@ extension PostgresData {
             case .int2, .int4, .int8:
                 return self.int?.description
             case .bpchar:
-                return self.character?.description
+                return value.readString(length: value.readableBytes)
             default:
                 return nil
             }


### PR DESCRIPTION
The `char(n)` (`BPCHAR`) data type now correctly supports values longer than one byte when converting to fixed-width integers or strings (fixes #71, fixes #79, #72).