### PR TITLE
User-defined Enum + Optional Fix

### DIFF
--- a/Sources/PostgresNIO/Data/PostgresData+Optional.swift
+++ b/Sources/PostgresNIO/Data/PostgresData+Optional.swift
@@ -12,7 +12,7 @@ extension Optional: PostgresDataConvertible where Wrapped: PostgresDataConvertib
         case .some(let wrapped):
             return wrapped.postgresData
         case .none:
-            return PostgresData.null
+            return .init(type: Wrapped.postgresDataType, value: nil)
         }
     }
 }

--- a/Sources/PostgresNIO/Data/PostgresData+String.swift
+++ b/Sources/PostgresNIO/Data/PostgresData+String.swift
@@ -49,7 +49,12 @@ extension PostgresData {
             case .bpchar:
                 return self.character?.description
             default:
-                return nil
+                if self.type.isUserDefined {
+                    // custom type
+                    return value.readString(length: value.readableBytes)
+                } else {
+                    return nil
+                }
             }
         case .text:
             guard let string = value.readString(length: value.readableBytes) else {

--- a/Sources/PostgresNIO/Data/PostgresData.swift
+++ b/Sources/PostgresNIO/Data/PostgresData.swift
@@ -71,7 +71,12 @@ public struct PostgresData: CustomStringConvertible, CustomDebugStringConvertibl
         case .jsonbArray:
             description = self.array?.description
         default:
-            description = nil
+            if self.type.isUserDefined {
+                // custom type
+                description = value.readString(length: value.readableBytes)
+            } else {
+                description = nil
+            }
         }
 
         if let description = description {

--- a/Sources/PostgresNIO/Data/PostgresDataType.swift
+++ b/Sources/PostgresNIO/Data/PostgresDataType.swift
@@ -106,6 +106,13 @@ public struct PostgresDataType: Codable, Equatable, ExpressibleByIntegerLiteral,
 
     /// The raw data type code recognized by PostgreSQL.
     public var rawValue: UInt32
+
+    /// Returns `true` if the type's raw value is greater than `2^14`.
+    /// This _appears_ to be true for all user-defined types, but I don't
+    /// have any documentation to back this up.
+    public var isUserDefined: Bool {
+        self.rawValue >= 1 << 14
+    }
     
     /// See `ExpressibleByIntegerLiteral.init(integerLiteral:)`
     public init(integerLiteral value: UInt32) {


### PR DESCRIPTION
Bound optional values that are `nil` should no longer result in an unexpected type warning (fixes https://github.com/vapor/postgres-nio/issues/74)

`PostgresData` will now return strings correctly for user-defined types like enums. 