### PR TITLE
Add query metadata

### DIFF
--- a/Sources/PostgresNIO/Message/PostgresMessage+CommandComplete.swift
+++ b/Sources/PostgresNIO/Message/PostgresMessage+CommandComplete.swift
@@ -2,7 +2,7 @@ import NIO
 
 extension PostgresMessage {
     /// Identifies the message as a Close command.
-    public struct CommandComplete {
+    public struct CommandComplete: PostgresMessageType {
         /// Parses an instance of this message type from a byte buffer.
         public static func parse(from buffer: inout ByteBuffer) throws -> CommandComplete {
             guard let string = buffer.readNullTerminatedString() else {


### PR DESCRIPTION
Adds new API for accessing query metadata via `conn.query` (fixes #93).

```swift
conn.query("...", onMetadata: { metadata in 
    print(metadata.rows) // Int?
}) { row in 
    print(row) // PostgresRow
}.wait()
```

This is a breaking change since `conn.query` now returns `PostgresQueryResult` instead of `[PostgresRow]`. However, `PostgresQueryResult` conforms to `Collection` so most code should be unaffected. 

```swift
let result = try conn.query("...").wait()
for row in result {
    print(row) // PostgresRow
}
print(result.metadata) // PostgresQueryMetadata
print(result.rows) // [PostgresRow]
```