### PR TITLE
Fix NIOSSL deprecations

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.28.0"),
-        .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.12.0"),
+        .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.14.0"),
         .package(url: "https://github.com/apple/swift-crypto.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-metrics.git", from: "2.0.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.4.0"),

--- a/Tests/IntegrationTests/PostgresNIOTests.swift
+++ b/Tests/IntegrationTests/PostgresNIOTests.swift
@@ -678,7 +678,7 @@ final class PostgresNIOTests: XCTestCase {
         var conn: PostgresConnection?
         XCTAssertNoThrow(conn = try PostgresConnection.connect(
             to: SocketAddress.makeAddressResolvingHost("elmer.db.elephantsql.com", port: 5432),
-            tlsConfiguration: .forClient(certificateVerification: .none),
+            tlsConfiguration: .makeClientConfiguration(),
             serverHostname: "elmer.db.elephantsql.com",
             on: eventLoop
         ).wait())
@@ -707,7 +707,7 @@ final class PostgresNIOTests: XCTestCase {
         XCTAssertThrowsError(
             try PostgresConnection.connect(
                 to: SocketAddress.makeAddressResolvingHost("elmer.db.elephantsql.com", port: 5432),
-                tlsConfiguration: .forClient(certificateVerification: .fullVerification),
+                tlsConfiguration: .makeClientConfiguration(),
                 serverHostname: "34.228.73.168",
                 on: eventLoop
             ).wait()

--- a/Tests/PostgresNIOTests/New/PSQLChannelHandlerTests.swift
+++ b/Tests/PostgresNIOTests/New/PSQLChannelHandlerTests.swift
@@ -32,7 +32,7 @@ class PSQLChannelHandlerTests: XCTestCase {
     
     func testEstablishSSLCallbackIsCalledIfSSLIsSupported() {
         var config = self.testConnectionConfiguration()
-        config.tlsConfiguration = .forClient(certificateVerification: .none)
+        config.tlsConfiguration = .makeClientConfiguration()
         var addSSLCallbackIsHit = false
         let handler = PSQLChannelHandler(authentification: config.authentication) { channel in
             addSSLCallbackIsHit = true
@@ -70,7 +70,7 @@ class PSQLChannelHandlerTests: XCTestCase {
     
     func testSSLUnsupportedClosesConnection() {
         var config = self.testConnectionConfiguration()
-        config.tlsConfiguration = .forClient()
+        config.tlsConfiguration = .makeClientConfiguration()
         
         let handler = PSQLChannelHandler(authentification: config.authentication) { channel in
             XCTFail("This callback should never be exectuded")


### PR DESCRIPTION
### Update required NIOSSL version to 2.14.0. Replace all usages of TLSConfiguration.forClient with TLSConfiguration.makeClientConfiguration

## Motivation
As described in issue #168, the NIOSSL 2.14.0 patch deprecated the `.forClient` way to create `TLSConfigurations`. Therefore, all instances of `TLSConfiguration.forClient` had to be replaced and the required NIOSSL version had to be increased to 2.14.0

## Changes
- `Package.swift` had the NIOSSL package raised to 2.14.0 from the previous 2.12.0. 
- All instances of `TLSConfiguration.forClient` have been replaced with `TLSConfiguration.makeClientConfiguration` 

<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->

<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
