### PR TITLE
RawRepresentable + PostgresData conformance

### DIFF
--- a/Sources/PostgresNIO/Data/PostgresData+RawRepresentable.swift
+++ b/Sources/PostgresNIO/Data/PostgresData+RawRepresentable.swift
@@ -1,0 +1,16 @@
+extension RawRepresentable where Self.RawValue: PostgresDataConvertible {
+    static var postgresDataType: PostgresDataType {
+        RawValue.postgresDataType
+    }
+
+    init?(postgresData: PostgresData) {
+        guard let rawValue = RawValue.init(postgresData: postgresData) else {
+            return nil
+        }
+        self.init(rawValue: rawValue)
+    }
+
+    var postgresData: PostgresData? {
+        self.rawValue.postgresData
+    }
+}


### PR DESCRIPTION
Add default `PostgresDataConvertible` conformance to `RawRepresentable` where the raw value is postgres convertible (#105, vapor/postgres-kit#179).