### PR TITLE
Support AWS redshift queries

### DIFF
--- a/Sources/PostgresNIO/PostgresDatabase+Query.swift
+++ b/Sources/PostgresNIO/PostgresDatabase+Query.swift
@@ -74,7 +74,7 @@ public struct PostgresQueryMetadata {
             self.command = .init(parts[0])
             self.oid = Int(parts[1])
             self.rows = Int(parts[2])
-        case "DELETE", "UPDATE", "SELECT", "MOVE", "FETCH", "COPY":
+        case "SELECT":
             // <cmd> rows
             // Note, Redshift does not return the actual count as per the spec
             guard parts.count == 1 || parts.count == 2 else {
@@ -83,6 +83,14 @@ public struct PostgresQueryMetadata {
             self.command = .init(parts[0])
             self.oid = nil
             self.rows = parts.count == 2 ? Int(parts[1]) : 0
+        case "DELETE", "UPDATE", "MOVE", "FETCH", "COPY":
+            // <cmd> rows
+            guard parts.count == 2 else {
+                return nil
+            }
+            self.command = .init(parts[0])
+            self.oid = nil
+            self.rows = Int(parts[1])
         default:
             // <cmd>
             self.command = string

--- a/Sources/PostgresNIO/PostgresDatabase+Query.swift
+++ b/Sources/PostgresNIO/PostgresDatabase+Query.swift
@@ -76,12 +76,13 @@ public struct PostgresQueryMetadata {
             self.rows = Int(parts[2])
         case "DELETE", "UPDATE", "SELECT", "MOVE", "FETCH", "COPY":
             // <cmd> rows
-            guard parts.count == 2 else {
+            // Note, Redshift does not return the actual count as per the spec
+            guard parts.count == 1 || parts.count == 2 else {
                 return nil
             }
             self.command = .init(parts[0])
             self.oid = nil
-            self.rows = Int(parts[1])
+            self.rows = parts.count == 2 ? Int(parts[1]) : 0
         default:
             // <cmd>
             self.command = string

--- a/Sources/PostgresNIO/PostgresDatabase+Query.swift
+++ b/Sources/PostgresNIO/PostgresDatabase+Query.swift
@@ -75,8 +75,8 @@ public struct PostgresQueryMetadata {
             self.oid = Int(parts[1])
             self.rows = Int(parts[2])
         case "SELECT":
-            // <cmd> rows
-            // Note, Redshift does not return the actual count as per the spec
+            // AWS Redshift does not return the actual row count as defined in the postgres wire spec:
+            // https://www.postgresql.org/docs/13/protocol-message-formats.html in section `CommandComplete`
             guard parts.count == 1 || parts.count == 2 else {
                 return nil
             }

--- a/Sources/PostgresNIO/PostgresDatabase+Query.swift
+++ b/Sources/PostgresNIO/PostgresDatabase+Query.swift
@@ -74,16 +74,13 @@ public struct PostgresQueryMetadata {
             self.command = .init(parts[0])
             self.oid = Int(parts[1])
             self.rows = Int(parts[2])
-        case "SELECT":
-            // AWS Redshift does not return the actual row count as defined in the postgres wire spec:
+        case "SELECT" where parts.count == 1:
+            // AWS Redshift does not return the actual row count as defined in the postgres wire spec for SELECT:
             // https://www.postgresql.org/docs/13/protocol-message-formats.html in section `CommandComplete`
-            guard parts.count == 1 || parts.count == 2 else {
-                return nil
-            }
-            self.command = .init(parts[0])
+            self.command = "SELECT"
             self.oid = nil
-            self.rows = parts.count == 2 ? Int(parts[1]) : 0
-        case "DELETE", "UPDATE", "MOVE", "FETCH", "COPY":
+            self.rows = nil
+        case "SELECT", "DELETE", "UPDATE", "MOVE", "FETCH", "COPY":
             // <cmd> rows
             guard parts.count == 2 else {
                 return nil

--- a/Tests/PostgresNIOTests/New/PSQLDataTests.swift
+++ b/Tests/PostgresNIOTests/New/PSQLDataTests.swift
@@ -15,10 +15,4 @@ class PSQLDataTests: XCTestCase {
         XCTAssertNoThrow(emptyResult = try data.decode(as: String?.self, context: .forTests()))
         XCTAssertNil(emptyResult)
     }
-    
-    func testMetadataParsing() {
-        XCTAssertEqual(100, PostgresQueryMetadata(string: "SELECT 100")?.rows)
-        XCTAssertEqual(0, PostgresQueryMetadata(string: "SELECT")?.rows)
-        XCTAssertNil(PostgresQueryMetadata(string: "SELECT 100 100"))
-    }
 }

--- a/Tests/PostgresNIOTests/New/PSQLDataTests.swift
+++ b/Tests/PostgresNIOTests/New/PSQLDataTests.swift
@@ -15,4 +15,10 @@ class PSQLDataTests: XCTestCase {
         XCTAssertNoThrow(emptyResult = try data.decode(as: String?.self, context: .forTests()))
         XCTAssertNil(emptyResult)
     }
+    
+    func testMetadataParsing() {
+        XCTAssertEqual(100, PostgresQueryMetadata(string: "SELECT 100")?.rows)
+        XCTAssertEqual(0, PostgresQueryMetadata(string: "SELECT")?.rows)
+        XCTAssertNil(PostgresQueryMetadata(string: "SELECT 100 100"))
+    }
 }

--- a/Tests/PostgresNIOTests/New/PSQLMetadataTests.swift
+++ b/Tests/PostgresNIOTests/New/PSQLMetadataTests.swift
@@ -5,7 +5,8 @@ import XCTest
 class PSQLMetadataTests: XCTestCase {
     func testSelect() {
         XCTAssertEqual(100, PostgresQueryMetadata(string: "SELECT 100")?.rows)
-        XCTAssertEqual(0, PostgresQueryMetadata(string: "SELECT")?.rows)
+        XCTAssertNotNil(PostgresQueryMetadata(string: "SELECT"))
+        XCTAssertNil(PostgresQueryMetadata(string: "SELECT")?.rows)
         XCTAssertNil(PostgresQueryMetadata(string: "SELECT 100 100"))
     }
 

--- a/Tests/PostgresNIOTests/New/PSQLMetadataTests.swift
+++ b/Tests/PostgresNIOTests/New/PSQLMetadataTests.swift
@@ -1,0 +1,17 @@
+import NIO
+import XCTest
+@testable import PostgresNIO
+
+class PSQLMetadataTests: XCTestCase {
+    func testSelect() {
+        XCTAssertEqual(100, PostgresQueryMetadata(string: "SELECT 100")?.rows)
+        XCTAssertEqual(0, PostgresQueryMetadata(string: "SELECT")?.rows)
+        XCTAssertNil(PostgresQueryMetadata(string: "SELECT 100 100"))
+    }
+
+    func testUpdate() {
+        XCTAssertEqual(100, PostgresQueryMetadata(string: "UPDATE 100")?.rows)
+        XCTAssertNil(PostgresQueryMetadata(string: "UPDATE"))
+        XCTAssertNil(PostgresQueryMetadata(string: "UPDATE 100 100"))
+    }
+}


### PR DESCRIPTION
This changes the metadata parser to accept a response that is missing the rowcount, event though this does not follow the spec. In my testing this allows my to now successfully query Redshift databases.

Fixes #166 
