### PR TITLE
Integer overflow fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,17 +198,15 @@ let data: PostgresData= ...
 
 print(data.string) // String?
 
+// Postgres only supports signed Ints.
 print(data.int) // Int?
-print(data.int8) // Int8?
 print(data.int16) // Int16?
 print(data.int32) // Int32?
 print(data.int64) // Int64?
 
-print(data.uint) // UInt?
+// 'char' can be interpreted as a UInt8. 
+// It will show in db as a character though. 
 print(data.uint8) // UInt8?
-print(data.uint16) // UInt16?
-print(data.uint32) // UInt32?
-print(data.uint64) // UInt64?
 
 print(data.bool) // Bool?
 

--- a/Sources/PostgresNIO/Deprecated/PostgresData+UInt.swift
+++ b/Sources/PostgresNIO/Deprecated/PostgresData+UInt.swift
@@ -14,6 +14,8 @@ private func warn(
     but may cause overflow. To avoid overflow errors, update
     your code to use \(new) instead.
 
+    See https://github.com/vapor/postgres-nio/pull/120
+
     """, file: file, line: line)
 }
 

--- a/Sources/PostgresNIO/Deprecated/PostgresData+UInt.swift
+++ b/Sources/PostgresNIO/Deprecated/PostgresData+UInt.swift
@@ -1,0 +1,160 @@
+private func warn(
+    _ old: Any.Type, mustBeConvertedTo new: Any.Type,
+    file: StaticString = #file, line: UInt = #line
+) {
+    assertionFailure("""
+    Integer conversion unsafe.
+    Postgres does not support storing \(old) natively.
+
+    To bypass this assertion, compile in release mode.
+
+        swift build -c release
+
+    Unsigned integers were previously allowed by PostgresNIO
+    but may cause overflow. To avoid overflow errors, update
+    your code to use \(new) instead.
+
+    """, file: file, line: line)
+}
+
+extension PostgresData {
+    @available(*, deprecated, renamed: "init(int:)")
+    public init(uint value: UInt) {
+        warn(UInt.self, mustBeConvertedTo: Int.self)
+        self.init(int: .init(bitPattern: value))
+    }
+
+    @available(*, deprecated, renamed: "init(uint8:)")
+    public init(int8 value: Int8) {
+        warn(Int8.self, mustBeConvertedTo: UInt8.self)
+        self.init(uint8: .init(bitPattern: value))
+    }
+
+    @available(*, deprecated, renamed: "init(int16:)")
+    public init(uint16 value: UInt16) {
+        warn(UInt16.self, mustBeConvertedTo: Int16.self)
+        self.init(int16: .init(bitPattern: value))
+    }
+
+    @available(*, deprecated, renamed: "init(int32:)")
+    public init(uint32 value: UInt32) {
+        warn(UInt32.self, mustBeConvertedTo: Int32.self)
+        self.init(int32: .init(bitPattern: value))
+    }
+
+    @available(*, deprecated, renamed: "init(int64:)")
+    public init(uint64 value: UInt64) {
+        warn(UInt64.self, mustBeConvertedTo: Int64.self)
+        self.init(int64: .init(bitPattern: value))
+    }
+
+    @available(*, deprecated, renamed: "int")
+    public var uint: UInt? {
+        warn(UInt.self, mustBeConvertedTo: Int.self)
+        return self.int.flatMap { .init(bitPattern: $0) }
+    }
+
+    @available(*, deprecated, renamed: "uint8")
+    public var int8: Int8? {
+        warn(Int8.self, mustBeConvertedTo: UInt8.self)
+        return self.uint8.flatMap { .init(bitPattern: $0) }
+    }
+
+    @available(*, deprecated, renamed: "int16")
+    public var uint16: UInt16? {
+        warn(UInt16.self, mustBeConvertedTo: Int16.self)
+        return self.int16.flatMap { .init(bitPattern: $0) }
+    }
+
+    @available(*, deprecated, renamed: "int32")
+    public var uint32: UInt32? {
+        warn(UInt32.self, mustBeConvertedTo: Int32.self)
+        return self.int32.flatMap { .init(bitPattern: $0) }
+    }
+
+    @available(*, deprecated, renamed: "int64")
+    public var uint64: UInt64? {
+        warn(UInt64.self, mustBeConvertedTo: Int64.self)
+        return self.int64.flatMap { .init(bitPattern: $0) }
+    }
+}
+
+@available(*, deprecated, message: "Use 'Int' instead.")
+extension UInt: PostgresDataConvertible {
+    public static var postgresDataType: PostgresDataType { .int8 }
+
+    public init?(postgresData: PostgresData) {
+        guard let uint = postgresData.uint else {
+            return nil
+        }
+        self = uint
+    }
+
+    public var postgresData: PostgresData? {
+        .init(uint: self)
+    }
+}
+
+@available(*, deprecated, message: "Use 'UInt8' instead.")
+extension Int8: PostgresDataConvertible {
+    public static var postgresDataType: PostgresDataType { .char }
+
+    public init?(postgresData: PostgresData) {
+        guard let int8 = postgresData.int8 else {
+            return nil
+        }
+        self = int8
+    }
+
+    public var postgresData: PostgresData? {
+        .init(int8: self)
+    }
+}
+
+@available(*, deprecated, message: "Use 'Int16' instead.")
+extension UInt16: PostgresDataConvertible {
+    public static var postgresDataType: PostgresDataType { .int2 }
+
+    public init?(postgresData: PostgresData) {
+        guard let uint16 = postgresData.uint16 else {
+            return nil
+        }
+        self = uint16
+    }
+
+    public var postgresData: PostgresData? {
+        .init(uint16:  self)
+    }
+}
+
+@available(*, deprecated, message: "Use 'Int32' instead.")
+extension UInt32: PostgresDataConvertible {
+    public static var postgresDataType: PostgresDataType { .int4 }
+
+    public init?(postgresData: PostgresData) {
+        guard let uint32 = postgresData.uint32 else {
+            return nil
+        }
+        self = uint32
+    }
+
+    public var postgresData: PostgresData? {
+        .init(uint32: self)
+    }
+}
+
+@available(*, deprecated, message: "Use 'Int64' instead.")
+extension UInt64: PostgresDataConvertible {
+    public static var postgresDataType: PostgresDataType { .int8 }
+
+    public init?(postgresData: PostgresData) {
+        guard let uint64 = postgresData.uint64 else {
+            return nil
+        }
+        self = uint64
+    }
+
+    public var postgresData: PostgresData? {
+        .init(uint64: self)
+    }
+}

--- a/Tests/PostgresNIOTests/PostgresNIOTests.swift
+++ b/Tests/PostgresNIOTests/PostgresNIOTests.swift
@@ -860,10 +860,10 @@ final class PostgresNIOTests: XCTestCase {
             '5'::char(2) as two
         """).wait()
         XCTAssertEqual(rows[0].column("one")?.uint8, 53)
-        XCTAssertEqual(rows[0].column("one")?.uint16, 53)
+        XCTAssertEqual(rows[0].column("one")?.int16, 53)
         XCTAssertEqual(rows[0].column("one")?.string, "5")
         XCTAssertEqual(rows[0].column("two")?.uint8, nil)
-        XCTAssertEqual(rows[0].column("two")?.uint16, nil)
+        XCTAssertEqual(rows[0].column("two")?.int16, nil)
         XCTAssertEqual(rows[0].column("two")?.string, "5 ")
     }
 


### PR DESCRIPTION
Deprecates `PostgresData` integer conversion methods that could lead to overflow errors (#120, fixes #119). 

Using the following types in **release-mode** should no longer be susceptible to overflow (or underflow) crashes:

- `UInt`
- `Int8`
- `UInt16`
- `UInt32`
- `UInt64`

⚠️ However, these types will still be interpreted incorrectly by Postgres since it doesn't have native support for them. This could create problems with other clients connecting to the database. To prevent such issues, using these types will now result in a **debug-mode** only `assertion`. 

To migrate away from these types, there are two options: 

1: Use a wider integer (or type) that does not overflow or underflow. 

For example:

- `Int8` -> `Int16`
- `UInt16` -> `Int32`
- `UInt32` -> `Int` (`Int64`)
- `UInt` / `UInt64` -> `String` 

The caveats with this method are increased storage size and a database migration is required.

2: Do an explicit `bitPattern` conversion to the inversely signed type with same bit width. 

For example, using Fluent: 

```swift
// Store the value as `Int32` in Postgres
@Field(key: "foo")
var _foo: Int32

// Access the value as if it were a `UInt32`. 
var foo: UInt32 {
    get {
        .init(bitPattern: self._foo)
    }
    set {
        self._foo = .init(bitPattern: newValue)
    }
}
```

The caveat with this method is that other clients may misinterpret the stored value. 