### PR TITLE
[RFC] Create connection and authenticate with a single function

### DIFF
--- a/Sources/PostgresNIO/Connection/PostgresConnection+Authenticate.swift
+++ b/Sources/PostgresNIO/Connection/PostgresConnection+Authenticate.swift
@@ -1,6 +1,7 @@
 import NIO
 
 extension PostgresConnection {
+    @available(*, deprecated, message: "Use the new `PostgresConnection.connect()` that allows you to specify username, password and database directly when creating the connection.")
     public func authenticate(
         username: String,
         database: String? = nil,

--- a/Sources/PostgresNIO/Connection/PostgresConnection+Connect.swift
+++ b/Sources/PostgresNIO/Connection/PostgresConnection+Connect.swift
@@ -1,6 +1,8 @@
 import NIO
+import Logging
 
 extension PostgresConnection {
+    @available(*, deprecated, message: "Use the new `PostgresConnection.connect(hostname:port:username:password:database:tlsConfiguration:logger:on eventLoop:)` that allows you to specify username, password and database directly when creating the connection.")
     public static func connect(
         to socketAddress: SocketAddress,
         tlsConfiguration: TLSConfiguration? = nil,
@@ -30,4 +32,102 @@ extension PostgresConnection {
             throw error.asAppropriatePostgresError
         }
     }
+    
+    /// Create a new Postgres Connection to a Postgres Server.
+    ///
+    /// - Parameters:
+    ///   - hostname: The server's hostname as domain or IP address.
+    ///   - port: The server's port. Defaults to the Postgres default port 5432.
+    ///   - username: The username to authenticate with to the remote server.
+    ///   - password: An optional password to authenticate with to the remote server.
+    ///   - database: The database name to connect to
+    ///   - tlsConfiguration: An optional `TLSConfiguration` that configures the TLS connection to the server. If
+    ///                       none is provided the connection to the server is created without TLS.
+    ///   - logger: A logger to use for connection state changes and action. The logger is only with the `debug` and
+    ///             `trace` log level.
+    ///   - eventLoop: The SwiftNIO `EventLoop` the connection should be created on.
+    /// - Returns: An `EventLoopFuture` which provides the `PSQLConnection` if the connection creation and
+    ///            authentification was successful. Otherwise an `Error`.
+    public static func connect(
+        hostname: String,
+        port: Int = 5432,
+        username: String,
+        password: String?,
+        database: String?,
+        tlsConfiguration: TLSConfiguration?,
+        logger: Logger = Logger(label: "codes.vapor.postgres", factory: { _ in SwiftLogNoOpLogHandler() }),
+        on eventLoop: EventLoop
+    ) -> EventLoopFuture<PostgresConnection> {
+        
+        let coders = PSQLConnection.Configuration.Coders(
+            jsonEncoder: PostgresJSONEncoderWrapper(_defaultJSONEncoder),
+            jsonDecoder: PostgresJSONDecoderWrapper(_defaultJSONDecoder)
+        )
+        
+        let configuration = PSQLConnection.Configuration(
+            connection: .unresolved(host: hostname, port: port),
+            authentication: .init(username: username, password: password, database: database),
+            tlsConfiguration: tlsConfiguration,
+            coders: coders)
+
+        return PSQLConnection.connect(
+            configuration: configuration,
+            logger: logger,
+            on: eventLoop
+        ).map { connection in
+            PostgresConnection(underlying: connection, logger: logger)
+        }.flatMapErrorThrowing { error in
+            throw error.asAppropriatePostgresError
+        }
+    }
+    
+    /// Create a new Postgres Connection to a Postgres Server.
+    ///
+    /// - Parameters:
+    ///   - address: The remote server's address as a `SocketAddress`.
+    ///   - serverName: The remote server's name to use for domain name certificate verification, if a
+    ///                 `TLSConfiguration` is supplied.
+    ///   - username: The username to authenticate with to the remote server.
+    ///   - password: An optional password to authenticate with to the remote server.
+    ///   - database: The database name to connect to
+    ///   - tlsConfiguration: An optional `TLSConfiguration` that configures the TLS connection to the server. If
+    ///                       none is provided the connection to the server is created without TLS.
+    ///   - logger: A logger to use for connection state changes and action. The logger is only with the `debug` and
+    ///             `trace` log level.
+    ///   - eventLoop: The SwiftNIO `EventLoop` the connection should be created on.
+    /// - Returns: An `EventLoopFuture` which provides the `PSQLConnection` if the connection creation and
+    ///            authentification was successful. Otherwise an `Error`.
+    public static func connect(
+        address: SocketAddress,
+        serverName: String? = nil,
+        username: String,
+        password: String?,
+        database: String?,
+        tlsConfiguration: TLSConfiguration?,
+        logger: Logger = Logger(label: "codes.vapor.postgres", factory: { _ in SwiftLogNoOpLogHandler() }),
+        on eventLoop: EventLoop
+    ) -> EventLoopFuture<PostgresConnection> {
+        
+        let coders = PSQLConnection.Configuration.Coders(
+            jsonEncoder: PostgresJSONEncoderWrapper(_defaultJSONEncoder),
+            jsonDecoder: PostgresJSONDecoderWrapper(_defaultJSONDecoder)
+        )
+        
+        let configuration = PSQLConnection.Configuration(
+            connection: .resolved(address: address, serverName: serverName),
+            authentication: .init(username: username, password: password, database: database),
+            tlsConfiguration: tlsConfiguration,
+            coders: coders)
+
+        return PSQLConnection.connect(
+            configuration: configuration,
+            logger: logger,
+            on: eventLoop
+        ).map { connection in
+            PostgresConnection(underlying: connection, logger: logger)
+        }.flatMapErrorThrowing { error in
+            throw error.asAppropriatePostgresError
+        }
+    }
+    
 }

--- a/Sources/PostgresNIO/New/PSQLConnection.swift
+++ b/Sources/PostgresNIO/New/PSQLConnection.swift
@@ -94,7 +94,7 @@ final class PSQLConnection {
         return !self.channel.isActive
     }
     
-    /// A logger to use in case
+    /// A connection logger to use for debugging
     private var logger: Logger
     let connectionID: String
     let jsonDecoder: PSQLJSONDecoder


### PR DESCRIPTION
### Current State

The current API forces users to do some state handling themselves during connection setup. Also `throwing` functions are mixed with functions that return `EventLoopFuture`s. From the README:

```swift
import PostgresNIO

let eventLoop: EventLoop = ...
let conn = try PostgresConnection.connect(
    to: .makeAddressResolvingHost("my.psql.server", port: 5432),
    on: eventLoop
).wait()
defer { try! conn.close().wait() }
```

There is a couple of issues with this:

1. `.makeAddressResolvingHost("my.psql.server", port: 5432)` is a throwing function
2. `PostgresConnection.connect` returns an `EventLoopFuture`. 
3. The connection is only setup and the user needs to authenticate from here on. In an error case the user needs to teardown the connection themselves.

If users want to create a connection themselves they are forced to write this code, which has a lot of implicit connection state:
```swift
eventLoop.submit { () throws -> SocketAddress in
    // callback only to transform the throwing SocketAddress into a Future for consistency
    try .makeAddressResolvingHost("my.psql.server", port: 5432)
}.flatMap {
    // connect to the server. Can setup TLS
    PostgresConnection.connect(to: $0, on: eventLoop)
}.flatMap { connection in
    // authenticate to database
    connection.authenticate(
        username: env("POSTGRES_USER") ?? "vapor_username",
        database: env("POSTGRES_DB") ?? "vapor_database",
        password: env("POSTGRES_PASSWORD") ?? "vapor_password"
    ).map {
        // map to connection to return the connection to the user
        return conn
    }.flatMapError { error in
        // close connection in case of auth error
        conn.close().flatMapThrowing {
            // rethrow error for the user to capture
            throw error
        }
    }
}
```

### Changes

With the StateMachine PR #135 a new underlying PSQLConnection has landed that supports connection creation and authentication with a single call. This PR brings this much easier API to the public interface:

#### Additions

```swift
class PostgresConnection {
    /// Create a new Postgres Connection to a Postgres Server.
    ///
    /// - Parameters:
    ///   - hostname: The server's hostname as domain or IP address.
    ///   - port: The server's port. Defaults to the Postgres default port 5432.
    ///   - username: The username to authenticate with to the remote server.
    ///   - password: An optional password to authenticate with to the remote server.
    ///   - database: The database name to connect to
    ///   - tlsConfiguration: An optional `TLSConfiguration` that configures the TLS connection to the server. If
    ///                       none is provided the connection to the server is created without TLS.
    ///   - logger: A logger to use for connection state changes and action. The logger is only with the `debug` and
    ///             `trace` log level.
    ///   - eventLoop: The SwiftNIO `EventLoop` the connection should be created on.
    /// - Returns: An `EventLoopFuture` which provides the `PSQLConnection` if the connection creation and
    ///            authentification was successful. Otherwise an `Error`.
    public static func connect(
        hostname: String,
        port: Int = 5432,
        username: String,
        password: String?,
        database: String?,
        tlsConfiguration: TLSConfiguration?,
        logger: Logger = Logger(label: "codes.vapor.postgres", factory: { _ in SwiftLogNoOpLogHandler() }),
        on eventLoop: EventLoop
    ) -> EventLoopFuture<PostgresConnection>
}
```

For users that want to connect to their Postgres server via unix sockets, we offer a new advanced API:
```swift
    /// Create a new Postgres Connection to a Postgres Server.
    ///
    /// - Parameters:
    ///   - address: The remote server's address as a `SocketAddress`.
    ///   - serverName: The remote server's name to use for domain name certificate verification, if a
    ///                 `TLSConfiguration` is supplied.
    ///   - username: The username to authenticate with to the remote server.
    ///   - password: An optional password to authenticate with to the remote server.
    ///   - database: The database name to connect to
    ///   - tlsConfiguration: An optional `TLSConfiguration` that configures the TLS connection to the server. If
    ///                       none is provided the connection to the server is created without TLS.
    ///   - logger: A logger to use for connection state changes and action. The logger is only with the `debug` and
    ///             `trace` log level.
    ///   - eventLoop: The SwiftNIO `EventLoop` the connection should be created on.
    /// - Returns: An `EventLoopFuture` which provides the `PSQLConnection` if the connection creation and
    ///            authentification was successful. Otherwise an `Error`.
    public static func connect(
        address: SocketAddress,
        serverName: String? = nil,
        username: String,
        password: String?,
        database: String?,
        tlsConfiguration: TLSConfiguration?,
        logger: Logger = Logger(label: "codes.vapor.postgres", factory: { _ in SwiftLogNoOpLogHandler() }),
        on eventLoop: EventLoop
    ) -> EventLoopFuture<PostgresConnection>
```

#### Deprecations

The current `connect` and `authenticate` methods are deprecated.

```swift
extension PostgresConnection {

    @available(*, deprecated, message: "Use the new `PostgresConnection.connect(hostname:port:username:password:database:tlsConfiguration:logger:on eventLoop:)` that allows you to specify username, password and database directly when creating the connection.")
    public static func connect(
        to socketAddress: SocketAddress,
        tlsConfiguration: TLSConfiguration? = nil,
        serverHostname: String? = nil,
        logger: Logger = .init(label: "codes.vapor.postgres"),
        on eventLoop: EventLoop
    ) -> EventLoopFuture<PostgresConnection>

    @available(*, deprecated, message: "Use the new `PostgresConnection.connect(hostname:port:username:password:database:tlsConfiguration:logger:on eventLoop:)` that allows you to specify username, password and database directly when creating the connection.")
    public func authenticate(
        username: String,
        database: String? = nil,
        password: String? = nil,
        logger: Logger = .init(label: "codes.vapor.postgres")
    ) -> EventLoopFuture<Void>
}
```

### Alternatives

Instead of using eight parameters for the connect function, we could use the a Config struct like this from PSQLConnection: https://github.com/vapor/postgres-nio/blob/main/Sources/PostgresNIO/New/PSQLConnection.swift#L12-L77