### PR TITLE
Internal: Rename Command Contexts

### DIFF
--- a/Sources/PostgresNIO/New/Connection State Machine/ConnectionStateMachine.swift
+++ b/Sources/PostgresNIO/New/Connection State Machine/ConnectionStateMachine.swift
@@ -85,9 +85,9 @@ struct ConnectionStateMachine {
         // --- general actions
         case sendParseDescribeBindExecuteSync(query: String, binds: [PSQLEncodable])
         case sendBindExecuteSync(statementName: String, binds: [PSQLEncodable])
-        case failQuery(ExecuteExtendedQueryContext, with: PSQLError, cleanupContext: CleanUpContext?)
-        case succeedQuery(ExecuteExtendedQueryContext, columns: [PSQLBackendMessage.RowDescription.Column])
-        case succeedQueryNoRowsComming(ExecuteExtendedQueryContext, commandTag: String)
+        case failQuery(ExtendedQueryContext, with: PSQLError, cleanupContext: CleanUpContext?)
+        case succeedQuery(ExtendedQueryContext, columns: [PSQLBackendMessage.RowDescription.Column])
+        case succeedQueryNoRowsComming(ExtendedQueryContext, commandTag: String)
         
         // --- streaming actions
         // actions if query has requested next row but we are waiting for backend
@@ -100,8 +100,8 @@ struct ConnectionStateMachine {
         
         // Prepare statement actions
         case sendParseDescribeSync(name: String, query: String)
-        case succeedPreparedStatementCreation(CreatePreparedStatementContext, with: PSQLBackendMessage.RowDescription?)
-        case failPreparedStatementCreation(CreatePreparedStatementContext, with: PSQLError, cleanupContext: CleanUpContext?)
+        case succeedPreparedStatementCreation(PrepareStatementContext, with: PSQLBackendMessage.RowDescription?)
+        case failPreparedStatementCreation(PrepareStatementContext, with: PSQLError, cleanupContext: CleanUpContext?)
         
         // Close actions
         case sendCloseSync(CloseTarget)

--- a/Sources/PostgresNIO/New/Connection State Machine/ExtendedQueryStateMachine.swift
+++ b/Sources/PostgresNIO/New/Connection State Machine/ExtendedQueryStateMachine.swift
@@ -2,17 +2,17 @@
 struct ExtendedQueryStateMachine {
     
     enum State {
-        case initialized(ExecuteExtendedQueryContext)
-        case parseDescribeBindExecuteSyncSent(ExecuteExtendedQueryContext)
+        case initialized(ExtendedQueryContext)
+        case parseDescribeBindExecuteSyncSent(ExtendedQueryContext)
         
-        case parseCompleteReceived(ExecuteExtendedQueryContext)
-        case parameterDescriptionReceived(ExecuteExtendedQueryContext)
-        case rowDescriptionReceived(ExecuteExtendedQueryContext, [PSQLBackendMessage.RowDescription.Column])
-        case noDataMessageReceived(ExecuteExtendedQueryContext)
+        case parseCompleteReceived(ExtendedQueryContext)
+        case parameterDescriptionReceived(ExtendedQueryContext)
+        case rowDescriptionReceived(ExtendedQueryContext, [PSQLBackendMessage.RowDescription.Column])
+        case noDataMessageReceived(ExtendedQueryContext)
         
         /// A state that is used if a noData message was received before. If a row description was received `bufferingRows` is
         /// used after receiving a `bindComplete` message
-        case bindCompleteReceived(ExecuteExtendedQueryContext)
+        case bindCompleteReceived(ExtendedQueryContext)
         case bufferingRows([PSQLBackendMessage.RowDescription.Column], CircularBuffer<[PSQLData]>, readOnEmpty: Bool)
         case waitingForNextRow([PSQLBackendMessage.RowDescription.Column], CircularBuffer<[PSQLData]>, EventLoopPromise<StateMachineStreamNextResult>)
         
@@ -27,9 +27,9 @@ struct ExtendedQueryStateMachine {
         case sendBindExecuteSync(statementName: String, binds: [PSQLEncodable])
         
         // --- general actions
-        case failQuery(ExecuteExtendedQueryContext, with: PSQLError)
-        case succeedQuery(ExecuteExtendedQueryContext, columns: [PSQLBackendMessage.RowDescription.Column])
-        case succeedQueryNoRowsComming(ExecuteExtendedQueryContext, commandTag: String)
+        case failQuery(ExtendedQueryContext, with: PSQLError)
+        case succeedQuery(ExtendedQueryContext, columns: [PSQLBackendMessage.RowDescription.Column])
+        case succeedQueryNoRowsComming(ExtendedQueryContext, commandTag: String)
         
         // --- streaming actions
         // actions if query has requested next row but we are waiting for backend
@@ -46,7 +46,7 @@ struct ExtendedQueryStateMachine {
     
     var state: State
     
-    init(queryContext: ExecuteExtendedQueryContext) {
+    init(queryContext: ExtendedQueryContext) {
         self.state = .initialized(queryContext)
     }
     

--- a/Sources/PostgresNIO/New/Connection State Machine/PrepareStatementStateMachine.swift
+++ b/Sources/PostgresNIO/New/Connection State Machine/PrepareStatementStateMachine.swift
@@ -2,11 +2,11 @@
 struct PrepareStatementStateMachine {
     
     enum State {
-        case initialized(CreatePreparedStatementContext)
-        case parseDescribeSent(CreatePreparedStatementContext)
+        case initialized(PrepareStatementContext)
+        case parseDescribeSent(PrepareStatementContext)
     
-        case parseCompleteReceived(CreatePreparedStatementContext)
-        case parameterDescriptionReceived(CreatePreparedStatementContext)
+        case parseCompleteReceived(PrepareStatementContext)
+        case parameterDescriptionReceived(PrepareStatementContext)
         case rowDescriptionReceived
         case noDataMessageReceived
         
@@ -15,8 +15,8 @@ struct PrepareStatementStateMachine {
     
     enum Action {
         case sendParseDescribeSync(name: String, query: String)
-        case succeedPreparedStatementCreation(CreatePreparedStatementContext, with: PSQLBackendMessage.RowDescription?)
-        case failPreparedStatementCreation(CreatePreparedStatementContext, with: PSQLError)
+        case succeedPreparedStatementCreation(PrepareStatementContext, with: PSQLBackendMessage.RowDescription?)
+        case failPreparedStatementCreation(PrepareStatementContext, with: PSQLError)
 
         case read
         case wait
@@ -24,7 +24,7 @@ struct PrepareStatementStateMachine {
     
     var state: State
     
-    init(createContext: CreatePreparedStatementContext) {
+    init(createContext: PrepareStatementContext) {
         self.state = .initialized(createContext)
     }
     

--- a/Sources/PostgresNIO/New/PSQLChannelHandler.swift
+++ b/Sources/PostgresNIO/New/PSQLChannelHandler.swift
@@ -417,7 +417,7 @@ final class PSQLChannelHandler: ChannelDuplexHandler {
     }
     
     private func succeedQueryWithRowStream(
-        _ queryContext: ExecuteExtendedQueryContext,
+        _ queryContext: ExtendedQueryContext,
         columns: [PSQLBackendMessage.RowDescription.Column],
         context: ChannelHandlerContext)
     {
@@ -448,7 +448,7 @@ final class PSQLChannelHandler: ChannelDuplexHandler {
     }
     
     private func succeedQueryWithoutRowStream(
-        _ queryContext: ExecuteExtendedQueryContext,
+        _ queryContext: ExtendedQueryContext,
         commandTag: String,
         context: ChannelHandlerContext)
     {

--- a/Sources/PostgresNIO/New/PSQLConnection.swift
+++ b/Sources/PostgresNIO/New/PSQLConnection.swift
@@ -131,7 +131,7 @@ final class PSQLConnection {
             return self.channel.eventLoop.makeFailedFuture(PSQLError.tooManyParameters)
         }
         let promise = self.channel.eventLoop.makePromise(of: PSQLRows.self)
-        let context = ExecuteExtendedQueryContext(
+        let context = ExtendedQueryContext(
             query: query,
             bind: bind,
             logger: logger,
@@ -151,7 +151,7 @@ final class PSQLConnection {
     
     func prepareStatement(_ query: String, with name: String, logger: Logger) -> EventLoopFuture<PSQLPreparedStatement> {
         let promise = self.channel.eventLoop.makePromise(of: PSQLBackendMessage.RowDescription?.self)
-        let context = CreatePreparedStatementContext(
+        let context = PrepareStatementContext(
             name: name,
             query: query,
             logger: logger,
@@ -170,7 +170,7 @@ final class PSQLConnection {
             return self.channel.eventLoop.makeFailedFuture(PSQLError.tooManyParameters)
         }
         let promise = self.channel.eventLoop.makePromise(of: PSQLRows.self)
-        let context = ExecuteExtendedQueryContext(
+        let context = ExtendedQueryContext(
             preparedStatement: preparedStatement,
             bind: bind,
             logger: logger,

--- a/Sources/PostgresNIO/New/PSQLRows.swift
+++ b/Sources/PostgresNIO/New/PSQLRows.swift
@@ -25,7 +25,7 @@ final class PSQLRows {
     private let jsonDecoder: PSQLJSONDecoder
     
     init(rowDescription: [PSQLBackendMessage.RowDescription.Column],
-         queryContext: ExecuteExtendedQueryContext,
+         queryContext: ExtendedQueryContext,
          eventLoop: EventLoop,
          cancel: @escaping () -> (),
          next: @escaping () -> EventLoopFuture<StateMachineStreamNextResult>)

--- a/Sources/PostgresNIO/New/PSQLTask.swift
+++ b/Sources/PostgresNIO/New/PSQLTask.swift
@@ -1,6 +1,6 @@
 enum PSQLTask {
-    case extendedQuery(ExecuteExtendedQueryContext)
-    case preparedStatement(CreatePreparedStatementContext)
+    case extendedQuery(ExtendedQueryContext)
+    case preparedStatement(PrepareStatementContext)
     case closeCommand(CloseCommandContext)
     
     func failWithError(_ error: PSQLError) {
@@ -15,7 +15,7 @@ enum PSQLTask {
     }
 }
 
-final class ExecuteExtendedQueryContext {
+final class ExtendedQueryContext {
     enum Query {
         case unnamed(String)
         case preparedStatement(name: String, rowDescription: PSQLBackendMessage.RowDescription?)
@@ -58,7 +58,7 @@ final class ExecuteExtendedQueryContext {
 
 }
 
-final class CreatePreparedStatementContext {
+final class PrepareStatementContext {
     let name: String
     let query: String
     let logger: Logger

--- a/Tests/PostgresNIOTests/New/Connection State Machine/ConnectionStateMachineTests.swift
+++ b/Tests/PostgresNIOTests/New/Connection State Machine/ConnectionStateMachineTests.swift
@@ -103,7 +103,7 @@ class ConnectionStateMachineTests: XCTestCase {
         let queryPromise = eventLoopGroup.next().makePromise(of: PSQLRows.self)
 
         var state = ConnectionStateMachine()
-        let extendedQueryContext = ExecuteExtendedQueryContext(
+        let extendedQueryContext = ExtendedQueryContext(
             query: "Select version()",
             bind: [],
             logger: .psqlTest,

--- a/Tests/PostgresNIOTests/New/Connection State Machine/ExtendedQueryStateMachineTests.swift
+++ b/Tests/PostgresNIOTests/New/Connection State Machine/ExtendedQueryStateMachineTests.swift
@@ -10,7 +10,7 @@ class ExtendedQueryStateMachineTests: XCTestCase {
         let promise = EmbeddedEventLoop().makePromise(of: PSQLRows.self)
         promise.fail(PSQLError.uncleanShutdown) // we don't care about the error at all.
         let query = "DELETE FROM table WHERE id=$0"
-        let queryContext = ExecuteExtendedQueryContext(query: query, bind: [1], logger: logger, jsonDecoder: JSONDecoder(), promise: promise)
+        let queryContext = ExtendedQueryContext(query: query, bind: [1], logger: logger, jsonDecoder: JSONDecoder(), promise: promise)
         
         XCTAssertEqual(state.enqueue(task: .extendedQuery(queryContext)), .sendParseDescribeBindExecuteSync(query: query, binds: [1]))
         XCTAssertEqual(state.parseCompleteReceived(), .wait)
@@ -28,7 +28,7 @@ class ExtendedQueryStateMachineTests: XCTestCase {
         let queryPromise = EmbeddedEventLoop().makePromise(of: PSQLRows.self)
         queryPromise.fail(PSQLError.uncleanShutdown) // we don't care about the error at all.
         let query = "SELECT version()"
-        let queryContext = ExecuteExtendedQueryContext(query: query, bind: [], logger: logger, jsonDecoder: JSONDecoder(), promise: queryPromise)
+        let queryContext = ExtendedQueryContext(query: query, bind: [], logger: logger, jsonDecoder: JSONDecoder(), promise: queryPromise)
         
         XCTAssertEqual(state.enqueue(task: .extendedQuery(queryContext)), .sendParseDescribeBindExecuteSync(query: query, binds: []))
         XCTAssertEqual(state.parseCompleteReceived(), .wait)
@@ -59,7 +59,7 @@ class ExtendedQueryStateMachineTests: XCTestCase {
         let promise = EmbeddedEventLoop().makePromise(of: PSQLRows.self)
         promise.fail(PSQLError.uncleanShutdown) // we don't care about the error at all.
         let query = "DELETE FROM table WHERE id=$0"
-        let queryContext = ExecuteExtendedQueryContext(query: query, bind: [1], logger: logger, jsonDecoder: JSONDecoder(), promise: promise)
+        let queryContext = ExtendedQueryContext(query: query, bind: [1], logger: logger, jsonDecoder: JSONDecoder(), promise: promise)
         
         XCTAssertEqual(state.enqueue(task: .extendedQuery(queryContext)), .sendParseDescribeBindExecuteSync(query: query, binds: [1]))
         XCTAssertEqual(state.parseCompleteReceived(), .wait)

--- a/Tests/PostgresNIOTests/New/Connection State Machine/PrepareStatementStateMachineTests.swift
+++ b/Tests/PostgresNIOTests/New/Connection State Machine/PrepareStatementStateMachineTests.swift
@@ -11,7 +11,7 @@ class PrepareStatementStateMachineTests: XCTestCase {
         
         let name = "haha"
         let query = #"SELECT id FROM users WHERE id = $1 "#
-        let prepareStatementContext = CreatePreparedStatementContext(
+        let prepareStatementContext = PrepareStatementContext(
             name: name, query: query, logger: .psqlTest, promise: promise)
         
         XCTAssertEqual(state.enqueue(task: .preparedStatement(prepareStatementContext)),
@@ -36,7 +36,7 @@ class PrepareStatementStateMachineTests: XCTestCase {
         
         let name = "haha"
         let query = #"DELETE FROM users WHERE id = $1 "#
-        let prepareStatementContext = CreatePreparedStatementContext(
+        let prepareStatementContext = PrepareStatementContext(
             name: name, query: query, logger: .psqlTest, promise: promise)
         
         XCTAssertEqual(state.enqueue(task: .preparedStatement(prepareStatementContext)),


### PR DESCRIPTION
Changes internal naming of 

```
ExecuteExtendedQueryContext -> ExtendedQueryContext
CreatePreparedStatementContext -> PrepareStatementContext
```

The current names are currently overly verbose and should be simplified a little. There is no public API impact since both types are internal.

This pr does not need a new release.