### PR TITLE
Add one Auth and one SSL test case

### DIFF
--- a/Tests/PostgresNIOTests/New/Connection State Machine/AuthenticationStateMachineTests.swift
+++ b/Tests/PostgresNIOTests/New/Connection State Machine/AuthenticationStateMachineTests.swift
@@ -22,6 +22,16 @@ class AuthenticationStateMachineTests: XCTestCase {
         XCTAssertEqual(state.authenticationMessageReceived(.ok), .wait)
     }
     
+    func testAuthenticateMD5WithoutPassword() {
+        let authContext = AuthContext(username: "test", password: nil, database: "test")
+        var state = ConnectionStateMachine(.waitingToStartAuthentication)
+        let salt: (UInt8, UInt8, UInt8, UInt8) = (0, 1, 2, 3)
+        
+        XCTAssertEqual(state.provideAuthenticationContext(authContext), .sendStartupMessage(authContext))
+        XCTAssertEqual(state.authenticationMessageReceived(.md5(salt: salt)),
+                       .closeConnectionAndCleanup(.init(action: .close, tasks: [], error: .authMechanismRequiresPassword, closePromise: nil)))
+    }
+    
     func testAuthenticateOkAfterStartUpWithoutAuthChallenge() {
         let authContext = AuthContext(username: "test", password: "abc123", database: "test")
         var state = ConnectionStateMachine(.waitingToStartAuthentication)

--- a/Tests/PostgresNIOTests/New/PSQLBackendMessageTests.swift
+++ b/Tests/PostgresNIOTests/New/PSQLBackendMessageTests.swift
@@ -269,6 +269,8 @@ class PSQLBackendMessageTests: XCTestCase {
         XCTAssertEqual("\(PSQLBackendMessage.authentication(.sspi))",
                        ".authentication(.sspi)")
         
+        XCTAssertEqual("\(PSQLBackendMessage.parameterStatus(.init(parameter: "foo", value: "bar")))",
+                       #".parameterStatus(parameter: "foo", value: "bar")"#)
         XCTAssertEqual("\(PSQLBackendMessage.backendKeyData(.init(processID: 1234, secretKey: 4567)))",
                        ".backendKeyData(processID: 1234, secretKey: 4567)")
         


### PR DESCRIPTION
Adding two test cases as a by product of some other work...

- Add a test case for instances in which adding a `SSLHandler` fails
- Add a test case for instances in which a md5 password requested but none is provided.