### PR TITLE
Add platform requirements for iOS, watchOS and tvOS

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,10 @@ import PackageDescription
 let package = Package(
     name: "postgres-nio",
     platforms: [
-       .macOS(.v10_15)
+        .macOS(.v10_15),
+        .iOS(.v13),
+        .watchOS(.v6),
+        .tvOS(.v13),
     ],
     products: [
         .library(name: "PostgresNIO", targets: ["PostgresNIO"]),


### PR DESCRIPTION
To use `postgres-nio` from iOS, watchOS and tvOS the platform requirements need to be set correctly.

Requirement raised in the forums: https://forums.swift.org/t/trouble-importing-postgresnio/47815/10