### PR TITLE
Close connection if requestTLS fails

### DIFF
--- a/Sources/PostgresNIO/Connection/PostgresConnection+Connect.swift
+++ b/Sources/PostgresNIO/Connection/PostgresConnection+Connect.swift
@@ -26,7 +26,11 @@ extension PostgresConnection {
                     using: tlsConfiguration,
                     serverHostname: serverHostname,
                     logger: logger
-                ).map { conn }
+                ).flatMapError { error in
+                    conn.close().flatMapThrowing {
+                        throw error
+                    }
+                }.map { conn }
             } else {
                 return eventLoop.makeSucceededFuture(conn)
             }


### PR DESCRIPTION
Correctly close the PostgreSQL connection if `requestTLS` fails.

Resolves #133 