### PR TITLE
Ensure no interference with other services in tests

### DIFF
--- a/Tests/PostgresNIOTests/New/IntegrationTests.swift
+++ b/Tests/PostgresNIOTests/New/IntegrationTests.swift
@@ -15,28 +15,6 @@ final class IntegrationTests: XCTestCase {
         XCTAssertNoThrow(try conn?.close().wait())
     }
     
-    func testConnectionFailure() {
-        // TODO: Create server with port 0 first
-        
-        let config = PSQLConnection.Configuration(
-            host: env("POSTGRES_HOSTNAME") ?? "localhost",
-            port: 1234, // wrong port number!
-            username: env("POSTGRES_USER") ?? "postgres",
-            database: env("POSTGRES_DB"),
-            password: env("POSTGRES_PASSWORD"),
-            tlsConfiguration: nil)
-        
-        let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer { XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully()) }
-        
-        var logger = Logger.psqlTest
-        logger.logLevel = .trace
-        
-        XCTAssertThrowsError(try PSQLConnection.connect(configuration: config, logger: logger, on: eventLoopGroup.next()).wait()) {
-            XCTAssertTrue($0 is PSQLError)
-        }
-    }
-    
     func testAuthenticationFailure() throws {
         // If the postgres server trusts every connection, it is really hard to create an
         // authentication failure.

--- a/Tests/PostgresNIOTests/New/PSQLConnectionTests.swift
+++ b/Tests/PostgresNIOTests/New/PSQLConnectionTests.swift
@@ -5,5 +5,34 @@ import Logging
 
 class PSQLConnectionTests: XCTestCase {
     
-
+    func testConnectionFailure() {
+        // We start a local server and close it immediately to ensure that the port
+        // number we try to connect to is not used by any other process.
+        let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully()) }
+        
+        var tempChannel: Channel?
+        XCTAssertNoThrow(tempChannel = try ServerBootstrap(group: eventLoopGroup)
+                            .bind(to: .init(ipAddress: "127.0.0.1", port: 0)).wait())
+        let maybePort = tempChannel?.localAddress?.port
+        XCTAssertNoThrow(try tempChannel?.close().wait())
+        guard let port = maybePort else {
+            return XCTFail("Could not get port number from temp started server")
+        }
+        
+        let config = PSQLConnection.Configuration(
+            host: "127.0.0.1",
+            port: port,
+            username: "postgres",
+            database: "postgres",
+            password: "abc123",
+            tlsConfiguration: nil)
+        
+        var logger = Logger.psqlTest
+        logger.logLevel = .trace
+        
+        XCTAssertThrowsError(try PSQLConnection.connect(configuration: config, logger: logger, on: eventLoopGroup.next()).wait()) {
+            XCTAssertTrue($0 is PSQLError)
+        }
+    }
 }


### PR DESCRIPTION
Ensure no interference with other services in tests.

### Motivation

- `testConnectionFailure` tried to create a Connection against `1234`. If a service was running on `1234` we might end up with a flaky test

### Modifications

- `testConnectionFailure` now starts a local server on a random local port, stops it and tries to connect to its previously used port. Therefore this test can not run into any crazy side effects any more.
- `testConnectionFailure` was moved from `IntegrationTests` to `PSQLConnectionTests`

### Result

- fewer potentially flaky tests
- needs no release!