### PR TITLE
Handle NAME Type in PropertyData.string Property

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
     - run: swift test --enable-test-discovery --sanitize=thread
   fluent:
     container: 
-      image: vapor/swift:5.1
+      image: vapor/swift:5.2
     services:
       psql:
         image: postgres

--- a/Sources/PostgresNIO/Data/PostgresData+String.swift
+++ b/Sources/PostgresNIO/Data/PostgresData+String.swift
@@ -12,7 +12,7 @@ extension PostgresData {
         switch self.formatCode {
         case .binary:
             switch self.type {
-            case .varchar, .text:
+            case .varchar, .text, .name:
                 guard let string = value.readString(length: value.readableBytes) else {
                     return nil
                 }


### PR DESCRIPTION
Allows data that is contained as the `.name` type to be accessed through the `PostgresData.string` property.

```swift
var buffer = ByteBufferAllocator().buffer(capacity: 13)
buffer.writeString("password_hash")

let data = PostgresData(.name, value: buffer)
let string = data.string

// string == "password_hash"
```