### PR TITLE
Use sync pipeline operations to add NIOSSLClientHandler

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,11 +10,11 @@ let package = Package(
         .library(name: "PostgresNIO", targets: ["PostgresNIO"]),
     ],
     dependencies: [
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.28.0"),
+        .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.12.0"),
         .package(url: "https://github.com/apple/swift-crypto.git", from: "1.0.0"),
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
-        .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.0.0"),
         .package(url: "https://github.com/apple/swift-metrics.git", from: "2.0.0"),
-        .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.4.0"),
     ],
     targets: [
         .target(name: "PostgresNIO", dependencies: [


### PR DESCRIPTION
- Bump required NIO dependencies.
- Modify the `PSQLChannelHandler`'s `enableSSLCallback` to a synchronous API
- Use `channel.pipeline.syncOperations` to add the `NIOSSLClientHandler` after it was verified that SSL is supported on this connection
- Extend test `testEstablishSSLCallbackIsCalledIfSSLIsSupported` to ensure startup is send after SSL connection is established.