### PR TITLE
Remove BPCHAR to Swift Integer conversion

### DIFF
--- a/Sources/PostgresNIO/Data/PostgresData+Int.swift
+++ b/Sources/PostgresNIO/Data/PostgresData+Int.swift
@@ -115,7 +115,7 @@ private extension PostgresData {
         switch self.formatCode {
         case .binary:
             switch self.type {
-            case .char, .bpchar:
+            case .char:
                 assert(value.readableBytes == 1)
                 guard let uint8 = value.getInteger(at: value.readerIndex, as: UInt8.self) else {
                     return nil

--- a/Tests/PostgresNIOTests/PostgresNIOTests.swift
+++ b/Tests/PostgresNIOTests/PostgresNIOTests.swift
@@ -986,7 +986,7 @@ final class PostgresNIOTests: XCTestCase {
         defer { try! conn.close().wait() }
         let rows = try conn.query("""
         select
-            $1::char as int
+            $1::"char" as int
         """, [
             .init(uint8: 5)
         ]).wait()


### PR DESCRIPTION
Removes support for converting `PostgresData` containing `BPCHAR` bytes (`CHARACTER(n)`, `CHAR`, etc) to Swift integers. Postgres `CHAR(n)` fields may be padded with extra zero-bytes which makes conversion tricky. Since Postgres intends `CHARACTER` fields to store string values, `PostgresData` should only support conversion to Swift strings. To store 8-bits natively, use Postgres `"char"` type (note the quotes).