### PR TITLE
Support parameter status messages in query / simpleQuery

### DIFF
--- a/Sources/PostgresNIO/Message/PostgresMessage+ParameterStatus.swift
+++ b/Sources/PostgresNIO/Message/PostgresMessage+ParameterStatus.swift
@@ -1,7 +1,7 @@
 import NIO
 
 extension PostgresMessage {
-    public struct ParameterStatus: CustomStringConvertible {
+    public struct ParameterStatus: PostgresMessageType, CustomStringConvertible {
         /// Parses an instance of this message type from a byte buffer.
         public static func parse(from buffer: inout ByteBuffer) throws -> ParameterStatus {
             guard let parameter = buffer.readNullTerminatedString() else {

--- a/Sources/PostgresNIO/PostgresDatabase+Query.swift
+++ b/Sources/PostgresNIO/PostgresDatabase+Query.swift
@@ -174,6 +174,8 @@ private final class PostgresParameterizedQuery: PostgresRequest {
             return []
         case .readyForQuery:
             return nil
+        case .parameterStatus:
+            return []
         default: throw PostgresError.protocol("Unexpected message during query: \(message)")
         }
     }

--- a/Sources/PostgresNIO/PostgresDatabase+SimpleQuery.swift
+++ b/Sources/PostgresNIO/PostgresDatabase+SimpleQuery.swift
@@ -56,6 +56,8 @@ private final class PostgresSimpleQuery: PostgresRequest {
             return []
         case .notificationResponse:
             return []
+        case .parameterStatus:
+            return []
         default:
             throw PostgresError.protocol("Unexpected message during simple query: \(message)")
         }

--- a/Tests/PostgresNIOTests/PostgresNIOTests.swift
+++ b/Tests/PostgresNIOTests/PostgresNIOTests.swift
@@ -928,6 +928,15 @@ final class PostgresNIOTests: XCTestCase {
         let res = try conn.query(#"SELECT '{"foo", "bar", "baz"}'::VARCHAR[] as foo"#).wait()
         XCTAssertEqual(res[0].column("foo")?.array(of: String.self), ["foo", "bar", "baz"])
     }
+
+    // https://github.com/vapor/postgres-nio/issues/115
+    func testSetTimeZone() throws {
+        let conn = try PostgresConnection.test(on: eventLoop).wait()
+        defer { try! conn.close().wait() }
+
+        _ = try conn.simpleQuery("SET TIME ZONE INTERVAL '+5:45' HOUR TO MINUTE").wait()
+        _ = try conn.query("SET TIME ZONE INTERVAL '+5:45' HOUR TO MINUTE").wait()
+    }
 }
 
 func env(_ name: String) -> String? {


### PR DESCRIPTION
Adds support for parameter status (`S`) messages in `query` and `simpleQuery` calls (#116, fixes #115). 