### PR TITLE
Splits CI Jobs Into Unit And Integration Tests On Linux

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,5 @@
 name: test
-on: [ 'push' ]
+on: [ 'pull_request' ]
 env:
   LOG_LEVEL: notice
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,5 @@
 name: test
-on: [ 'pull_request' ]
+on: [ 'push' ]
 env:
   LOG_LEVEL: notice
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,8 +66,8 @@ jobs:
           - swift:5.2
           - swift:5.3
           - swift:5.4
-          - swiftlang:swift/5.5-nightly
-          - swiftlang:swift/main-nightly
+          - swiftlang:swift/nightly-5.5
+          - swiftlang:swift/nightly-main
         swiftos:
           #- xenial
           #- bionic

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,7 @@ jobs:
         swiftver:
           - 5.2
           - 5.3
+          - 5.4
         dbimage:
           - postgres:13
           - postgres:12
@@ -55,9 +56,35 @@ jobs:
           POSTGRES_HOSTNAME: psql-a
           POSTGRES_HOSTNAME_A: psql-a
           POSTGRES_HOSTNAME_B: psql-b
+          
+  # Run unit tests on Linux Swift runners on 
+  linux-unit-tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        swiftver:
+          - swift:5.2
+          - swift:5.3
+          - swift:5.4
+          - swiftlang:swift/5.5-nightly
+          - swiftlang:swift/main-nightly
+        swiftos:
+          #- xenial
+          #- bionic
+          - focal
+          #- centos7
+          #- centos8
+          - amazonlinux2
+    container: ${{ format('{0}-{1}', matrix.swiftver, matrix.swiftos) }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Run tests with Thread Sanitizer
+        run: swift test --enable-test-discovery --sanitize=thread --filter=^PostgresNIOTests
 
-  # Run package tests on Linux Swift runners against supported PSQL versions
-  linux:
+  # Run integration tests on Linux Swift runners against supported PSQL versions
+  linux-integration-tests:
     strategy:
       fail-fast: false
       matrix:
@@ -70,10 +97,7 @@ jobs:
           - md5
           - scram-sha-256
         swiftver:
-          - swift:5.2
-          - swift:5.3
-          #- swiftlang/swift:nightly-5.3
-          #- swiftlang/swift:nightly-master
+          - swift:5.4
         swiftos:
           #- xenial
           #- bionic
@@ -96,7 +120,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
       - name: Run tests with Thread Sanitizer
-        run: swift test --enable-test-discovery --sanitize=thread
+        run: swift test --enable-test-discovery --sanitize=thread --filter=^IntegrationTests
         env:
           POSTGRES_HOSTNAME: psql
           POSTGRES_USER: vapor_username

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,8 +66,8 @@ jobs:
           - swift:5.2
           - swift:5.3
           - swift:5.4
-          - swiftlang:swift/nightly-5.5
-          - swiftlang:swift/nightly-main
+          - swiftlang/swift:nightly-5.5
+          - swiftlang/swift:nightly-main
         swiftos:
           #- xenial
           #- bionic

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,7 +74,7 @@ jobs:
           - focal
           #- centos7
           #- centos8
-          - amazonlinux2
+          #- amazonlinux2
     container: ${{ format('{0}-{1}', matrix.swiftver, matrix.swiftos) }}
     runs-on: ubuntu-latest
     steps:
@@ -104,7 +104,7 @@ jobs:
           - focal
           #- centos7
           #- centos8
-          - amazonlinux2
+          #- amazonlinux2
     container: ${{ format('{0}-{1}', matrix.swiftver, matrix.swiftos) }}
     runs-on: ubuntu-latest
     services:


### PR DESCRIPTION
This was prepared by #157.  
CI now also uses more swift compiler versions, namely `5.4`, `nightly-5.5` and `nightly-main`.
It also removes `amazonlinux2` and now only tests on `focal`.

fixes #165
