### PR TITLE
Fix typo in comments for JSON encoder and decoder

### DIFF
--- a/Sources/PostgresNIO/Utilities/PostgresJSONDecoder.swift
+++ b/Sources/PostgresNIO/Utilities/PostgresJSONDecoder.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// A protocol that mimmicks the Foundation `JSONDecoder.decode(_:from:)` function.
+/// A protocol that mimicks the Foundation `JSONDecoder.decode(_:from:)` function.
 /// Conform a non-Foundation JSON decoder to this protocol if you want PostgresNIO to be
 /// able to use it when decoding JSON & JSONB values (see `PostgresNIO._defaultJSONDecoder`)
 public protocol PostgresJSONDecoder {

--- a/Sources/PostgresNIO/Utilities/PostgresJSONEncoder.swift
+++ b/Sources/PostgresNIO/Utilities/PostgresJSONEncoder.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// A protocol that mimmicks the Foundation `JSONEncoder.encode(_:)` function.
+/// A protocol that mimicks the Foundation `JSONEncoder.encode(_:)` function.
 /// Conform a non-Foundation JSON encoder to this protocol if you want PostgresNIO to be
 /// able to use it when encoding JSON & JSONB values (see `PostgresNIO._defaultJSONEncoder`)
 public protocol PostgresJSONEncoder {


### PR DESCRIPTION
`mimmicks` -> `mimicks`

<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->

<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
