### PR TITLE
Support remote close

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,16 +46,12 @@ jobs:
     services:
       postgres-a:
         image: postgres
-        ports:
-          - 5432:5432
         env:
           POSTGRES_USER: vapor_username
           POSTGRES_DB: vapor_database
           POSTGRES_PASSWORD: vapor_password
       postgres-b:
         image: postgres
-        ports:
-          - 5432:5432
         env:
           POSTGRES_USER: vapor_username
           POSTGRES_DB: vapor_database

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,3 +71,4 @@ jobs:
       env:
         POSTGRES_HOSTNAME_A: postgres-a
         POSTGRES_HOSTNAME_B: postgres-b
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,15 @@ jobs:
     container: 
       image: vapor/swift:5.2
     services:
-      psql:
+      postgres-a:
+        image: postgres
+        ports:
+          - 5432:5432
+        env:
+          POSTGRES_USER: vapor_username
+          POSTGRES_DB: vapor_database
+          POSTGRES_PASSWORD: vapor_password
+      postgres-b:
         image: postgres
         ports:
           - 5432:5432
@@ -61,4 +69,5 @@ jobs:
     - run: swift test --enable-test-discovery --sanitize=thread
       working-directory: ./fluent-postgres-driver
       env:
-        POSTGRES_HOSTNAME: psql
+        POSTGRES_HOSTNAME_A: postgres-a
+        POSTGRES_HOSTNAME_B: postgres-b

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@
 DerivedData
 Package.resolved
 .swiftpm
-
+Tests/LinuxMain.swift

--- a/Sources/PostgresNIO/Connection/PostgresConnection.swift
+++ b/Sources/PostgresNIO/Connection/PostgresConnection.swift
@@ -14,8 +14,6 @@ public final class PostgresConnection {
     
     public var logger: Logger
 
-    private var didClose: Bool
-
     public var isClosed: Bool {
         return !self.channel.isActive
     }
@@ -23,22 +21,16 @@ public final class PostgresConnection {
     init(channel: Channel, logger: Logger) {
         self.channel = channel
         self.logger = logger
-        self.didClose = false
     }
     
     public func close() -> EventLoopFuture<Void> {
-        guard !self.didClose else {
+        guard !self.isClosed else {
             return self.eventLoop.makeSucceededFuture(())
         }
-        self.didClose = true
-        if !self.isClosed {
-            return self.channel.close(mode: .all)
-        } else {
-            return self.eventLoop.makeSucceededFuture(())
-        }
+        return self.channel.close(mode: .all)
     }
     
     deinit {
-        assert(self.didClose, "PostgresConnection deinitialized before being closed.")
+        assert(self.isClosed, "PostgresConnection deinitialized before being closed.")
     }
 }

--- a/Tests/PostgresNIOTests/PostgresNIOTests.swift
+++ b/Tests/PostgresNIOTests/PostgresNIOTests.swift
@@ -1,5 +1,5 @@
 import Logging
-import PostgresNIO
+@testable import PostgresNIO
 import XCTest
 import NIOTestUtils
 
@@ -913,6 +913,11 @@ final class PostgresNIOTests: XCTestCase {
             _ = try conn.query("SELECT version()", binds).wait()
             XCTFail("Should have failed")
         } catch PostgresError.connectionClosed { }
+    }
+
+    func testRemoteClose() throws {
+        let conn = try PostgresConnection.test(on: eventLoop).wait()
+        try conn.channel.close().wait()
     }
 }
 

--- a/Tests/PostgresNIOTests/Utilities.swift
+++ b/Tests/PostgresNIOTests/Utilities.swift
@@ -4,11 +4,7 @@ import XCTest
 
 extension PostgresConnection {
     static func address() throws -> SocketAddress {
-        #if os(Linux)
-        return try .makeAddressResolvingHost("psql", port: 5432)
-        #else
-        return try .init(ipAddress: "127.0.0.1", port: 5432)
-        #endif
+        try .makeAddressResolvingHost(hostname, port: 5432)
     }
 
     static func testUnauthenticated(on eventLoop: EventLoop) -> EventLoopFuture<PostgresConnection> {
@@ -33,6 +29,18 @@ extension PostgresConnection {
                 }
             }
         }
+    }
+}
+
+var hostname: String {
+    if let hostname = env("POSTGRES_HOSTNAME") {
+        return hostname
+    } else {
+        #if os(Linux)
+        return "psql"
+        #else
+        return "localhost"
+        #endif
     }
 }
 


### PR DESCRIPTION
Adds support for recognizing a remote close as calling `close()` (fixes #107, #110)