### PR TITLE
Support custom JSON coders

### DIFF
--- a/Sources/PostgresNIO/Data/PostgresData+JSON.swift
+++ b/Sources/PostgresNIO/Data/PostgresData+JSON.swift
@@ -11,7 +11,7 @@ extension PostgresData {
     }
 
     public init<T>(json value: T) throws where T: Encodable {
-        let jsonData = try JSONEncoder().encode(value)
+        let jsonData = try PostgresNIO._defaultJSONEncoder.encode(value)
         self.init(json: jsonData)
     }
 
@@ -32,7 +32,7 @@ extension PostgresData {
         guard let data = self.json else {
             return nil
         }
-        return try JSONDecoder().decode(T.self, from: data)
+        return try PostgresNIO._defaultJSONDecoder.decode(T.self, from: data)
     }
 }
 

--- a/Sources/PostgresNIO/Data/PostgresData+JSONB.swift
+++ b/Sources/PostgresNIO/Data/PostgresData+JSONB.swift
@@ -15,7 +15,7 @@ extension PostgresData {
     }
 
     public init<T>(jsonb value: T) throws where T: Encodable {
-        let jsonData = try JSONEncoder().encode(value)
+        let jsonData = try PostgresNIO._defaultJSONEncoder.encode(value)
         self.init(jsonb: jsonData)
     }
 
@@ -43,7 +43,7 @@ extension PostgresData {
             return nil
         }
 
-        return try JSONDecoder().decode(T.self, from: data)
+        return try PostgresNIO._defaultJSONDecoder.decode(T.self, from: data)
     }
 }
 

--- a/Sources/PostgresNIO/Utilities/PostgresJSONDecoder.swift
+++ b/Sources/PostgresNIO/Utilities/PostgresJSONDecoder.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public protocol PostgresJSONDecoder {
+    func decode<T>(_ type: T.Type, from data: Data) throws -> T where T : Decodable
+}
+
+extension JSONDecoder: PostgresJSONDecoder {}
+
+public var _defaultJSONDecoder: PostgresJSONDecoder = JSONDecoder()

--- a/Sources/PostgresNIO/Utilities/PostgresJSONDecoder.swift
+++ b/Sources/PostgresNIO/Utilities/PostgresJSONDecoder.swift
@@ -1,9 +1,16 @@
 import Foundation
 
+/// A protocol that mimmicks the Foundation `JSONDecoder.decode(_:from:)` function.
+/// Conform a non-Foundation JSON decoder to this protocol if you want PostgresNIO to be
+/// able to use it when decoding JSON & JSONB values (see `PostgresNIO._defaultJSONDecoder`)
 public protocol PostgresJSONDecoder {
     func decode<T>(_ type: T.Type, from data: Data) throws -> T where T : Decodable
 }
 
 extension JSONDecoder: PostgresJSONDecoder {}
 
+/// The default JSON decoder used by PostgresNIO when decoding JSON & JSONB values.
+/// As `_defaultJSONDecoder` will be reused for decoding all JSON & JSONB values
+/// from potentially multiple threads at once, you must ensure your custom JSON decoder is
+/// thread safe internally like `Foundation.JSONDecoder`.
 public var _defaultJSONDecoder: PostgresJSONDecoder = JSONDecoder()

--- a/Sources/PostgresNIO/Utilities/PostgresJSONEncoder.swift
+++ b/Sources/PostgresNIO/Utilities/PostgresJSONEncoder.swift
@@ -1,9 +1,16 @@
 import Foundation
 
+/// A protocol that mimmicks the Foundation `JSONEncoder.encode(_:)` function.
+/// Conform a non-Foundation JSON encoder to this protocol if you want PostgresNIO to be
+/// able to use it when encoding JSON & JSONB values (see `PostgresNIO._defaultJSONEncoder`)
 public protocol PostgresJSONEncoder {
     func encode<T>(_ value: T) throws -> Data where T : Encodable
 }
 
 extension JSONEncoder: PostgresJSONEncoder {}
 
+/// The default JSON encoder used by PostgresNIO when encoding JSON & JSONB values.
+/// As `_defaultJSONEncoder` will be reused for encoding all JSON & JSONB values
+/// from potentially multiple threads at once, you must ensure your custom JSON encoder is
+/// thread safe internally like `Foundation.JSONEncoder`.
 public var _defaultJSONEncoder: PostgresJSONEncoder = JSONEncoder()

--- a/Sources/PostgresNIO/Utilities/PostgresJSONEncoder.swift
+++ b/Sources/PostgresNIO/Utilities/PostgresJSONEncoder.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public protocol PostgresJSONEncoder {
+    func encode<T>(_ value: T) throws -> Data where T : Encodable
+}
+
+extension JSONEncoder: PostgresJSONEncoder {}
+
+public var _defaultJSONEncoder: PostgresJSONEncoder = JSONEncoder()


### PR DESCRIPTION
Add support for custom, non-Foundation, JSON encoder & decoder through global variables `PostgresNIO._defaultJSONEncoder` and `PostgresNIO._defaultJSONDecoder` (#125, fixes #126).