### PR TITLE
Ignore errors when closing the connection

### DIFF
--- a/Sources/PostgresNIO/New/PSQLChannelHandler.swift
+++ b/Sources/PostgresNIO/New/PSQLChannelHandler.swift
@@ -75,7 +75,7 @@ final class PSQLChannelHandler: ChannelDuplexHandler {
     }
     
     func errorCaught(context: ChannelHandlerContext, error: Error) {
-        self.logger.error("Channel error caught.", metadata: [.error: "\(error)"])
+        self.logger.debug("Channel error caught.", metadata: [.error: "\(error)"])
         let action = self.state.errorHappened(.channel(underlying: error))
         self.run(action, with: context)
     }
@@ -470,7 +470,7 @@ final class PSQLChannelHandler: ChannelDuplexHandler {
         _ cleanup: ConnectionStateMachine.ConnectionAction.CleanUpContext,
         context: ChannelHandlerContext)
     {
-        self.logger.error("Channel error caught. Closing connection.", metadata: [.error: "\(cleanup.error)"])
+        self.logger.debug("Cleaning up and closing connection.", metadata: [.error: "\(cleanup.error)"])
         
         // 1. fail all tasks
         cleanup.tasks.forEach { task in

--- a/Sources/PostgresNIO/New/PSQLConnection.swift
+++ b/Sources/PostgresNIO/New/PSQLConnection.swift
@@ -140,10 +140,6 @@ final class PSQLConnection {
         
         self.channel.write(PSQLTask.extendedQuery(context), promise: nil)
         
-        // success is logged in PSQLQuery
-        promise.futureResult.whenFailure { error in
-            logger.error("Query failed", metadata: [.error: "\(error)"])
-        }
         return promise.futureResult
     }
     

--- a/Sources/PostgresNIO/New/PSQLRows.swift
+++ b/Sources/PostgresNIO/New/PSQLRows.swift
@@ -99,7 +99,9 @@ final class PSQLRows {
     }
     
     internal func noticeReceived(_ notice: PSQLBackendMessage.NoticeResponse) {
-        self.logger.notice("Notice Received \(notice)")
+        self.logger.debug("Notice Received", metadata: [
+            .notice: "\(notice)"
+        ])
     }
     
     internal func finalForward(_ finalForward: Result<(CircularBuffer<[PSQLData]>, commandTag: String), PSQLError>?) {

--- a/Tests/PostgresNIOTests/New/Connection State Machine/ConnectionStateMachineTests.swift
+++ b/Tests/PostgresNIOTests/New/Connection State Machine/ConnectionStateMachineTests.swift
@@ -91,6 +91,19 @@ class ConnectionStateMachineTests: XCTestCase {
                        .closeConnectionAndCleanup(.init(action: .close, tasks: [], error: .unexpectedBackendMessage(.readyForQuery(.idle)), closePromise: nil)))
     }
     
+    func testErrorIsIgnoredWhenClosingConnection() {
+        // test ignore unclean shutdown when closing connection
+        var stateIgnoreChannelError = ConnectionStateMachine(.closing)
+        
+        XCTAssertEqual(stateIgnoreChannelError.errorHappened(.channel(underlying: NIOSSLError.uncleanShutdown)), .wait)
+        XCTAssertEqual(stateIgnoreChannelError.closed(), .fireChannelInactive)
+        
+        // test ignore any other error when closing connection
+        
+        var stateIgnoreErrorMessage = ConnectionStateMachine(.closing)
+        XCTAssertEqual(stateIgnoreErrorMessage.errorReceived(.init(fields: [:])), .wait)
+        XCTAssertEqual(stateIgnoreErrorMessage.closed(), .fireChannelInactive)
+    }
     
     func testFailQueuedQueriesOnAuthenticationFailure() throws {
         let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)

--- a/Tests/PostgresNIOTests/New/Extensions/ConnectionAction+TestUtils.swift
+++ b/Tests/PostgresNIOTests/New/Extensions/ConnectionAction+TestUtils.swift
@@ -74,6 +74,8 @@ extension ConnectionStateMachine.ConnectionAction: Equatable {
             return lhsName == rhsName && lhsQuery == rhsQuery
         case (.succeedPreparedStatementCreation(let lhsContext, let lhsRowDescription), .succeedPreparedStatementCreation(let rhsContext, let rhsRowDescription)):
             return lhsContext === rhsContext && lhsRowDescription == rhsRowDescription
+        case (.fireChannelInactive, .fireChannelInactive):
+            return true
         default:
             return false
         }


### PR DESCRIPTION
Resolves an issue where errors thrown by some database servers during closing a connection would cause an error in PostgresNIO. Resolves #150 

### Modifications

- We ignore errors when the connection is already closing
- Updated logging to only issue debug and trace logs.
- Don't print password in trace logging mode.