### PR TITLE
Too many binds error

### DIFF
--- a/Sources/PostgresNIO/PostgresDatabase+Query.swift
+++ b/Sources/PostgresNIO/PostgresDatabase+Query.swift
@@ -179,6 +179,9 @@ private final class PostgresParameterizedQuery: PostgresRequest {
     }
 
     func start() throws -> [PostgresMessage] {
+        guard self.binds.count <= Int16.max else {
+            throw PostgresError.protocol("Bind count must be <= \(Int16.max).")
+        }
         let parse = PostgresMessage.Parse(
             statementName: "",
             query: self.query,

--- a/Tests/PostgresNIOTests/PostgresNIOTests.swift
+++ b/Tests/PostgresNIOTests/PostgresNIOTests.swift
@@ -904,7 +904,16 @@ final class PostgresNIOTests: XCTestCase {
         XCTAssertEqual(rows.metadata.oid, nil)
         XCTAssertEqual(rows.metadata.rows, 0)
     }
-    
+
+    func testTooManyBinds() throws {
+        let conn = try PostgresConnection.test(on: eventLoop).wait()
+        defer { try! conn.close().wait() }
+        let binds = [PostgresData].init(repeating: .null, count: Int(Int16.max) + 1)
+        do {
+            _ = try conn.query("SELECT version()", binds).wait()
+            XCTFail("Should have failed")
+        } catch PostgresError.connectionClosed { }
+    }
 }
 
 let isLoggingConfigured: Bool = {


### PR DESCRIPTION
Throw an error if too many binds (>= Int16.max) are sent in a parameterized query (#103, fixes #102). 