### PR TITLE
Remove unintended SASL print statement

### DIFF
--- a/Sources/PostgresNIO/Utilities/SASLAuthentication+SCRAM-SHA256.swift
+++ b/Sources/PostgresNIO/Utilities/SASLAuthentication+SCRAM-SHA256.swift
@@ -402,7 +402,6 @@ fileprivate final class SASLMechanism_SCRAM_SHA256_Common {
     
     public func step(message: [UInt8]?) -> SASLAuthenticationStepResult {
         do {
-            print("State: \(state)")
             switch state {
                 case .clientInitial(let username, let nonce, let binding):
                     guard message == nil else { throw SASLAuthenticationError.initialRequestNotSent }


### PR DESCRIPTION
We currently print the internal SASL state when authenticating via `SCRAM-SHA256`. This messes up logs and is a potential security issue.

### Modifications

- Remove a print `statement`