### PR TITLE
Support non Foundation JSON coders

### DIFF
--- a/Sources/PostgresNIO/Data/PostgresData+JSON.swift
+++ b/Sources/PostgresNIO/Data/PostgresData+JSON.swift
@@ -11,7 +11,7 @@ extension PostgresData {
     }
 
     public init<T>(json value: T) throws where T: Encodable {
-        let jsonData = try JSONEncoder().encode(value)
+        let jsonData = try PostgresNIO._defaultJSONEncoder.encode(value)
         self.init(json: jsonData)
     }
 
@@ -32,7 +32,7 @@ extension PostgresData {
         guard let data = self.json else {
             return nil
         }
-        return try JSONDecoder().decode(T.self, from: data)
+        return try PostgresNIO._defaultJSONDecoder.decode(T.self, from: data)
     }
 }
 

--- a/Sources/PostgresNIO/Data/PostgresData+JSONB.swift
+++ b/Sources/PostgresNIO/Data/PostgresData+JSONB.swift
@@ -15,7 +15,7 @@ extension PostgresData {
     }
 
     public init<T>(jsonb value: T) throws where T: Encodable {
-        let jsonData = try JSONEncoder().encode(value)
+        let jsonData = try PostgresNIO._defaultJSONEncoder.encode(value)
         self.init(jsonb: jsonData)
     }
 
@@ -43,7 +43,7 @@ extension PostgresData {
             return nil
         }
 
-        return try JSONDecoder().decode(T.self, from: data)
+        return try PostgresNIO._defaultJSONDecoder.decode(T.self, from: data)
     }
 }
 

--- a/Sources/PostgresNIO/Utilities/PostgresJSONDecoder.swift
+++ b/Sources/PostgresNIO/Utilities/PostgresJSONDecoder.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public protocol PostgresJSONDecoder {
+    func decode<T>(_ type: T.Type, from data: Data) throws -> T where T : Decodable
+}
+
+extension JSONDecoder: PostgresJSONDecoder {}
+
+public var _defaultJSONDecoder: PostgresJSONDecoder = JSONDecoder()

--- a/Sources/PostgresNIO/Utilities/PostgresJSONEncoder.swift
+++ b/Sources/PostgresNIO/Utilities/PostgresJSONEncoder.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public protocol PostgresJSONEncoder {
+    func encode<T>(_ value: T) throws -> Data where T : Encodable
+}
+
+extension JSONEncoder: PostgresJSONEncoder {}
+
+public var _defaultJSONEncoder: PostgresJSONEncoder = JSONEncoder()


### PR DESCRIPTION
Add support for custom, non-Foundation, JSON encoder and decoder through global variables `PostgresNIO._defaultJSONEncoder` and `PostgresNIO._defaultJSONDecoder` (#125, fixes #126).