### PR TITLE
Use PSQLFormat when encoding and decoding

### DIFF
--- a/Sources/PostgresNIO/Connection/PostgresConnection+Database.swift
+++ b/Sources/PostgresNIO/Connection/PostgresConnection+Database.swift
@@ -23,7 +23,7 @@ extension PostgresConnection: PostgresDatabase {
                         dataType: PostgresDataType(UInt32(column.dataType.rawValue)),
                         dataTypeSize: column.dataTypeSize,
                         dataTypeModifier: column.dataTypeModifier,
-                        formatCode: .init(psqlFormatCode: column.formatCode)
+                        formatCode: .init(psqlFormatCode: column.format)
                     )
                 }
                 

--- a/Sources/PostgresNIO/Connection/PostgresDatabase+PreparedQuery.swift
+++ b/Sources/PostgresNIO/Connection/PostgresDatabase+PreparedQuery.swift
@@ -43,7 +43,7 @@ public struct PreparedQuery {
                     dataType: PostgresDataType(UInt32(column.dataType.rawValue)),
                     dataTypeSize: column.dataTypeSize,
                     dataTypeModifier: column.dataTypeModifier,
-                    formatCode: .init(psqlFormatCode: column.formatCode)
+                    formatCode: .init(psqlFormatCode: column.format)
                 )
             }
             

--- a/Sources/PostgresNIO/New/Connection State Machine/ExtendedQueryStateMachine.swift
+++ b/Sources/PostgresNIO/New/Connection State Machine/ExtendedQueryStateMachine.swift
@@ -115,7 +115,7 @@ struct ExtendedQueryStateMachine {
         
         return self.avoidingStateMachineCoW { state -> Action in
             // In Postgres extended queries we receive the `rowDescription` before we send the
-            // `Bind` message. Well actually it's vica versa, but this is only true since we do
+            // `Bind` message. Well actually it's vice versa, but this is only true since we do
             // pipelining during a query.
             //
             // In the actual protocol description we receive a rowDescription before the Bind

--- a/Sources/PostgresNIO/New/Data/Bool+PSQLCodable.swift
+++ b/Sources/PostgresNIO/New/Data/Bool+PSQLCodable.swift
@@ -3,18 +3,42 @@ extension Bool: PSQLCodable {
         .bool
     }
     
-    static func decode(from buffer: inout ByteBuffer, type: PSQLDataType, context: PSQLDecodingContext) throws -> Bool {
-        guard type == .bool, buffer.readableBytes == 1 else {
+    var psqlFormat: PSQLFormat {
+        .binary
+    }
+    
+    static func decode(from buffer: inout ByteBuffer, type: PSQLDataType, format: PSQLFormat, context: PSQLDecodingContext) throws -> Bool {
+        guard type == .bool else {
             throw PSQLCastingError.failure(targetType: Self.self, type: type, postgresData: buffer, context: context)
         }
         
-        switch buffer.readInteger(as: UInt8.self) {
-        case .some(0):
-            return false
-        case .some(1):
-            return true
-        default:
-            throw PSQLCastingError.failure(targetType: Self.self, type: type, postgresData: buffer, context: context)
+        switch format {
+        case .binary:
+            guard buffer.readableBytes == 1 else {
+                throw PSQLCastingError.failure(targetType: Self.self, type: type, postgresData: buffer, context: context)
+            }
+            
+            switch buffer.readInteger(as: UInt8.self) {
+            case .some(0):
+                return false
+            case .some(1):
+                return true
+            default:
+                throw PSQLCastingError.failure(targetType: Self.self, type: type, postgresData: buffer, context: context)
+            }
+        case .text:
+            guard buffer.readableBytes >= 1 else {
+                throw PSQLCastingError.failure(targetType: Self.self, type: type, postgresData: buffer, context: context)
+            }
+            
+            switch buffer.readInteger(as: UInt8.self) {
+            case .some(UInt8(ascii: "f")):
+                return false
+            case .some(UInt8(ascii: "t")):
+                return true
+            default:
+                throw PSQLCastingError.failure(targetType: Self.self, type: type, postgresData: buffer, context: context)
+            }
         }
     }
     

--- a/Sources/PostgresNIO/New/Data/Bool+PSQLCodable.swift
+++ b/Sources/PostgresNIO/New/Data/Bool+PSQLCodable.swift
@@ -27,7 +27,7 @@ extension Bool: PSQLCodable {
                 throw PSQLCastingError.failure(targetType: Self.self, type: type, postgresData: buffer, context: context)
             }
         case .text:
-            guard buffer.readableBytes >= 1 else {
+            guard buffer.readableBytes == 1 else {
                 throw PSQLCastingError.failure(targetType: Self.self, type: type, postgresData: buffer, context: context)
             }
             

--- a/Sources/PostgresNIO/New/Data/Bytes+PSQLCodable.swift
+++ b/Sources/PostgresNIO/New/Data/Bytes+PSQLCodable.swift
@@ -6,6 +6,10 @@ extension PSQLEncodable where Self: Sequence, Self.Element == UInt8 {
         .bytea
     }
     
+    var psqlFormat: PSQLFormat {
+        .binary
+    }
+    
     func encode(into byteBuffer: inout ByteBuffer, context: PSQLEncodingContext) {
         byteBuffer.writeBytes(self)
     }
@@ -16,12 +20,16 @@ extension ByteBuffer: PSQLCodable {
         .bytea
     }
     
+    var psqlFormat: PSQLFormat {
+        .binary
+    }
+    
     func encode(into byteBuffer: inout ByteBuffer, context: PSQLEncodingContext) {
         var copyOfSelf = self // dirty hack
         byteBuffer.writeBuffer(&copyOfSelf)
     }
     
-    static func decode(from buffer: inout ByteBuffer, type: PSQLDataType, context: PSQLDecodingContext) throws -> Self {
+    static func decode(from buffer: inout ByteBuffer, type: PSQLDataType, format: PSQLFormat, context: PSQLDecodingContext) throws -> Self {
         return buffer
     }
 }
@@ -30,12 +38,16 @@ extension Data: PSQLCodable {
     var psqlType: PSQLDataType {
         .bytea
     }
-    
+
+    var psqlFormat: PSQLFormat {
+        .binary
+    }
+
     func encode(into byteBuffer: inout ByteBuffer, context: PSQLEncodingContext) {
         byteBuffer.writeBytes(self)
     }
-    
-    static func decode(from buffer: inout ByteBuffer, type: PSQLDataType, context: PSQLDecodingContext) throws -> Self {
+
+    static func decode(from buffer: inout ByteBuffer, type: PSQLDataType, format: PSQLFormat, context: PSQLDecodingContext) throws -> Self {
         return buffer.readData(length: buffer.readableBytes, byteTransferStrategy: .automatic)!
     }
 }

--- a/Sources/PostgresNIO/New/Data/Date+PSQLCodable.swift
+++ b/Sources/PostgresNIO/New/Data/Date+PSQLCodable.swift
@@ -5,7 +5,11 @@ extension Date: PSQLCodable {
         .timestamptz
     }
     
-    static func decode(from buffer: inout ByteBuffer, type: PSQLDataType, context: PSQLDecodingContext) throws -> Self {
+    var psqlFormat: PSQLFormat {
+        .binary
+    }
+    
+    static func decode(from buffer: inout ByteBuffer, type: PSQLDataType, format: PSQLFormat, context: PSQLDecodingContext) throws -> Self {
         switch type {
         case .timestamp, .timestamptz:
             guard buffer.readableBytes == 8, let microseconds = buffer.readInteger(as: Int64.self) else {

--- a/Sources/PostgresNIO/New/Data/Float+PSQLCodable.swift
+++ b/Sources/PostgresNIO/New/Data/Float+PSQLCodable.swift
@@ -3,18 +3,27 @@ extension Float: PSQLCodable {
         .float4
     }
     
-    static func decode(from buffer: inout ByteBuffer, type: PSQLDataType, context: PSQLDecodingContext) throws -> Float {
-        switch type {
-        case .float4:
+    var psqlFormat: PSQLFormat {
+        .binary
+    }
+    
+    static func decode(from buffer: inout ByteBuffer, type: PSQLDataType, format: PSQLFormat, context: PSQLDecodingContext) throws -> Float {
+        switch (format, type) {
+        case (.binary, .float4):
             guard buffer.readableBytes == 4, let float = buffer.readFloat() else {
                 throw PSQLCastingError.failure(targetType: Self.self, type: type, postgresData: buffer, context: context)
             }
             return float
-        case .float8:
+        case (.binary, .float8):
             guard buffer.readableBytes == 8, let double = buffer.readDouble() else {
                 throw PSQLCastingError.failure(targetType: Self.self, type: type, postgresData: buffer, context: context)
             }
             return Float(double)
+        case (.text, .float4), (.text, .float8):
+            guard let string = buffer.readString(length: buffer.readableBytes), let value = Float(string) else {
+                throw PSQLCastingError.failure(targetType: Self.self, type: type, postgresData: buffer, context: context)
+            }
+            return value
         default:
             throw PSQLCastingError.failure(targetType: Self.self, type: type, postgresData: buffer, context: context)
         }
@@ -30,18 +39,27 @@ extension Double: PSQLCodable {
         .float8
     }
     
-    static func decode(from buffer: inout ByteBuffer, type: PSQLDataType, context: PSQLDecodingContext) throws -> Double {
-        switch type {
-        case .float4:
+    var psqlFormat: PSQLFormat {
+        .binary
+    }
+    
+    static func decode(from buffer: inout ByteBuffer, type: PSQLDataType, format: PSQLFormat, context: PSQLDecodingContext) throws -> Double {
+        switch (format, type) {
+        case (.binary, .float4):
             guard buffer.readableBytes == 4, let float = buffer.readFloat() else {
                 throw PSQLCastingError.failure(targetType: Self.self, type: type, postgresData: buffer, context: context)
             }
             return Double(float)
-        case .float8:
+        case (.binary, .float8):
             guard buffer.readableBytes == 8, let double = buffer.readDouble() else {
                 throw PSQLCastingError.failure(targetType: Self.self, type: type, postgresData: buffer, context: context)
             }
             return double
+        case (.text, .float4), (.text, .float8):
+            guard let string = buffer.readString(length: buffer.readableBytes), let value = Double(string) else {
+                throw PSQLCastingError.failure(targetType: Self.self, type: type, postgresData: buffer, context: context)
+            }
+            return value
         default:
             throw PSQLCastingError.failure(targetType: Self.self, type: type, postgresData: buffer, context: context)
         }

--- a/Sources/PostgresNIO/New/Data/JSON+PSQLCodable.swift
+++ b/Sources/PostgresNIO/New/Data/JSON+PSQLCodable.swift
@@ -14,7 +14,6 @@ extension PSQLCodable where Self: Codable {
     }
     
     static func decode(from buffer: inout ByteBuffer, type: PSQLDataType, format: PSQLFormat, context: PSQLDecodingContext) throws -> Self {
-        print(buffer.getString(at: 0, length: buffer.readableBytes)!)
         switch (format, type) {
         case (.binary, .jsonb):
             guard JSONBVersionByte == buffer.readInteger(as: UInt8.self) else {

--- a/Sources/PostgresNIO/New/Data/JSON+PSQLCodable.swift
+++ b/Sources/PostgresNIO/New/Data/JSON+PSQLCodable.swift
@@ -9,15 +9,19 @@ extension PSQLCodable where Self: Codable {
         .jsonb
     }
     
-    static func decode(from buffer: inout ByteBuffer, type: PSQLDataType, context: PSQLDecodingContext) throws -> Self {
-        switch type {
-        case .jsonb:
+    var psqlFormat: PSQLFormat {
+        .binary
+    }
+    
+    static func decode(from buffer: inout ByteBuffer, type: PSQLDataType, format: PSQLFormat, context: PSQLDecodingContext) throws -> Self {
+        print(buffer.getString(at: 0, length: buffer.readableBytes)!)
+        switch (format, type) {
+        case (.binary, .jsonb):
             guard JSONBVersionByte == buffer.readInteger(as: UInt8.self) else {
                 throw PSQLCastingError.failure(targetType: Self.self, type: type, postgresData: buffer, context: context)
             }
-            
             return try context.jsonDecoder.decode(Self.self, from: buffer)
-        case .json:
+        case (.binary, .json), (.text, .jsonb), (.text, .json):
             return try context.jsonDecoder.decode(Self.self, from: buffer)
         default:
             throw PSQLCastingError.failure(targetType: Self.self, type: type, postgresData: buffer, context: context)

--- a/Sources/PostgresNIO/New/Data/Optional+PSQLCodable.swift
+++ b/Sources/PostgresNIO/New/Data/Optional+PSQLCodable.swift
@@ -1,5 +1,5 @@
 extension Optional: PSQLDecodable where Wrapped: PSQLDecodable {
-    static func decode(from byteBuffer: inout ByteBuffer, type: PSQLDataType, context: PSQLDecodingContext) throws -> Optional<Wrapped> {
+    static func decode(from byteBuffer: inout ByteBuffer, type: PSQLDataType, format: PSQLFormat, context: PSQLDecodingContext) throws -> Optional<Wrapped> {
         preconditionFailure("This code path should never be hit.")
         // The code path for decoding an optional should be:
         //  -> PSQLData.decode(as: String?.self)
@@ -15,6 +15,15 @@ extension Optional: PSQLEncodable where Wrapped: PSQLEncodable {
             return value.psqlType
         case .none:
             return .null
+        }
+    }
+    
+    var psqlFormat: PSQLFormat {
+        switch self {
+        case .some(let value):
+            return value.psqlFormat
+        case .none:
+            return .binary
         }
     }
     

--- a/Sources/PostgresNIO/New/Data/RawRepresentable+PSQLCodable.swift
+++ b/Sources/PostgresNIO/New/Data/RawRepresentable+PSQLCodable.swift
@@ -3,8 +3,12 @@ extension PSQLCodable where Self: RawRepresentable, RawValue: PSQLCodable {
         self.rawValue.psqlType
     }
     
-    static func decode(from buffer: inout ByteBuffer, type: PSQLDataType, context: PSQLDecodingContext) throws -> Self {
-        guard let rawValue = try? RawValue.decode(from: &buffer, type: type, context: context),
+    var psqlFormat: PSQLFormat {
+        self.rawValue.psqlFormat
+    }
+    
+    static func decode(from buffer: inout ByteBuffer, type: PSQLDataType, format: PSQLFormat, context: PSQLDecodingContext) throws -> Self {
+        guard let rawValue = try? RawValue.decode(from: &buffer, type: type, format: format, context: context),
               let selfValue = Self.init(rawValue: rawValue) else {
             throw PSQLCastingError.failure(targetType: Self.self, type: type, postgresData: buffer, context: context)
         }

--- a/Sources/PostgresNIO/New/Data/String+PSQLCodable.swift
+++ b/Sources/PostgresNIO/New/Data/String+PSQLCodable.swift
@@ -5,18 +5,24 @@ extension String: PSQLCodable {
         .text
     }
     
+    var psqlFormat: PSQLFormat {
+        .binary
+    }
+    
     func encode(into byteBuffer: inout ByteBuffer, context: PSQLEncodingContext) {
         byteBuffer.writeString(self)
     }
     
-    static func decode(from buffer: inout ByteBuffer, type: PSQLDataType, context: PSQLDecodingContext) throws -> String {
-        switch type {
-        case .varchar, .text, .name:
+    static func decode(from buffer: inout ByteBuffer, type: PSQLDataType, format: PSQLFormat, context: PSQLDecodingContext) throws -> String {
+        switch (format, type) {
+        case (_, .varchar),
+             (_, .text),
+             (_, .name):
             // we can force unwrap here, since this method only fails if there are not enough
             // bytes available.
             return buffer.readString(length: buffer.readableBytes)!
-        case .uuid:
-            guard let uuid = try? UUID.decode(from: &buffer, type: .uuid, context: context) else {
+        case (_, .uuid):
+            guard let uuid = try? UUID.decode(from: &buffer, type: .uuid, format: format, context: context) else {
                 throw PSQLCastingError.failure(targetType: Self.self, type: type, postgresData: buffer, context: context)
             }
             return uuid.uuidString

--- a/Sources/PostgresNIO/New/Messages/Bind.swift
+++ b/Sources/PostgresNIO/New/Messages/Bind.swift
@@ -18,10 +18,12 @@ extension PSQLFrontendMessage {
             // zero to indicate that there are no parameters or that the parameters all use the
             // default format (text); or one, in which case the specified format code is applied
             // to all parameters; or it can equal the actual number of parameters.
-            buffer.writeInteger(1, as: Int16.self)
+            buffer.writeInteger(Int16(self.parameters.count))
             
             // The parameter format codes. Each must presently be zero (text) or one (binary).
-            buffer.writeInteger(1, as: Int16.self)
+            self.parameters.forEach {
+                buffer.writeInteger($0.psqlFormat.rawValue)
+            }
             
             buffer.writeInteger(Int16(self.parameters.count))
             
@@ -38,7 +40,7 @@ extension PSQLFrontendMessage {
             // result columns of the query.
             buffer.writeInteger(1, as: Int16.self)
             // The result-column format codes. Each must presently be zero (text) or one (binary).
-            buffer.writeInteger(1, as: Int16.self)
+            buffer.writeInteger(PSQLFormat.binary.rawValue, as: Int16.self)
         }
     }
 }

--- a/Sources/PostgresNIO/New/Messages/RowDescription.swift
+++ b/Sources/PostgresNIO/New/Messages/RowDescription.swift
@@ -23,7 +23,7 @@ extension PSQLBackendMessage {
             /// The type modifier (see pg_attribute.atttypmod). The meaning of the modifier is type-specific.
             var dataTypeModifier: Int32
             
-            /// The format being used for the field. Currently will text or binary. In a RowDescription returned
+            /// The format being used for the field. Currently will be text or binary. In a RowDescription returned
             /// from the statement variant of Describe, the format code is not yet known and will always be text.
             var format: PSQLFormat
         }

--- a/Sources/PostgresNIO/New/Messages/RowDescription.swift
+++ b/Sources/PostgresNIO/New/Messages/RowDescription.swift
@@ -23,9 +23,9 @@ extension PSQLBackendMessage {
             /// The type modifier (see pg_attribute.atttypmod). The meaning of the modifier is type-specific.
             var dataTypeModifier: Int32
             
-            /// The format code being used for the field. Currently will be zero (text) or one (binary). In a RowDescription returned
-            /// from the statement variant of Describe, the format code is not yet known and will always be zero.
-            var formatCode: PSQLFormatCode
+            /// The format being used for the field. Currently will text or binary. In a RowDescription returned
+            /// from the statement variant of Describe, the format code is not yet known and will always be text.
+            var format: PSQLFormat
         }
         
         static func decode(from buffer: inout ByteBuffer) throws -> Self {
@@ -53,8 +53,8 @@ extension PSQLBackendMessage {
                 let dataTypeModifier = buffer.readInteger(as: Int32.self)!
                 let formatCodeInt16 = buffer.readInteger(as: Int16.self)!
                 
-                guard let formatCode = PSQLFormatCode(rawValue: formatCodeInt16) else {
-                    throw PartialDecodingError.valueNotRawRepresentable(value: formatCodeInt16, asType: PSQLFormatCode.self)
+                guard let format = PSQLFormat(rawValue: formatCodeInt16) else {
+                    throw PartialDecodingError.valueNotRawRepresentable(value: formatCodeInt16, asType: PSQLFormat.self)
                 }
                 
                 let field = Column(
@@ -64,7 +64,7 @@ extension PSQLBackendMessage {
                     dataType: dataType,
                     dataTypeSize: dataTypeSize,
                     dataTypeModifier: dataTypeModifier,
-                    formatCode: formatCode)
+                    format: format)
                 
                 result.append(field)
             }

--- a/Sources/PostgresNIO/New/PSQLCodable.swift
+++ b/Sources/PostgresNIO/New/PSQLCodable.swift
@@ -19,7 +19,17 @@ protocol PSQLEncodable {
 /// A type that can decode itself from a postgres wire binary representation.
 protocol PSQLDecodable {
 
-    /// decode an entity from the `byteBuffer` in postgres binary format
+    /// Decode an entity from the `byteBuffer` in postgres binary format
+    ///
+    /// - Parameters:
+    ///   - byteBuffer: A `ByteBuffer` to decode. The byteBuffer is sliced in such a way that it is expected
+    ///                 that the complete buffer is consumed for decoding
+    ///   - type: The postgres data type. Depending on this type the `byteBuffer`'s bytes need to be interpreted
+    ///           in different ways.
+    ///   - format: The postgres wire format. Can be `.text` or `.binary`
+    ///   - context: A `PSQLDecodingContext` providing context for decoding. This includes a `JSONDecoder`
+    ///              to use when decoding json and metadata to create better erros.
+    /// - Returns: A decoded object
     static func decode(from byteBuffer: inout ByteBuffer, type: PSQLDataType, format: PSQLFormat, context: PSQLDecodingContext) throws -> Self
 }
 

--- a/Sources/PostgresNIO/New/PSQLCodable.swift
+++ b/Sources/PostgresNIO/New/PSQLCodable.swift
@@ -3,6 +3,9 @@ protocol PSQLEncodable {
     /// identifies the data type that we will encode into `byteBuffer` in `encode`
     var psqlType: PSQLDataType { get }
     
+    /// identifies the postgres format that is used to encode the value into `byteBuffer` in `encode`
+    var psqlFormat: PSQLFormat { get }
+    
     /// Encode the entity into the `byteBuffer` in Postgres binary format, without setting
     /// the byte count. This method is called from the default `encodeRaw` implementation.
     func encode(into byteBuffer: inout ByteBuffer, context: PSQLEncodingContext) throws
@@ -17,7 +20,7 @@ protocol PSQLEncodable {
 protocol PSQLDecodable {
 
     /// decode an entity from the `byteBuffer` in postgres binary format
-    static func decode(from byteBuffer: inout ByteBuffer, type: PSQLDataType, context: PSQLDecodingContext) throws -> Self
+    static func decode(from byteBuffer: inout ByteBuffer, type: PSQLDataType, format: PSQLFormat, context: PSQLDecodingContext) throws -> Self
 }
 
 /// A type that can be encoded into and decoded from a postgres binary format

--- a/Sources/PostgresNIO/New/PSQLCodable.swift
+++ b/Sources/PostgresNIO/New/PSQLCodable.swift
@@ -19,7 +19,7 @@ protocol PSQLEncodable {
 /// A type that can decode itself from a postgres wire binary representation.
 protocol PSQLDecodable {
 
-    /// Decode an entity from the `byteBuffer` in postgres binary format
+    /// Decode an entity from the `byteBuffer` in postgres wire format
     ///
     /// - Parameters:
     ///   - byteBuffer: A `ByteBuffer` to decode. The byteBuffer is sliced in such a way that it is expected
@@ -28,7 +28,7 @@ protocol PSQLDecodable {
     ///           in different ways.
     ///   - format: The postgres wire format. Can be `.text` or `.binary`
     ///   - context: A `PSQLDecodingContext` providing context for decoding. This includes a `JSONDecoder`
-    ///              to use when decoding json and metadata to create better erros.
+    ///              to use when decoding json and metadata to create better errors.
     /// - Returns: A decoded object
     static func decode(from byteBuffer: inout ByteBuffer, type: PSQLDataType, format: PSQLFormat, context: PSQLDecodingContext) throws -> Self
 }

--- a/Sources/PostgresNIO/New/PSQLData.swift
+++ b/Sources/PostgresNIO/New/PSQLData.swift
@@ -3,9 +3,6 @@
 /// Currently there a two wire formats supported:
 ///  - text
 ///  - binary
-///
-/// In a `RowDescription` returned from the statement variant of `Describe`,
-/// the format is not yet known and will always be `.text`.
 enum PSQLFormat: Int16 {
     case text = 0
     case binary = 1

--- a/Sources/PostgresNIO/Postgres+PSQLCompat.swift
+++ b/Sources/PostgresNIO/Postgres+PSQLCompat.swift
@@ -30,6 +30,10 @@ extension PostgresData: PSQLEncodable {
         PSQLDataType(Int32(self.type.rawValue))
     }
     
+    var psqlFormat: PSQLFormat {
+        .binary
+    }
+    
     func encode(into byteBuffer: inout ByteBuffer, context: PSQLEncodingContext) throws {
         preconditionFailure("Should never be hit, since `encodeRaw` is implemented.")
     }
@@ -47,7 +51,7 @@ extension PostgresData: PSQLEncodable {
 }
 
 extension PostgresData: PSQLDecodable {
-    static func decode(from byteBuffer: inout ByteBuffer, type: PSQLDataType, context: PSQLDecodingContext) throws -> PostgresData {
+    static func decode(from byteBuffer: inout ByteBuffer, type: PSQLDataType, format: PSQLFormat, context: PSQLDecodingContext) throws -> PostgresData {
         let myBuffer = byteBuffer.readSlice(length: byteBuffer.readableBytes)!
         
         return PostgresData(type: PostgresDataType(UInt32(type.rawValue)), typeModifier: nil, formatCode: .binary, value: myBuffer)
@@ -97,7 +101,7 @@ extension PSQLError {
 }
 
 extension PostgresFormatCode {
-    init(psqlFormatCode: PSQLFormatCode) {
+    init(psqlFormatCode: PSQLFormat) {
         switch psqlFormatCode {
         case .binary:
             self = .binary

--- a/Tests/PostgresNIOTests/New/Connection State Machine/ExtendedQueryStateMachineTests.swift
+++ b/Tests/PostgresNIOTests/New/Connection State Machine/ExtendedQueryStateMachineTests.swift
@@ -34,19 +34,26 @@ class ExtendedQueryStateMachineTests: XCTestCase {
         XCTAssertEqual(state.parseCompleteReceived(), .wait)
         XCTAssertEqual(state.parameterDescriptionReceived(.init(dataTypes: [.int8])), .wait)
         
-        let columns: [PSQLBackendMessage.RowDescription.Column] = [
-            .init(name: "version", tableOID: 0, columnAttributeNumber: 0, dataType: .text, dataTypeSize: -1, dataTypeModifier: -1, formatCode: .text)
+        // We need to ensure that even though the row description from the wire says that we
+        // will receive data in `.text` format, we will actually receive it in binary format,
+        // since we requested it in binary with our bind message.
+        let input: [PSQLBackendMessage.RowDescription.Column] = [
+            .init(name: "version", tableOID: 0, columnAttributeNumber: 0, dataType: .text, dataTypeSize: -1, dataTypeModifier: -1, format: .text)
         ]
+        let expected: [PSQLBackendMessage.RowDescription.Column] = input.map {
+            .init(name: $0.name, tableOID: $0.tableOID, columnAttributeNumber: $0.columnAttributeNumber, dataType: $0.dataType,
+                  dataTypeSize: $0.dataTypeSize, dataTypeModifier: $0.dataTypeModifier, format: .binary)
+        }
         
-        XCTAssertEqual(state.rowDescriptionReceived(.init(columns: columns)), .wait)
-        XCTAssertEqual(state.bindCompleteReceived(), .succeedQuery(queryContext, columns: columns))
+        XCTAssertEqual(state.rowDescriptionReceived(.init(columns: input)), .wait)
+        XCTAssertEqual(state.bindCompleteReceived(), .succeedQuery(queryContext, columns: expected))
         let rowContent = ByteBuffer(string: "test")
         XCTAssertEqual(state.dataRowReceived(.init(columns: [rowContent])), .wait)
         XCTAssertEqual(state.readEventCaught(), .wait)
         
         let rowPromise = EmbeddedEventLoop().makePromise(of: StateMachineStreamNextResult.self)
         rowPromise.fail(PSQLError.uncleanShutdown) // we don't care about the error at all.
-        XCTAssertEqual(state.consumeNextQueryRow(promise: rowPromise), .forwardRow([.init(bytes: rowContent, dataType: .text)], to: rowPromise))
+        XCTAssertEqual(state.consumeNextQueryRow(promise: rowPromise), .forwardRow([.init(bytes: rowContent, dataType: .text, format: .binary)], to: rowPromise))
         
         XCTAssertEqual(state.commandCompletedReceived("SELECT 1"), .forwardStreamCompletedToCurrentQuery(CircularBuffer(), commandTag: "SELECT 1", read: true))
         XCTAssertEqual(state.readyForQueryReceived(.idle), .fireEventReadyForQuery)

--- a/Tests/PostgresNIOTests/New/Connection State Machine/PrepareStatementStateMachineTests.swift
+++ b/Tests/PostgresNIOTests/New/Connection State Machine/PrepareStatementStateMachineTests.swift
@@ -20,7 +20,7 @@ class PrepareStatementStateMachineTests: XCTestCase {
         XCTAssertEqual(state.parameterDescriptionReceived(.init(dataTypes: [.int8])), .wait)
         
         let columns: [PSQLBackendMessage.RowDescription.Column] = [
-            .init(name: "id", tableOID: 0, columnAttributeNumber: 0, dataType: .int8, dataTypeSize: 8, dataTypeModifier: -1, formatCode: .binary)
+            .init(name: "id", tableOID: 0, columnAttributeNumber: 0, dataType: .int8, dataTypeSize: 8, dataTypeModifier: -1, format: .binary)
         ]
         
         XCTAssertEqual(state.rowDescriptionReceived(.init(columns: columns)),

--- a/Tests/PostgresNIOTests/New/Data/Array+PSQLCodableTests.swift
+++ b/Tests/PostgresNIOTests/New/Data/Array+PSQLCodableTests.swift
@@ -61,7 +61,7 @@ class Array_PSQLCodableTests: XCTestCase {
         
         var buffer = ByteBuffer()
         XCTAssertNoThrow(try values.encode(into: &buffer, context: .forTests()))
-        let data = PSQLData(bytes: buffer, dataType: .textArray)
+        let data = PSQLData(bytes: buffer, dataType: .textArray, format: .binary)
         
         var result: [String]?
         XCTAssertNoThrow(result = try data.decode(as: [String].self, context: .forTests()))
@@ -73,7 +73,7 @@ class Array_PSQLCodableTests: XCTestCase {
         
         var buffer = ByteBuffer()
         XCTAssertNoThrow(try values.encode(into: &buffer, context: .forTests()))
-        let data = PSQLData(bytes: buffer, dataType: .textArray)
+        let data = PSQLData(bytes: buffer, dataType: .textArray, format: .binary)
         
         var result: [String]?
         XCTAssertNoThrow(result = try data.decode(as: [String].self, context: .forTests()))
@@ -85,7 +85,7 @@ class Array_PSQLCodableTests: XCTestCase {
         buffer.writeInteger(Int32(2)) // invalid value
         buffer.writeInteger(Int32(0))
         buffer.writeInteger(String.psqlArrayElementType.rawValue)
-        let data = PSQLData(bytes: buffer, dataType: .textArray)
+        let data = PSQLData(bytes: buffer, dataType: .textArray, format: .binary)
         
         XCTAssertThrowsError(try data.decode(as: [String].self, context: .forTests())) { error in
             XCTAssert(error is PSQLCastingError)
@@ -97,7 +97,7 @@ class Array_PSQLCodableTests: XCTestCase {
         buffer.writeInteger(Int32(0)) // is empty
         buffer.writeInteger(Int32(1)) // invalid value, must always be 0
         buffer.writeInteger(String.psqlArrayElementType.rawValue)
-        let data = PSQLData(bytes: buffer, dataType: .textArray)
+        let data = PSQLData(bytes: buffer, dataType: .textArray, format: .binary)
         
         XCTAssertThrowsError(try data.decode(as: [String].self, context: .forTests())) { error in
             XCTAssert(error is PSQLCastingError)
@@ -108,7 +108,7 @@ class Array_PSQLCodableTests: XCTestCase {
         let value: Int64 = 1 << 32
         var buffer = ByteBuffer()
         value.encode(into: &buffer, context: .forTests())
-        let data = PSQLData(bytes: buffer, dataType: .textArray)
+        let data = PSQLData(bytes: buffer, dataType: .textArray, format: .binary)
         
         XCTAssertThrowsError(try data.decode(as: [String].self, context: .forTests())) { error in
             XCTAssert(error is PSQLCastingError)
@@ -122,7 +122,7 @@ class Array_PSQLCodableTests: XCTestCase {
         buffer.writeInteger(String.psqlArrayElementType.rawValue)
         buffer.writeInteger(Int32(-123)) // expected element count
         buffer.writeInteger(Int32(1)) // dimensions... must be one
-        let data = PSQLData(bytes: buffer, dataType: .textArray)
+        let data = PSQLData(bytes: buffer, dataType: .textArray, format: .binary)
         
         XCTAssertThrowsError(try data.decode(as: [String].self, context: .forTests())) { error in
             XCTAssert(error is PSQLCastingError)
@@ -136,7 +136,7 @@ class Array_PSQLCodableTests: XCTestCase {
         buffer.writeInteger(String.psqlArrayElementType.rawValue)
         buffer.writeInteger(Int32(1)) // expected element count
         buffer.writeInteger(Int32(2)) // dimensions... must be one
-        let data = PSQLData(bytes: buffer, dataType: .textArray)
+        let data = PSQLData(bytes: buffer, dataType: .textArray, format: .binary)
         
         XCTAssertThrowsError(try data.decode(as: [String].self, context: .forTests())) { error in
             XCTAssert(error is PSQLCastingError)
@@ -151,7 +151,7 @@ class Array_PSQLCodableTests: XCTestCase {
         unexpectedEndInElementLengthBuffer.writeInteger(Int32(1)) // expected element count
         unexpectedEndInElementLengthBuffer.writeInteger(Int32(1)) // dimensions
         unexpectedEndInElementLengthBuffer.writeInteger(Int16(1)) // length of element, must be Int32
-        let data = PSQLData(bytes: unexpectedEndInElementLengthBuffer, dataType: .textArray)
+        let data = PSQLData(bytes: unexpectedEndInElementLengthBuffer, dataType: .textArray, format: .binary)
         
         XCTAssertThrowsError(try data.decode(as: [String].self, context: .forTests())) { error in
             XCTAssert(error is PSQLCastingError)
@@ -165,7 +165,7 @@ class Array_PSQLCodableTests: XCTestCase {
         unexpectedEndInElementBuffer.writeInteger(Int32(1)) // dimensions
         unexpectedEndInElementBuffer.writeInteger(Int32(12)) // length of element, must be Int32
         unexpectedEndInElementBuffer.writeString("Hello World") // only 11 bytes, 12 needed!
-        let unexpectedEndInElementData = PSQLData(bytes: unexpectedEndInElementBuffer, dataType: .textArray)
+        let unexpectedEndInElementData = PSQLData(bytes: unexpectedEndInElementBuffer, dataType: .textArray, format: .binary)
         
         XCTAssertThrowsError(try unexpectedEndInElementData.decode(as: [String].self, context: .forTests())) { error in
             XCTAssert(error is PSQLCastingError)

--- a/Tests/PostgresNIOTests/New/Data/Bool+PSQLCodableTests.swift
+++ b/Tests/PostgresNIOTests/New/Data/Bool+PSQLCodableTests.swift
@@ -3,50 +3,90 @@ import XCTest
 
 class Bool_PSQLCodableTests: XCTestCase {
     
-    func testTrueRoundTrip() {
+    // MARK: - Binary
+    
+    func testBinaryTrueRoundTrip() {
         let value = true
         
         var buffer = ByteBuffer()
         value.encode(into: &buffer, context: .forTests())
         XCTAssertEqual(value.psqlType, .bool)
+        XCTAssertEqual(value.psqlFormat, .binary)
         XCTAssertEqual(buffer.readableBytes, 1)
         XCTAssertEqual(buffer.getInteger(at: buffer.readerIndex, as: UInt8.self), 1)
-        let data = PSQLData(bytes: buffer, dataType: .bool)
+        let data = PSQLData(bytes: buffer, dataType: .bool, format: .binary)
         
         var result: Bool?
         XCTAssertNoThrow(result = try data.decode(as: Bool.self, context: .forTests()))
         XCTAssertEqual(value, result)
     }
     
-    func testFalseRoundTrip() {
+    func testBinaryFalseRoundTrip() {
         let value = false
         
         var buffer = ByteBuffer()
         value.encode(into: &buffer, context: .forTests())
         XCTAssertEqual(value.psqlType, .bool)
+        XCTAssertEqual(value.psqlFormat, .binary)
         XCTAssertEqual(buffer.readableBytes, 1)
         XCTAssertEqual(buffer.getInteger(at: buffer.readerIndex, as: UInt8.self), 0)
-        let data = PSQLData(bytes: buffer, dataType: .bool)
+        let data = PSQLData(bytes: buffer, dataType: .bool, format: .binary)
         
         var result: Bool?
         XCTAssertNoThrow(result = try data.decode(as: Bool.self, context: .forTests()))
         XCTAssertEqual(value, result)
     }
-
-    func testDecodeBoolInvalidLength() {
+    
+    func testBinaryDecodeBoolInvalidLength() {
         var buffer = ByteBuffer()
         buffer.writeInteger(Int64(1))
-        let data = PSQLData(bytes: buffer, dataType: .bool)
+        let data = PSQLData(bytes: buffer, dataType: .bool, format: .binary)
         
         XCTAssertThrowsError(try data.decode(as: Bool.self, context: .forTests())) { error in
             XCTAssert(error is PSQLCastingError)
         }
     }
     
-    func testDecodeBoolInvalidValue() {
+    func testBinaryDecodeBoolInvalidValue() {
         var buffer = ByteBuffer()
         buffer.writeInteger(UInt8(13))
-        let data = PSQLData(bytes: buffer, dataType: .bool)
+        let data = PSQLData(bytes: buffer, dataType: .bool, format: .binary)
+        
+        XCTAssertThrowsError(try data.decode(as: Bool.self, context: .forTests())) { error in
+            XCTAssert(error is PSQLCastingError)
+        }
+    }
+
+    // MARK: - Text
+    
+    func testTextTrueDecode() {
+        let value = true
+        
+        var buffer = ByteBuffer()
+        buffer.writeInteger(UInt8(ascii: "t"))
+        let data = PSQLData(bytes: buffer, dataType: .bool, format: .text)
+        
+        var result: Bool?
+        XCTAssertNoThrow(result = try data.decode(as: Bool.self, context: .forTests()))
+        XCTAssertEqual(value, result)
+    }
+    
+    func testTextFalseDecode() {
+        let value = false
+        
+        var buffer = ByteBuffer()
+        buffer.writeInteger(UInt8(ascii: "f"))
+        let data = PSQLData(bytes: buffer, dataType: .bool, format: .text)
+        
+        var result: Bool?
+        XCTAssertNoThrow(result = try data.decode(as: Bool.self, context: .forTests()))
+        XCTAssertEqual(value, result)
+    }
+    
+    func testTextDecodeBoolInvalidValue() {
+        var buffer = ByteBuffer()
+        buffer.writeInteger(UInt8(13))
+        let data = PSQLData(bytes: buffer, dataType: .bool, format: .text)
         
         XCTAssertThrowsError(try data.decode(as: Bool.self, context: .forTests())) { error in
             XCTAssert(error is PSQLCastingError)

--- a/Tests/PostgresNIOTests/New/Data/Bytes+PSQLCodableTests.swift
+++ b/Tests/PostgresNIOTests/New/Data/Bytes+PSQLCodableTests.swift
@@ -9,7 +9,7 @@ class Bytes_PSQLCodableTests: XCTestCase {
         var buffer = ByteBuffer()
         data.encode(into: &buffer, context: .forTests())
         XCTAssertEqual(data.psqlType, .bytea)
-        let psqlData = PSQLData(bytes: buffer, dataType: .bytea)
+        let psqlData = PSQLData(bytes: buffer, dataType: .bytea, format: .binary)
         
         var result: Data?
         XCTAssertNoThrow(result = try psqlData.decode(as: Data.self, context: .forTests()))
@@ -22,7 +22,7 @@ class Bytes_PSQLCodableTests: XCTestCase {
         var buffer = ByteBuffer()
         bytes.encode(into: &buffer, context: .forTests())
         XCTAssertEqual(bytes.psqlType, .bytea)
-        let psqlData = PSQLData(bytes: buffer, dataType: .bytea)
+        let psqlData = PSQLData(bytes: buffer, dataType: .bytea, format: .binary)
         
         var result: ByteBuffer?
         XCTAssertNoThrow(result = try psqlData.decode(as: ByteBuffer.self, context: .forTests()))

--- a/Tests/PostgresNIOTests/New/Data/Date+PSQLCodableTests.swift
+++ b/Tests/PostgresNIOTests/New/Data/Date+PSQLCodableTests.swift
@@ -10,7 +10,7 @@ class Date_PSQLCodableTests: XCTestCase {
         value.encode(into: &buffer, context: .forTests())
         XCTAssertEqual(value.psqlType, .timestamptz)
         XCTAssertEqual(buffer.readableBytes, 8)
-        let data = PSQLData(bytes: buffer, dataType: .timestamptz)
+        let data = PSQLData(bytes: buffer, dataType: .timestamptz, format: .binary)
         
         var result: Date?
         XCTAssertNoThrow(result = try data.decode(as: Date.self, context: .forTests()))
@@ -20,7 +20,7 @@ class Date_PSQLCodableTests: XCTestCase {
     func testDecodeRandomDate() {
         var buffer = ByteBuffer()
         buffer.writeInteger(Int64.random(in: Int64.min...Int64.max))
-        let data = PSQLData(bytes: buffer, dataType: .timestamptz)
+        let data = PSQLData(bytes: buffer, dataType: .timestamptz, format: .binary)
         
         var result: Date?
         XCTAssertNoThrow(result = try data.decode(as: Date.self, context: .forTests()))
@@ -31,7 +31,7 @@ class Date_PSQLCodableTests: XCTestCase {
         var buffer = ByteBuffer()
         buffer.writeInteger(Int64.random(in: Int64.min...Int64.max))
         buffer.writeInteger(Int64.random(in: Int64.min...Int64.max))
-        let data = PSQLData(bytes: buffer, dataType: .timestamptz)
+        let data = PSQLData(bytes: buffer, dataType: .timestamptz, format: .binary)
         
         XCTAssertThrowsError(try data.decode(as: Date.self, context: .forTests())) { error in
             XCTAssert(error is PSQLCastingError)
@@ -41,7 +41,7 @@ class Date_PSQLCodableTests: XCTestCase {
     func testDecodeDate() {
         var firstDateBuffer = ByteBuffer()
         firstDateBuffer.writeInteger(Int32.min)
-        let firstDateData = PSQLData(bytes: firstDateBuffer, dataType: .date)
+        let firstDateData = PSQLData(bytes: firstDateBuffer, dataType: .date, format: .binary)
         
         var firstDate: Date?
         XCTAssertNoThrow(firstDate = try firstDateData.decode(as: Date.self, context: .forTests()))
@@ -49,7 +49,7 @@ class Date_PSQLCodableTests: XCTestCase {
         
         var lastDateBuffer = ByteBuffer()
         lastDateBuffer.writeInteger(Int32.max)
-        let lastDateData = PSQLData(bytes: lastDateBuffer, dataType: .date)
+        let lastDateData = PSQLData(bytes: lastDateBuffer, dataType: .date, format: .binary)
         
         var lastDate: Date?
         XCTAssertNoThrow(lastDate = try lastDateData.decode(as: Date.self, context: .forTests()))
@@ -59,7 +59,7 @@ class Date_PSQLCodableTests: XCTestCase {
     func testDecodeDateFromTimestamp() {
         var firstDateBuffer = ByteBuffer()
         firstDateBuffer.writeInteger(Int32.min)
-        let firstDateData = PSQLData(bytes: firstDateBuffer, dataType: .date)
+        let firstDateData = PSQLData(bytes: firstDateBuffer, dataType: .date, format: .binary)
         
         var firstDate: Date?
         XCTAssertNoThrow(firstDate = try firstDateData.decode(as: Date.self, context: .forTests()))
@@ -67,7 +67,7 @@ class Date_PSQLCodableTests: XCTestCase {
         
         var lastDateBuffer = ByteBuffer()
         lastDateBuffer.writeInteger(Int32.max)
-        let lastDateData = PSQLData(bytes: lastDateBuffer, dataType: .date)
+        let lastDateData = PSQLData(bytes: lastDateBuffer, dataType: .date, format: .binary)
         
         var lastDate: Date?
         XCTAssertNoThrow(lastDate = try lastDateData.decode(as: Date.self, context: .forTests()))
@@ -77,7 +77,7 @@ class Date_PSQLCodableTests: XCTestCase {
     func testDecodeDateFailsWithToMuchData() {
         var buffer = ByteBuffer()
         buffer.writeInteger(Int64(0))
-        let data = PSQLData(bytes: buffer, dataType: .date)
+        let data = PSQLData(bytes: buffer, dataType: .date, format: .binary)
         
         XCTAssertThrowsError(try data.decode(as: Date.self, context: .forTests())) { error in
             XCTAssert(error is PSQLCastingError)
@@ -87,7 +87,7 @@ class Date_PSQLCodableTests: XCTestCase {
     func testDecodeDateFailsWithWrongDataType() {
         var buffer = ByteBuffer()
         buffer.writeInteger(Int64(0))
-        let data = PSQLData(bytes: buffer, dataType: .int8)
+        let data = PSQLData(bytes: buffer, dataType: .int8, format: .binary)
         
         XCTAssertThrowsError(try data.decode(as: Date.self, context: .forTests())) { error in
             XCTAssert(error is PSQLCastingError)

--- a/Tests/PostgresNIOTests/New/Data/Float+PSQLCodableTests.swift
+++ b/Tests/PostgresNIOTests/New/Data/Float+PSQLCodableTests.swift
@@ -11,7 +11,7 @@ class Float_PSQLCodableTests: XCTestCase {
             value.encode(into: &buffer, context: .forTests())
             XCTAssertEqual(value.psqlType, .float8)
             XCTAssertEqual(buffer.readableBytes, 8)
-            let data = PSQLData(bytes: buffer, dataType: .float8)
+            let data = PSQLData(bytes: buffer, dataType: .float8, format: .binary)
             
             var result: Double?
             XCTAssertNoThrow(result = try data.decode(as: Double.self, context: .forTests()))
@@ -27,7 +27,7 @@ class Float_PSQLCodableTests: XCTestCase {
             value.encode(into: &buffer, context: .forTests())
             XCTAssertEqual(value.psqlType, .float4)
             XCTAssertEqual(buffer.readableBytes, 4)
-            let data = PSQLData(bytes: buffer, dataType: .float4)
+            let data = PSQLData(bytes: buffer, dataType: .float4, format: .binary)
             
             var result: Float?
             XCTAssertNoThrow(result = try data.decode(as: Float.self, context: .forTests()))
@@ -42,7 +42,7 @@ class Float_PSQLCodableTests: XCTestCase {
         value.encode(into: &buffer, context: .forTests())
         XCTAssertEqual(value.psqlType, .float8)
         XCTAssertEqual(buffer.readableBytes, 8)
-        let data = PSQLData(bytes: buffer, dataType: .float8)
+        let data = PSQLData(bytes: buffer, dataType: .float8, format: .binary)
         
         var result: Double?
         XCTAssertNoThrow(result = try data.decode(as: Double.self, context: .forTests()))
@@ -56,7 +56,7 @@ class Float_PSQLCodableTests: XCTestCase {
         value.encode(into: &buffer, context: .forTests())
         XCTAssertEqual(value.psqlType, .float8)
         XCTAssertEqual(buffer.readableBytes, 8)
-        let data = PSQLData(bytes: buffer, dataType: .float8)
+        let data = PSQLData(bytes: buffer, dataType: .float8, format: .binary)
         
         var result: Double?
         XCTAssertNoThrow(result = try data.decode(as: Double.self, context: .forTests()))
@@ -71,7 +71,7 @@ class Float_PSQLCodableTests: XCTestCase {
             value.encode(into: &buffer, context: .forTests())
             XCTAssertEqual(value.psqlType, .float4)
             XCTAssertEqual(buffer.readableBytes, 4)
-            let data = PSQLData(bytes: buffer, dataType: .float4)
+            let data = PSQLData(bytes: buffer, dataType: .float4, format: .binary)
             
             var result: Double?
             XCTAssertNoThrow(result = try data.decode(as: Double.self, context: .forTests()))
@@ -87,7 +87,7 @@ class Float_PSQLCodableTests: XCTestCase {
             value.encode(into: &buffer, context: .forTests())
             XCTAssertEqual(value.psqlType, .float8)
             XCTAssertEqual(buffer.readableBytes, 8)
-            let data = PSQLData(bytes: buffer, dataType: .float8)
+            let data = PSQLData(bytes: buffer, dataType: .float8, format: .binary)
             
             var result: Float?
             XCTAssertNoThrow(result = try data.decode(as: Float.self, context: .forTests()))
@@ -100,8 +100,8 @@ class Float_PSQLCodableTests: XCTestCase {
         eightByteBuffer.writeInteger(Int64(0))
         var fourByteBuffer = ByteBuffer()
         fourByteBuffer.writeInteger(Int32(0))
-        let toLongData = PSQLData(bytes: eightByteBuffer, dataType: .float4)
-        let toShortData = PSQLData(bytes: fourByteBuffer, dataType: .float8)
+        let toLongData = PSQLData(bytes: eightByteBuffer, dataType: .float4, format: .binary)
+        let toShortData = PSQLData(bytes: fourByteBuffer, dataType: .float8, format: .binary)
         
         XCTAssertThrowsError(try toLongData.decode(as: Double.self, context: .forTests())) { error in
             XCTAssert(error is PSQLCastingError)
@@ -123,7 +123,7 @@ class Float_PSQLCodableTests: XCTestCase {
     func testDecodeFailureInvalidType() {
         var buffer = ByteBuffer()
         buffer.writeInteger(Int64(0))
-        let data = PSQLData(bytes: buffer, dataType: .int8)
+        let data = PSQLData(bytes: buffer, dataType: .int8, format: .binary)
         
         XCTAssertThrowsError(try data.decode(as: Double.self, context: .forTests())) { error in
             XCTAssert(error is PSQLCastingError)

--- a/Tests/PostgresNIOTests/New/Data/Optional+PSQLCodableTests.swift
+++ b/Tests/PostgresNIOTests/New/Data/Optional+PSQLCodableTests.swift
@@ -9,7 +9,7 @@ class Optional_PSQLCodableTests: XCTestCase {
         var buffer = ByteBuffer()
         value?.encode(into: &buffer, context: .forTests())
         XCTAssertEqual(value.psqlType, .text)
-        let data = PSQLData(bytes: buffer, dataType: .text)
+        let data = PSQLData(bytes: buffer, dataType: .text, format: .binary)
         
         var result: String?
         XCTAssertNoThrow(result = try data.decode(as: String?.self, context: .forTests()))
@@ -24,7 +24,7 @@ class Optional_PSQLCodableTests: XCTestCase {
         XCTAssertEqual(buffer.readableBytes, 0)
         XCTAssertEqual(value.psqlType, .null)
         
-        let data = PSQLData(bytes: nil, dataType: .text)
+        let data = PSQLData(bytes: nil, dataType: .text, format: .binary)
         
         var result: String?
         XCTAssertNoThrow(result = try data.decode(as: String?.self, context: .forTests()))
@@ -40,7 +40,7 @@ class Optional_PSQLCodableTests: XCTestCase {
         XCTAssertNoThrow(try encodable.encodeRaw(into: &buffer, context: .forTests()))
         XCTAssertEqual(buffer.readableBytes, 20)
         XCTAssertEqual(buffer.readInteger(as: Int32.self), 16)
-        let data = PSQLData(bytes: buffer, dataType: .uuid)
+        let data = PSQLData(bytes: buffer, dataType: .uuid, format: .binary)
         
         var result: UUID?
         XCTAssertNoThrow(result = try data.decode(as: UUID?.self, context: .forTests()))
@@ -57,7 +57,7 @@ class Optional_PSQLCodableTests: XCTestCase {
         XCTAssertEqual(buffer.readableBytes, 4)
         XCTAssertEqual(buffer.readInteger(as: Int32.self), -1)
         
-        let data = PSQLData(bytes: nil, dataType: .uuid)
+        let data = PSQLData(bytes: nil, dataType: .uuid, format: .binary)
         
         var result: UUID?
         XCTAssertNoThrow(result = try data.decode(as: UUID?.self, context: .forTests()))

--- a/Tests/PostgresNIOTests/New/Data/RawRepresentable+PSQLCodableTests.swift
+++ b/Tests/PostgresNIOTests/New/Data/RawRepresentable+PSQLCodableTests.swift
@@ -17,7 +17,7 @@ class RawRepresentable_PSQLCodableTests: XCTestCase {
             XCTAssertNoThrow(try value.encode(into: &buffer, context: .forTests()))
             XCTAssertEqual(value.psqlType, Int16.psqlArrayElementType)
             XCTAssertEqual(buffer.readableBytes, 2)
-            let data = PSQLData(bytes: buffer, dataType: Int16.psqlArrayElementType)
+            let data = PSQLData(bytes: buffer, dataType: Int16.psqlArrayElementType, format: .binary)
             
             var result: MyRawRepresentable?
             XCTAssertNoThrow(result = try data.decode(as: MyRawRepresentable.self, context: .forTests()))
@@ -28,7 +28,7 @@ class RawRepresentable_PSQLCodableTests: XCTestCase {
     func testDecodeInvalidRawTypeValue() {
         var buffer = ByteBuffer()
         buffer.writeInteger(Int16(4)) // out of bounds
-        let data = PSQLData(bytes: buffer, dataType: Int16.psqlArrayElementType)
+        let data = PSQLData(bytes: buffer, dataType: Int16.psqlArrayElementType, format: .binary)
         
         XCTAssertThrowsError(try data.decode(as: MyRawRepresentable.self, context: .forTests())) { error in
             XCTAssertEqual((error as? PSQLCastingError)?.line, #line - 1)
@@ -40,7 +40,7 @@ class RawRepresentable_PSQLCodableTests: XCTestCase {
     func testDecodeInvalidUnderlyingTypeValue() {
         var buffer = ByteBuffer()
         buffer.writeInteger(Int32(1)) // out of bounds
-        let data = PSQLData(bytes: buffer, dataType: Int32.psqlArrayElementType)
+        let data = PSQLData(bytes: buffer, dataType: Int32.psqlArrayElementType, format: .binary)
         
         XCTAssertThrowsError(try data.decode(as: MyRawRepresentable.self, context: .forTests())) { error in
             XCTAssertEqual((error as? PSQLCastingError)?.line, #line - 1)

--- a/Tests/PostgresNIOTests/New/Data/String+PSQLCodableTests.swift
+++ b/Tests/PostgresNIOTests/New/Data/String+PSQLCodableTests.swift
@@ -25,7 +25,7 @@ class String_PSQLCodableTests: XCTestCase {
         for dataType in dataTypes {
             var loopBuffer = buffer
             var result: String?
-            XCTAssertNoThrow(result = try String.decode(from: &loopBuffer, type: dataType, context: .forTests()))
+            XCTAssertNoThrow(result = try String.decode(from: &loopBuffer, type: dataType, format: .binary, context: .forTests()))
             XCTAssertEqual(result, expected)
         }
     }
@@ -36,7 +36,7 @@ class String_PSQLCodableTests: XCTestCase {
         
         for dataType in dataTypes {
             var loopBuffer = buffer
-            XCTAssertThrowsError(try String.decode(from: &loopBuffer, type: dataType, context: .forTests())) { error in
+            XCTAssertThrowsError(try String.decode(from: &loopBuffer, type: dataType, format: .binary, context: .forTests())) { error in
                 XCTAssertEqual((error as? PSQLCastingError)?.line, #line - 1)
                 XCTAssertEqual((error as? PSQLCastingError)?.file, #file)
                 
@@ -50,7 +50,7 @@ class String_PSQLCodableTests: XCTestCase {
         let dataTypes: [PSQLDataType] = [.text, .varchar, .name]
         
         for dataType in dataTypes {
-            let data = PSQLData(bytes: nil, dataType: dataType)
+            let data = PSQLData(bytes: nil, dataType: dataType, format: .binary)
             XCTAssertThrowsError(try data.decode(as: String.self, context: .forTests())) { error in
                 XCTAssertEqual((error as? PSQLCastingError)?.line, #line - 1)
                 XCTAssertEqual((error as? PSQLCastingError)?.file, #file)
@@ -67,7 +67,7 @@ class String_PSQLCodableTests: XCTestCase {
         uuid.encode(into: &buffer, context: .forTests())
         
         var decoded: String?
-        XCTAssertNoThrow(decoded = try String.decode(from: &buffer, type: .uuid, context: .forTests()))
+        XCTAssertNoThrow(decoded = try String.decode(from: &buffer, type: .uuid, format: .binary, context: .forTests()))
         XCTAssertEqual(decoded, uuid.uuidString)
     }
     
@@ -78,7 +78,7 @@ class String_PSQLCodableTests: XCTestCase {
         // this makes only 15 bytes readable. this should lead to an error
         buffer.moveReaderIndex(forwardBy: 1)
         
-        XCTAssertThrowsError(try String.decode(from: &buffer, type: .uuid, context: .forTests())) { error in
+        XCTAssertThrowsError(try String.decode(from: &buffer, type: .uuid, format: .binary, context: .forTests())) { error in
             XCTAssertEqual((error as? PSQLCastingError)?.line, #line - 1)
             XCTAssertEqual((error as? PSQLCastingError)?.file, #file)
             

--- a/Tests/PostgresNIOTests/New/Messages/BindTests.swift
+++ b/Tests/PostgresNIOTests/New/Messages/BindTests.swift
@@ -10,14 +10,15 @@ class BindTests: XCTestCase {
         let message = PSQLFrontendMessage.bind(bind)
         XCTAssertNoThrow(try encoder.encode(data: message, out: &byteBuffer))
         
-        XCTAssertEqual(byteBuffer.readableBytes, 35)
+        XCTAssertEqual(byteBuffer.readableBytes, 37)
         XCTAssertEqual(PSQLFrontendMessage.ID.bind.byte, byteBuffer.readInteger(as: UInt8.self))
-        XCTAssertEqual(byteBuffer.readInteger(as: Int32.self), 34)
+        XCTAssertEqual(byteBuffer.readInteger(as: Int32.self), 36)
         XCTAssertEqual("", byteBuffer.readNullTerminatedString())
         XCTAssertEqual("", byteBuffer.readNullTerminatedString())
-        // all parameters have the same format: therefore one format byte is next
+        // the number of parameters
+        XCTAssertEqual(2, byteBuffer.readInteger(as: Int16.self))
+        // all (two) parameters have the same format (binary)
         XCTAssertEqual(1, byteBuffer.readInteger(as: Int16.self))
-        // all parameters have the same format (binary)
         XCTAssertEqual(1, byteBuffer.readInteger(as: Int16.self))
         
         // read number of parameters

--- a/Tests/PostgresNIOTests/New/Messages/RowDescriptionTests.swift
+++ b/Tests/PostgresNIOTests/New/Messages/RowDescriptionTests.swift
@@ -7,8 +7,8 @@ class RowDescriptionTests: XCTestCase {
     
     func testDecode() {
         let columns: [PSQLBackendMessage.RowDescription.Column] = [
-            .init(name: "First", tableOID: 123, columnAttributeNumber: 123, dataType: .bool, dataTypeSize: 2, dataTypeModifier: 8, formatCode: .binary),
-            .init(name: "Second", tableOID: 123, columnAttributeNumber: 456, dataType: .uuidArray, dataTypeSize: 567, dataTypeModifier: 123, formatCode: .text),
+            .init(name: "First", tableOID: 123, columnAttributeNumber: 123, dataType: .bool, dataTypeSize: 2, dataTypeModifier: 8, format: .binary),
+            .init(name: "Second", tableOID: 123, columnAttributeNumber: 456, dataType: .uuidArray, dataTypeSize: 567, dataTypeModifier: 123, format: .text),
         ]
         
         let expected: [PSQLBackendMessage] = [
@@ -31,7 +31,7 @@ class RowDescriptionTests: XCTestCase {
                     buffer.writeInteger(column.dataType.rawValue)
                     buffer.writeInteger(column.dataTypeSize)
                     buffer.writeInteger(column.dataTypeModifier)
-                    buffer.writeInteger(column.formatCode.rawValue)
+                    buffer.writeInteger(column.format.rawValue)
                 }
             }
         }
@@ -43,7 +43,7 @@ class RowDescriptionTests: XCTestCase {
     
     func testDecodeFailureBecauseOfMissingNullTerminationInColumnName() {
         let column = PSQLBackendMessage.RowDescription.Column(
-            name: "First", tableOID: 123, columnAttributeNumber: 123, dataType: .bool, dataTypeSize: 2, dataTypeModifier: 8, formatCode: .binary)
+            name: "First", tableOID: 123, columnAttributeNumber: 123, dataType: .bool, dataTypeSize: 2, dataTypeModifier: 8, format: .binary)
         
         var buffer = ByteBuffer()
         buffer.writeBackendMessage(id: .rowDescription) { buffer in
@@ -54,7 +54,7 @@ class RowDescriptionTests: XCTestCase {
             buffer.writeInteger(column.dataType.rawValue)
             buffer.writeInteger(column.dataTypeSize)
             buffer.writeInteger(column.dataTypeModifier)
-            buffer.writeInteger(column.formatCode.rawValue)
+            buffer.writeInteger(column.format.rawValue)
         }
         
         XCTAssertThrowsError(try ByteToMessageDecoderVerifier.verifyDecoder(
@@ -66,7 +66,7 @@ class RowDescriptionTests: XCTestCase {
     
     func testDecodeFailureBecauseOfMissingColumnCount() {
         let column = PSQLBackendMessage.RowDescription.Column(
-            name: "First", tableOID: 123, columnAttributeNumber: 123, dataType: .bool, dataTypeSize: 2, dataTypeModifier: 8, formatCode: .binary)
+            name: "First", tableOID: 123, columnAttributeNumber: 123, dataType: .bool, dataTypeSize: 2, dataTypeModifier: 8, format: .binary)
         
         var buffer = ByteBuffer()
         buffer.writeBackendMessage(id: .rowDescription) { buffer in
@@ -76,7 +76,7 @@ class RowDescriptionTests: XCTestCase {
             buffer.writeInteger(column.dataType.rawValue)
             buffer.writeInteger(column.dataTypeSize)
             buffer.writeInteger(column.dataTypeModifier)
-            buffer.writeInteger(column.formatCode.rawValue)
+            buffer.writeInteger(column.format.rawValue)
         }
         
         XCTAssertThrowsError(try ByteToMessageDecoderVerifier.verifyDecoder(
@@ -88,7 +88,7 @@ class RowDescriptionTests: XCTestCase {
     
     func testDecodeFailureBecauseInvalidFormatCode() {
         let column = PSQLBackendMessage.RowDescription.Column(
-            name: "First", tableOID: 123, columnAttributeNumber: 123, dataType: .bool, dataTypeSize: 2, dataTypeModifier: 8, formatCode: .binary)
+            name: "First", tableOID: 123, columnAttributeNumber: 123, dataType: .bool, dataTypeSize: 2, dataTypeModifier: 8, format: .binary)
         
         var buffer = ByteBuffer()
         buffer.writeBackendMessage(id: .rowDescription) { buffer in
@@ -111,7 +111,7 @@ class RowDescriptionTests: XCTestCase {
     
     func testDecodeFailureBecauseNegativeColumnCount() {
         let column = PSQLBackendMessage.RowDescription.Column(
-            name: "First", tableOID: 123, columnAttributeNumber: 123, dataType: .bool, dataTypeSize: 2, dataTypeModifier: 8, formatCode: .binary)
+            name: "First", tableOID: 123, columnAttributeNumber: 123, dataType: .bool, dataTypeSize: 2, dataTypeModifier: 8, format: .binary)
         
         var buffer = ByteBuffer()
         buffer.writeBackendMessage(id: .rowDescription) { buffer in
@@ -122,7 +122,7 @@ class RowDescriptionTests: XCTestCase {
             buffer.writeInteger(column.dataType.rawValue)
             buffer.writeInteger(column.dataTypeSize)
             buffer.writeInteger(column.dataTypeModifier)
-            buffer.writeInteger(column.formatCode.rawValue)
+            buffer.writeInteger(column.format.rawValue)
         }
         
         XCTAssertThrowsError(try ByteToMessageDecoderVerifier.verifyDecoder(

--- a/Tests/PostgresNIOTests/New/PSQLDataTests.swift
+++ b/Tests/PostgresNIOTests/New/PSQLDataTests.swift
@@ -6,7 +6,7 @@ class PSQLDataTests: XCTestCase {
     func testStringDecoding() {
         let emptyBuffer: ByteBuffer? = nil
         
-        let data = PSQLData(bytes: emptyBuffer, dataType: .text)
+        let data = PSQLData(bytes: emptyBuffer, dataType: .text, format: .binary)
         
         var emptyResult: String?
         XCTAssertNoThrow(emptyResult = try data.decodeIfPresent(as: String.self, context: .forTests()))


### PR DESCRIPTION
Postgres supports two encodings on the wire text (0) and binary (1). Up until now the new `PSQLDecodable` only supported binary encoding. 

- This PR does not change any public API
- Rename `PSQLFormatCode` to `PSQLFormat`
- Add `PSQLFormat` as parameter to the decode function.
- Add `psqlFormat: PSQLFormat` as protocol requirement for `PSQLEncodable`
- All existing types encode into and decode from `.binary` format only (we can change this with follow up PRs)
