### PR TITLE
Fix NIO imports

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         .library(name: "PostgresNIO", targets: ["PostgresNIO"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.28.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.32.0"),
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.12.0"),
         .package(url: "https://github.com/apple/swift-crypto.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-metrics.git", from: "2.0.0"),
@@ -25,12 +25,15 @@ let package = Package(
             .product(name: "Logging", package: "swift-log"),
             .product(name: "Metrics", package: "swift-metrics"),
             .product(name: "NIO", package: "swift-nio"),
+            .product(name: "NIOCore", package: "swift-nio"),
+            .product(name: "NIOPosix", package: "swift-nio"),
             .product(name: "NIOTLS", package: "swift-nio"),
-            .product(name: "NIOFoundationCompat", package: "swift-nio"),
             .product(name: "NIOSSL", package: "swift-nio-ssl"),
+            .product(name: "NIOFoundationCompat", package: "swift-nio"),
         ]),
         .testTarget(name: "PostgresNIOTests", dependencies: [
             .target(name: "PostgresNIO"),
+            .product(name: "NIOEmbedded", package: "swift-nio"),
             .product(name: "NIOTestUtils", package: "swift-nio"),
         ]),
         .testTarget(name: "IntegrationTests", dependencies: [

--- a/Sources/PostgresNIO/Connection/PostgresConnection+Authenticate.swift
+++ b/Sources/PostgresNIO/Connection/PostgresConnection+Authenticate.swift
@@ -1,4 +1,5 @@
-import NIO
+import NIOCore
+import Logging
 
 extension PostgresConnection {
     public func authenticate(

--- a/Sources/PostgresNIO/Connection/PostgresConnection+Connect.swift
+++ b/Sources/PostgresNIO/Connection/PostgresConnection+Connect.swift
@@ -1,4 +1,6 @@
-import NIO
+import NIOCore
+import NIOSSL
+import Logging
 
 extension PostgresConnection {
     public static func connect(

--- a/Sources/PostgresNIO/Connection/PostgresConnection+Database.swift
+++ b/Sources/PostgresNIO/Connection/PostgresConnection+Database.swift
@@ -1,3 +1,4 @@
+import NIOCore
 import Logging
 import struct Foundation.Data
 

--- a/Sources/PostgresNIO/Connection/PostgresConnection+Notifications.swift
+++ b/Sources/PostgresNIO/Connection/PostgresConnection+Notifications.swift
@@ -1,4 +1,4 @@
-import NIO
+import NIOCore
 import Logging
 
 /// Context for receiving NotificationResponse messages on a connection, used for PostgreSQL's `LISTEN`/`NOTIFY` support.

--- a/Sources/PostgresNIO/Connection/PostgresConnection.swift
+++ b/Sources/PostgresNIO/Connection/PostgresConnection.swift
@@ -1,4 +1,4 @@
-import NIO
+import NIOCore
 import Logging
 import struct Foundation.UUID
 

--- a/Sources/PostgresNIO/Connection/PostgresDatabase+PreparedQuery.swift
+++ b/Sources/PostgresNIO/Connection/PostgresDatabase+PreparedQuery.swift
@@ -1,4 +1,5 @@
-import Foundation
+import NIOCore
+import struct Foundation.UUID
 
 extension PostgresDatabase {
     public func prepare(query: String) -> EventLoopFuture<PreparedQuery> {

--- a/Sources/PostgresNIO/Data/PostgresData+Array.swift
+++ b/Sources/PostgresNIO/Data/PostgresData+Array.swift
@@ -1,3 +1,5 @@
+import NIOCore
+
 extension PostgresData {
     public init<T>(array: [T])
         where T: PostgresDataConvertible

--- a/Sources/PostgresNIO/Data/PostgresData+Bool.swift
+++ b/Sources/PostgresNIO/Data/PostgresData+Bool.swift
@@ -1,3 +1,5 @@
+import NIOCore
+
 extension PostgresData {
     public init(bool: Bool) {
         var buffer = ByteBufferAllocator().buffer(capacity: 1)

--- a/Sources/PostgresNIO/Data/PostgresData+Bytes.swift
+++ b/Sources/PostgresNIO/Data/PostgresData+Bytes.swift
@@ -1,4 +1,5 @@
 import struct Foundation.Data
+import NIOCore
 
 extension PostgresData {
     public init<Bytes>(bytes: Bytes)

--- a/Sources/PostgresNIO/Data/PostgresData+Date.swift
+++ b/Sources/PostgresNIO/Data/PostgresData+Date.swift
@@ -1,4 +1,5 @@
-import Foundation
+import struct Foundation.Date
+import NIOCore
 
 extension PostgresData {
     public init(date: Date) {

--- a/Sources/PostgresNIO/Data/PostgresData+Double.swift
+++ b/Sources/PostgresNIO/Data/PostgresData+Double.swift
@@ -1,3 +1,5 @@
+import NIOCore
+
 extension PostgresData {
     public init(double: Double) {
         var buffer = ByteBufferAllocator().buffer(capacity: 0)

--- a/Sources/PostgresNIO/Data/PostgresData+JSON.swift
+++ b/Sources/PostgresNIO/Data/PostgresData+JSON.swift
@@ -1,4 +1,5 @@
-import Foundation
+import struct Foundation.Data
+import NIOCore
 
 extension PostgresData {
     public init(json jsonData: Data) {

--- a/Sources/PostgresNIO/Data/PostgresData+JSONB.swift
+++ b/Sources/PostgresNIO/Data/PostgresData+JSONB.swift
@@ -1,4 +1,5 @@
-import Foundation
+import NIOCore
+import struct Foundation.Data
 
 fileprivate let jsonBVersionBytes: [UInt8] = [0x01]
 

--- a/Sources/PostgresNIO/Data/PostgresData+Numeric.swift
+++ b/Sources/PostgresNIO/Data/PostgresData+Numeric.swift
@@ -1,3 +1,4 @@
+import NIOCore
 import struct Foundation.Decimal
 
 public struct PostgresNumeric: CustomStringConvertible, CustomDebugStringConvertible, ExpressibleByStringLiteral {

--- a/Sources/PostgresNIO/Data/PostgresData+String.swift
+++ b/Sources/PostgresNIO/Data/PostgresData+String.swift
@@ -1,3 +1,5 @@
+import NIOCore
+
 extension PostgresData {
     public init(string: String) {
         var buffer = ByteBufferAllocator().buffer(capacity: string.utf8.count)

--- a/Sources/PostgresNIO/Data/PostgresData+UUID.swift
+++ b/Sources/PostgresNIO/Data/PostgresData+UUID.swift
@@ -1,4 +1,5 @@
 import Foundation
+import NIOCore
 
 extension PostgresData {
     public init(uuid: UUID) {

--- a/Sources/PostgresNIO/Data/PostgresData.swift
+++ b/Sources/PostgresNIO/Data/PostgresData.swift
@@ -1,4 +1,4 @@
-import NIO
+import NIOCore
 import Foundation
 
 public struct PostgresData: CustomStringConvertible, CustomDebugStringConvertible {

--- a/Sources/PostgresNIO/Message/PostgresMessage+0.swift
+++ b/Sources/PostgresNIO/Message/PostgresMessage+0.swift
@@ -1,3 +1,5 @@
+import NIOCore
+
 /// A frontend or backend Postgres message.
 public struct PostgresMessage: Equatable {
     public var identifier: Identifier

--- a/Sources/PostgresNIO/Message/PostgresMessage+Authentication.swift
+++ b/Sources/PostgresNIO/Message/PostgresMessage+Authentication.swift
@@ -1,4 +1,4 @@
-import NIO
+import NIOCore
 
 extension PostgresMessage {
     /// Authentication request returned by the server.

--- a/Sources/PostgresNIO/Message/PostgresMessage+BackendKeyData.swift
+++ b/Sources/PostgresNIO/Message/PostgresMessage+BackendKeyData.swift
@@ -1,4 +1,4 @@
-import NIO
+import NIOCore
 
 extension PostgresMessage {
     /// Identifies the message as cancellation key data.

--- a/Sources/PostgresNIO/Message/PostgresMessage+Bind.swift
+++ b/Sources/PostgresNIO/Message/PostgresMessage+Bind.swift
@@ -1,4 +1,4 @@
-import NIO
+import NIOCore
 
 extension PostgresMessage {
     /// Identifies the message as a Bind command.

--- a/Sources/PostgresNIO/Message/PostgresMessage+Close.swift
+++ b/Sources/PostgresNIO/Message/PostgresMessage+Close.swift
@@ -1,4 +1,4 @@
-import NIO
+import NIOCore
 
 extension PostgresMessage {
     /// Identifies the message as a Close Command

--- a/Sources/PostgresNIO/Message/PostgresMessage+CommandComplete.swift
+++ b/Sources/PostgresNIO/Message/PostgresMessage+CommandComplete.swift
@@ -1,4 +1,4 @@
-import NIO
+import NIOCore
 
 extension PostgresMessage {
     /// Identifies the message as a Close command.

--- a/Sources/PostgresNIO/Message/PostgresMessage+DataRow.swift
+++ b/Sources/PostgresNIO/Message/PostgresMessage+DataRow.swift
@@ -1,4 +1,4 @@
-import NIO
+import NIOCore
 
 extension PostgresMessage {
     /// Identifies the message as a data row.

--- a/Sources/PostgresNIO/Message/PostgresMessage+Describe.swift
+++ b/Sources/PostgresNIO/Message/PostgresMessage+Describe.swift
@@ -1,4 +1,4 @@
-import NIO
+import NIOCore
 
 extension PostgresMessage {
     /// Identifies the message as a Describe command.

--- a/Sources/PostgresNIO/Message/PostgresMessage+Error.swift
+++ b/Sources/PostgresNIO/Message/PostgresMessage+Error.swift
@@ -1,4 +1,4 @@
-import NIO
+import NIOCore
 
 extension PostgresMessage {
     /// First message sent from the frontend during startup.

--- a/Sources/PostgresNIO/Message/PostgresMessage+Execute.swift
+++ b/Sources/PostgresNIO/Message/PostgresMessage+Execute.swift
@@ -1,4 +1,4 @@
-import NIO
+import NIOCore
 
 extension PostgresMessage {
     /// Identifies the message as an Execute command.

--- a/Sources/PostgresNIO/Message/PostgresMessage+Identifier.swift
+++ b/Sources/PostgresNIO/Message/PostgresMessage+Identifier.swift
@@ -1,4 +1,4 @@
-import NIO
+import NIOCore
 
 extension PostgresMessage {
     /// Identifies an incoming or outgoing postgres message. Sent as the first byte, before the message size.

--- a/Sources/PostgresNIO/Message/PostgresMessage+NotificationResponse.swift
+++ b/Sources/PostgresNIO/Message/PostgresMessage+NotificationResponse.swift
@@ -1,4 +1,4 @@
-import NIO
+import NIOCore
 
 extension PostgresMessage {
     /// Identifies the message as a notification response.

--- a/Sources/PostgresNIO/Message/PostgresMessage+ParameterDescription.swift
+++ b/Sources/PostgresNIO/Message/PostgresMessage+ParameterDescription.swift
@@ -1,4 +1,4 @@
-import NIO
+import NIOCore
 
 extension PostgresMessage {
     /// Identifies the message as a parameter description.

--- a/Sources/PostgresNIO/Message/PostgresMessage+ParameterStatus.swift
+++ b/Sources/PostgresNIO/Message/PostgresMessage+ParameterStatus.swift
@@ -1,4 +1,4 @@
-import NIO
+import NIOCore
 
 extension PostgresMessage {
     public struct ParameterStatus: PostgresMessageType, CustomStringConvertible {

--- a/Sources/PostgresNIO/Message/PostgresMessage+Parse.swift
+++ b/Sources/PostgresNIO/Message/PostgresMessage+Parse.swift
@@ -1,4 +1,4 @@
-import NIO
+import NIOCore
 
 extension PostgresMessage {
     /// Identifies the message as a Parse command.

--- a/Sources/PostgresNIO/Message/PostgresMessage+Password.swift
+++ b/Sources/PostgresNIO/Message/PostgresMessage+Password.swift
@@ -1,4 +1,4 @@
-import NIO
+import NIOCore
 
 extension PostgresMessage {
     /// Identifies the message as a password response. Note that this is also used for

--- a/Sources/PostgresNIO/Message/PostgresMessage+ReadyForQuery.swift
+++ b/Sources/PostgresNIO/Message/PostgresMessage+ReadyForQuery.swift
@@ -1,4 +1,4 @@
-import NIO
+import NIOCore
 
 extension PostgresMessage {
     /// Identifies the message type. ReadyForQuery is sent whenever the backend is ready for a new query cycle.

--- a/Sources/PostgresNIO/Message/PostgresMessage+RowDescription.swift
+++ b/Sources/PostgresNIO/Message/PostgresMessage+RowDescription.swift
@@ -1,4 +1,4 @@
-import NIO
+import NIOCore
 
 extension PostgresMessage {
     /// Identifies the message as a row description.

--- a/Sources/PostgresNIO/Message/PostgresMessage+SASLResponse.swift
+++ b/Sources/PostgresNIO/Message/PostgresMessage+SASLResponse.swift
@@ -1,4 +1,4 @@
-import NIO
+import NIOCore
 
 extension PostgresMessage {
     /// SASL ongoing challenge response message sent by the client.

--- a/Sources/PostgresNIO/Message/PostgresMessage+SSLRequest.swift
+++ b/Sources/PostgresNIO/Message/PostgresMessage+SSLRequest.swift
@@ -1,4 +1,4 @@
-import NIO
+import NIOCore
 
 extension PostgresMessage {
     /// A message asking the PostgreSQL server if SSL is supported

--- a/Sources/PostgresNIO/Message/PostgresMessage+SimpleQuery.swift
+++ b/Sources/PostgresNIO/Message/PostgresMessage+SimpleQuery.swift
@@ -1,4 +1,4 @@
-import NIO
+import NIOCore
 
 extension PostgresMessage {
     /// Identifies the message as a simple query.

--- a/Sources/PostgresNIO/Message/PostgresMessage+Startup.swift
+++ b/Sources/PostgresNIO/Message/PostgresMessage+Startup.swift
@@ -1,4 +1,4 @@
-import NIO
+import NIOCore
 
 extension PostgresMessage {
     /// First message sent from the frontend during startup.

--- a/Sources/PostgresNIO/Message/PostgresMessage+Sync.swift
+++ b/Sources/PostgresNIO/Message/PostgresMessage+Sync.swift
@@ -1,4 +1,4 @@
-import NIO
+import NIOCore
 
 extension PostgresMessage {
     /// Identifies the message as a Bind command.

--- a/Sources/PostgresNIO/Message/PostgresMessage+Terminate.swift
+++ b/Sources/PostgresNIO/Message/PostgresMessage+Terminate.swift
@@ -1,3 +1,5 @@
+import NIOCore
+
 extension PostgresMessage {
     public struct Terminate: PostgresMessageType {
         public static var identifier: PostgresMessage.Identifier {

--- a/Sources/PostgresNIO/Message/PostgresMessageDecoder.swift
+++ b/Sources/PostgresNIO/Message/PostgresMessageDecoder.swift
@@ -1,4 +1,5 @@
-import NIO
+import NIOCore
+import Logging
 
 public final class PostgresMessageDecoder: ByteToMessageDecoder {
     /// See `ByteToMessageDecoder`.

--- a/Sources/PostgresNIO/Message/PostgresMessageEncoder.swift
+++ b/Sources/PostgresNIO/Message/PostgresMessageEncoder.swift
@@ -1,4 +1,5 @@
-import NIO
+import NIOCore
+import Logging
 
 public final class PostgresMessageEncoder: MessageToByteEncoder {
     /// See `MessageToByteEncoder`.

--- a/Sources/PostgresNIO/Message/PostgresMessageType.swift
+++ b/Sources/PostgresNIO/Message/PostgresMessageType.swift
@@ -1,3 +1,5 @@
+import NIOCore
+
 public protocol PostgresMessageType {
     static var identifier: PostgresMessage.Identifier { get }
     static func parse(from buffer: inout ByteBuffer) throws -> Self

--- a/Sources/PostgresNIO/New/Connection State Machine/AuthenticationStateMachine.swift
+++ b/Sources/PostgresNIO/New/Connection State Machine/AuthenticationStateMachine.swift
@@ -1,4 +1,4 @@
-import NIO
+import NIOCore
 
 struct AuthenticationStateMachine {
     

--- a/Sources/PostgresNIO/New/Connection State Machine/ConnectionStateMachine.swift
+++ b/Sources/PostgresNIO/New/Connection State Machine/ConnectionStateMachine.swift
@@ -1,3 +1,4 @@
+import NIOCore
 
 struct ConnectionStateMachine {
     

--- a/Sources/PostgresNIO/New/Connection State Machine/ExtendedQueryStateMachine.swift
+++ b/Sources/PostgresNIO/New/Connection State Machine/ExtendedQueryStateMachine.swift
@@ -1,3 +1,4 @@
+import NIOCore
 
 struct ExtendedQueryStateMachine {
     

--- a/Sources/PostgresNIO/New/Data/Array+PSQLCodable.swift
+++ b/Sources/PostgresNIO/New/Data/Array+PSQLCodable.swift
@@ -1,4 +1,4 @@
-import NIO
+import NIOCore
 import struct Foundation.UUID
 
 /// A type, of which arrays can be encoded into and decoded from a postgres binary format

--- a/Sources/PostgresNIO/New/Data/Bool+PSQLCodable.swift
+++ b/Sources/PostgresNIO/New/Data/Bool+PSQLCodable.swift
@@ -1,3 +1,5 @@
+import NIOCore
+
 extension Bool: PSQLCodable {
     var psqlType: PSQLDataType {
         .bool

--- a/Sources/PostgresNIO/New/Data/Bytes+PSQLCodable.swift
+++ b/Sources/PostgresNIO/New/Data/Bytes+PSQLCodable.swift
@@ -1,4 +1,5 @@
 import struct Foundation.Data
+import NIOCore
 import NIOFoundationCompat
 
 extension PSQLEncodable where Self: Sequence, Self.Element == UInt8 {

--- a/Sources/PostgresNIO/New/Data/Date+PSQLCodable.swift
+++ b/Sources/PostgresNIO/New/Data/Date+PSQLCodable.swift
@@ -1,3 +1,4 @@
+import NIOCore
 import struct Foundation.Date
 
 extension Date: PSQLCodable {

--- a/Sources/PostgresNIO/New/Data/Float+PSQLCodable.swift
+++ b/Sources/PostgresNIO/New/Data/Float+PSQLCodable.swift
@@ -1,3 +1,5 @@
+import NIOCore
+
 extension Float: PSQLCodable {
     var psqlType: PSQLDataType {
         .float4

--- a/Sources/PostgresNIO/New/Data/Int+PSQLCodable.swift
+++ b/Sources/PostgresNIO/New/Data/Int+PSQLCodable.swift
@@ -1,3 +1,5 @@
+import NIOCore
+
 extension UInt8: PSQLCodable {
     var psqlType: PSQLDataType {
         .char

--- a/Sources/PostgresNIO/New/Data/JSON+PSQLCodable.swift
+++ b/Sources/PostgresNIO/New/Data/JSON+PSQLCodable.swift
@@ -1,3 +1,4 @@
+import NIOCore
 import NIOFoundationCompat
 import class Foundation.JSONEncoder
 import class Foundation.JSONDecoder

--- a/Sources/PostgresNIO/New/Data/Optional+PSQLCodable.swift
+++ b/Sources/PostgresNIO/New/Data/Optional+PSQLCodable.swift
@@ -1,3 +1,5 @@
+import NIOCore
+
 extension Optional: PSQLDecodable where Wrapped: PSQLDecodable {
     static func decode(from byteBuffer: inout ByteBuffer, type: PSQLDataType, format: PSQLFormat, context: PSQLDecodingContext) throws -> Optional<Wrapped> {
         preconditionFailure("This code path should never be hit.")

--- a/Sources/PostgresNIO/New/Data/RawRepresentable+PSQLCodable.swift
+++ b/Sources/PostgresNIO/New/Data/RawRepresentable+PSQLCodable.swift
@@ -1,3 +1,5 @@
+import NIOCore
+
 extension PSQLCodable where Self: RawRepresentable, RawValue: PSQLCodable {
     var psqlType: PSQLDataType {
         self.rawValue.psqlType

--- a/Sources/PostgresNIO/New/Data/String+PSQLCodable.swift
+++ b/Sources/PostgresNIO/New/Data/String+PSQLCodable.swift
@@ -1,3 +1,4 @@
+import NIOCore
 import struct Foundation.UUID
 
 extension String: PSQLCodable {

--- a/Sources/PostgresNIO/New/Data/UUID+PSQLCodable.swift
+++ b/Sources/PostgresNIO/New/Data/UUID+PSQLCodable.swift
@@ -1,3 +1,4 @@
+import NIOCore
 import struct Foundation.UUID
 import typealias Foundation.uuid_t
 

--- a/Sources/PostgresNIO/New/Extensions/ByteBuffer+PSQL.swift
+++ b/Sources/PostgresNIO/New/Extensions/ByteBuffer+PSQL.swift
@@ -1,4 +1,4 @@
-import NIO
+import NIOCore
 
 internal extension ByteBuffer {
     mutating func writeNullTerminatedString(_ string: String) {

--- a/Sources/PostgresNIO/New/Messages/Authentication.swift
+++ b/Sources/PostgresNIO/New/Messages/Authentication.swift
@@ -1,4 +1,4 @@
-import NIO
+import NIOCore
 
 extension PSQLBackendMessage {
     

--- a/Sources/PostgresNIO/New/Messages/BackendKeyData.swift
+++ b/Sources/PostgresNIO/New/Messages/BackendKeyData.swift
@@ -1,3 +1,5 @@
+import NIOCore
+
 extension PSQLBackendMessage {
     
     struct BackendKeyData: PayloadDecodable, Equatable {

--- a/Sources/PostgresNIO/New/Messages/Bind.swift
+++ b/Sources/PostgresNIO/New/Messages/Bind.swift
@@ -1,3 +1,5 @@
+import NIOCore
+
 extension PSQLFrontendMessage {
     
     struct Bind {

--- a/Sources/PostgresNIO/New/Messages/Cancel.swift
+++ b/Sources/PostgresNIO/New/Messages/Cancel.swift
@@ -1,3 +1,5 @@
+import NIOCore
+
 extension PSQLFrontendMessage {
     
     struct Cancel: PayloadEncodable, Equatable {

--- a/Sources/PostgresNIO/New/Messages/Close.swift
+++ b/Sources/PostgresNIO/New/Messages/Close.swift
@@ -1,3 +1,5 @@
+import NIOCore
+
 extension PSQLFrontendMessage {
     
     enum Close: PayloadEncodable, Equatable {

--- a/Sources/PostgresNIO/New/Messages/DataRow.swift
+++ b/Sources/PostgresNIO/New/Messages/DataRow.swift
@@ -1,4 +1,4 @@
-import NIO
+import NIOCore
 
 extension PSQLBackendMessage {
     

--- a/Sources/PostgresNIO/New/Messages/Describe.swift
+++ b/Sources/PostgresNIO/New/Messages/Describe.swift
@@ -1,3 +1,5 @@
+import NIOCore
+
 extension PSQLFrontendMessage {
     
     enum Describe: PayloadEncodable, Equatable {

--- a/Sources/PostgresNIO/New/Messages/ErrorResponse.swift
+++ b/Sources/PostgresNIO/New/Messages/ErrorResponse.swift
@@ -1,3 +1,5 @@
+import NIOCore
+
 extension PSQLBackendMessage {
     
     enum Field: UInt8, Hashable {

--- a/Sources/PostgresNIO/New/Messages/Execute.swift
+++ b/Sources/PostgresNIO/New/Messages/Execute.swift
@@ -1,3 +1,5 @@
+import NIOCore
+
 extension PSQLFrontendMessage {
     
     struct Execute: PayloadEncodable, Equatable {

--- a/Sources/PostgresNIO/New/Messages/NotificationResponse.swift
+++ b/Sources/PostgresNIO/New/Messages/NotificationResponse.swift
@@ -1,4 +1,4 @@
-import NIO
+import NIOCore
 
 extension PSQLBackendMessage {
     

--- a/Sources/PostgresNIO/New/Messages/ParameterDescription.swift
+++ b/Sources/PostgresNIO/New/Messages/ParameterDescription.swift
@@ -1,3 +1,5 @@
+import NIOCore
+
 extension PSQLBackendMessage {
     
     struct ParameterDescription: PayloadDecodable, Equatable {

--- a/Sources/PostgresNIO/New/Messages/ParameterStatus.swift
+++ b/Sources/PostgresNIO/New/Messages/ParameterStatus.swift
@@ -1,3 +1,5 @@
+import NIOCore
+
 extension PSQLBackendMessage {
     
     struct ParameterStatus: PayloadDecodable, Equatable {

--- a/Sources/PostgresNIO/New/Messages/Parse.swift
+++ b/Sources/PostgresNIO/New/Messages/Parse.swift
@@ -1,3 +1,5 @@
+import NIOCore
+
 extension PSQLFrontendMessage {
     
     struct Parse: PayloadEncodable, Equatable {

--- a/Sources/PostgresNIO/New/Messages/Password.swift
+++ b/Sources/PostgresNIO/New/Messages/Password.swift
@@ -1,3 +1,5 @@
+import NIOCore
+
 extension PSQLFrontendMessage {
     
     struct Password: PayloadEncodable, Equatable {

--- a/Sources/PostgresNIO/New/Messages/ReadyForQuery.swift
+++ b/Sources/PostgresNIO/New/Messages/ReadyForQuery.swift
@@ -1,3 +1,5 @@
+import NIOCore
+
 extension PSQLBackendMessage {
     enum TransactionState: PayloadDecodable, RawRepresentable {
         typealias RawValue = UInt8

--- a/Sources/PostgresNIO/New/Messages/RowDescription.swift
+++ b/Sources/PostgresNIO/New/Messages/RowDescription.swift
@@ -1,3 +1,5 @@
+import NIOCore
+
 extension PSQLBackendMessage {
     
     struct RowDescription: PayloadDecodable, Equatable {

--- a/Sources/PostgresNIO/New/Messages/SASLInitialResponse.swift
+++ b/Sources/PostgresNIO/New/Messages/SASLInitialResponse.swift
@@ -1,3 +1,5 @@
+import NIOCore
+
 extension PSQLFrontendMessage {
     
     struct SASLInitialResponse: PayloadEncodable, Equatable {

--- a/Sources/PostgresNIO/New/Messages/SASLResponse.swift
+++ b/Sources/PostgresNIO/New/Messages/SASLResponse.swift
@@ -1,3 +1,5 @@
+import NIOCore
+
 extension PSQLFrontendMessage {
     
     struct SASLResponse: PayloadEncodable, Equatable {

--- a/Sources/PostgresNIO/New/Messages/SSLRequest.swift
+++ b/Sources/PostgresNIO/New/Messages/SSLRequest.swift
@@ -1,4 +1,4 @@
-import NIO
+import NIOCore
 
 extension PSQLFrontendMessage {
     /// A message asking the PostgreSQL server if TLS is supported

--- a/Sources/PostgresNIO/New/Messages/Startup.swift
+++ b/Sources/PostgresNIO/New/Messages/Startup.swift
@@ -1,4 +1,4 @@
-import NIO
+import NIOCore
 
 extension PSQLFrontendMessage {
     struct Startup: PayloadEncodable, Equatable {

--- a/Sources/PostgresNIO/New/PSQL+JSON.swift
+++ b/Sources/PostgresNIO/New/PSQL+JSON.swift
@@ -1,6 +1,7 @@
+import NIOCore
+import NIOFoundationCompat
 import class Foundation.JSONEncoder
 import class Foundation.JSONDecoder
-import NIOFoundationCompat
 
 protocol PSQLJSONEncoder {
     func encode<T: Encodable>(_ value: T, into buffer: inout ByteBuffer) throws

--- a/Sources/PostgresNIO/New/PSQLBackendMessage.swift
+++ b/Sources/PostgresNIO/New/PSQLBackendMessage.swift
@@ -1,4 +1,5 @@
-import struct Foundation.Data
+import NIOCore
+//import struct Foundation.Data
 
 
 /// A protocol to implement for all associated value in the `PSQLBackendMessage` enum

--- a/Sources/PostgresNIO/New/PSQLChannelHandler.swift
+++ b/Sources/PostgresNIO/New/PSQLChannelHandler.swift
@@ -1,4 +1,4 @@
-import NIO
+import NIOCore
 import NIOTLS
 import Crypto
 import Logging

--- a/Sources/PostgresNIO/New/PSQLCodable.swift
+++ b/Sources/PostgresNIO/New/PSQLCodable.swift
@@ -1,3 +1,5 @@
+import NIOCore
+
 /// A type that can encode itself to a postgres wire binary representation.
 protocol PSQLEncodable {
     /// identifies the data type that we will encode into `byteBuffer` in `encode`

--- a/Sources/PostgresNIO/New/PSQLConnection.swift
+++ b/Sources/PostgresNIO/New/PSQLConnection.swift
@@ -1,4 +1,5 @@
-import NIO
+import NIOCore
+import NIOPosix
 import NIOFoundationCompat
 import NIOSSL
 import class Foundation.JSONEncoder

--- a/Sources/PostgresNIO/New/PSQLData.swift
+++ b/Sources/PostgresNIO/New/PSQLData.swift
@@ -1,3 +1,5 @@
+import NIOCore
+
 /// The format the postgres types are encoded in on the wire.
 ///
 /// Currently there a two wire formats supported:

--- a/Sources/PostgresNIO/New/PSQLError.swift
+++ b/Sources/PostgresNIO/New/PSQLError.swift
@@ -1,4 +1,4 @@
-import struct Foundation.Data
+import NIOCore
 
 struct PSQLError: Error {
     

--- a/Sources/PostgresNIO/New/PSQLEventsHandler.swift
+++ b/Sources/PostgresNIO/New/PSQLEventsHandler.swift
@@ -1,4 +1,6 @@
+import NIOCore
 import NIOTLS
+import Logging
 
 enum PSQLOutgoingEvent {    
     /// the event we send down the channel to inform the `PSQLChannelHandler` to authenticate

--- a/Sources/PostgresNIO/New/PSQLFrontendMessage.swift
+++ b/Sources/PostgresNIO/New/PSQLFrontendMessage.swift
@@ -1,4 +1,4 @@
-import NIO
+import NIOCore
 
 /// A wire message that is created by a Postgres client to be consumed by Postgres server.
 ///

--- a/Sources/PostgresNIO/New/PSQLRows.swift
+++ b/Sources/PostgresNIO/New/PSQLRows.swift
@@ -1,4 +1,4 @@
-import NIO
+import NIOCore
 import Logging
 
 final class PSQLRows {

--- a/Sources/PostgresNIO/New/PSQLTask.swift
+++ b/Sources/PostgresNIO/New/PSQLTask.swift
@@ -1,3 +1,6 @@
+import Logging
+import NIOCore
+
 enum PSQLTask {
     case extendedQuery(ExtendedQueryContext)
     case preparedStatement(PrepareStatementContext)

--- a/Sources/PostgresNIO/Postgres+PSQLCompat.swift
+++ b/Sources/PostgresNIO/Postgres+PSQLCompat.swift
@@ -1,3 +1,5 @@
+import NIOCore
+
 struct PostgresJSONDecoderWrapper: PSQLJSONDecoder {
     let downstream: PostgresJSONDecoder
     

--- a/Sources/PostgresNIO/PostgresDatabase+Query.swift
+++ b/Sources/PostgresNIO/PostgresDatabase+Query.swift
@@ -1,4 +1,4 @@
-import NIO
+import NIOCore
 import Logging
 
 extension PostgresDatabase {

--- a/Sources/PostgresNIO/PostgresDatabase+SimpleQuery.swift
+++ b/Sources/PostgresNIO/PostgresDatabase+SimpleQuery.swift
@@ -1,4 +1,4 @@
-import NIO
+import NIOCore
 import Logging
 
 extension PostgresDatabase {

--- a/Sources/PostgresNIO/PostgresDatabase.swift
+++ b/Sources/PostgresNIO/PostgresDatabase.swift
@@ -1,3 +1,6 @@
+import NIOCore
+import Logging
+
 public protocol PostgresDatabase {
     var logger: Logger { get }
     var eventLoop: EventLoop { get }

--- a/Sources/PostgresNIO/Utilities/Exports.swift
+++ b/Sources/PostgresNIO/Utilities/Exports.swift
@@ -1,3 +1,4 @@
+// TODO: Remove this with the next major release!
 @_exported import NIO
 @_exported import NIOSSL
 @_exported import struct Logging.Logger

--- a/Sources/PostgresNIO/Utilities/NIOUtils.swift
+++ b/Sources/PostgresNIO/Utilities/NIOUtils.swift
@@ -1,5 +1,5 @@
 import Foundation
-import NIO
+import NIOCore
 
 internal extension ByteBuffer {
     mutating func readInteger<E>(endianness: Endianness = .big, as rawRepresentable: E.Type) -> E? where E: RawRepresentable, E.RawValue: FixedWidthInteger {

--- a/Tests/IntegrationTests/PSQLIntegrationTests.swift
+++ b/Tests/IntegrationTests/PSQLIntegrationTests.swift
@@ -1,6 +1,8 @@
+import XCTest
 import Logging
 @testable import PostgresNIO
-import XCTest
+import NIOCore
+import NIOPosix
 import NIOTestUtils
 
 final class IntegrationTests: XCTestCase {

--- a/Tests/IntegrationTests/PerformanceTests.swift
+++ b/Tests/IntegrationTests/PerformanceTests.swift
@@ -1,6 +1,8 @@
-import Logging
-import PostgresNIO
 import XCTest
+import Logging
+import NIOCore
+import NIOPosix
+import PostgresNIO
 import NIOTestUtils
 
 final class PerformanceTests: XCTestCase {

--- a/Tests/IntegrationTests/PostgresNIOTests.swift
+++ b/Tests/IntegrationTests/PostgresNIOTests.swift
@@ -1,6 +1,8 @@
 import Logging
 @testable import PostgresNIO
 import XCTest
+import NIOCore
+import NIOPosix
 import NIOTestUtils
 
 final class PostgresNIOTests: XCTestCase {

--- a/Tests/IntegrationTests/Utilities.swift
+++ b/Tests/IntegrationTests/Utilities.swift
@@ -1,5 +1,6 @@
-import PostgresNIO
 import XCTest
+import PostgresNIO
+import NIOCore
 import Logging
 #if canImport(Darwin)
 import Darwin.C

--- a/Tests/PostgresNIOTests/New/Connection State Machine/AuthenticationStateMachineTests.swift
+++ b/Tests/PostgresNIOTests/New/Connection State Machine/AuthenticationStateMachineTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import NIOCore
 @testable import PostgresNIO
 
 class AuthenticationStateMachineTests: XCTestCase {

--- a/Tests/PostgresNIOTests/New/Connection State Machine/ConnectionStateMachineTests.swift
+++ b/Tests/PostgresNIOTests/New/Connection State Machine/ConnectionStateMachineTests.swift
@@ -1,6 +1,8 @@
 import XCTest
 @testable import PostgresNIO
-@testable import NIO
+@testable import NIOCore
+import NIOPosix
+import NIOSSL
 
 class ConnectionStateMachineTests: XCTestCase {
     

--- a/Tests/PostgresNIOTests/New/Connection State Machine/ExtendedQueryStateMachineTests.swift
+++ b/Tests/PostgresNIOTests/New/Connection State Machine/ExtendedQueryStateMachineTests.swift
@@ -1,4 +1,7 @@
 import XCTest
+import NIOCore
+import NIOEmbedded
+import Logging
 @testable import PostgresNIO
 
 class ExtendedQueryStateMachineTests: XCTestCase {

--- a/Tests/PostgresNIOTests/New/Connection State Machine/PrepareStatementStateMachineTests.swift
+++ b/Tests/PostgresNIOTests/New/Connection State Machine/PrepareStatementStateMachineTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import NIOEmbedded
 @testable import PostgresNIO
 
 class PrepareStatementStateMachineTests: XCTestCase {

--- a/Tests/PostgresNIOTests/New/Data/Array+PSQLCodableTests.swift
+++ b/Tests/PostgresNIOTests/New/Data/Array+PSQLCodableTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import NIOCore
 @testable import PostgresNIO
 
 class Array_PSQLCodableTests: XCTestCase {

--- a/Tests/PostgresNIOTests/New/Data/Bool+PSQLCodableTests.swift
+++ b/Tests/PostgresNIOTests/New/Data/Bool+PSQLCodableTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import NIOCore
 @testable import PostgresNIO
 
 class Bool_PSQLCodableTests: XCTestCase {

--- a/Tests/PostgresNIOTests/New/Data/Bytes+PSQLCodableTests.swift
+++ b/Tests/PostgresNIOTests/New/Data/Bytes+PSQLCodableTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import NIOCore
 @testable import PostgresNIO
 
 class Bytes_PSQLCodableTests: XCTestCase {

--- a/Tests/PostgresNIOTests/New/Data/Date+PSQLCodableTests.swift
+++ b/Tests/PostgresNIOTests/New/Data/Date+PSQLCodableTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import NIOCore
 @testable import PostgresNIO
 
 class Date_PSQLCodableTests: XCTestCase {

--- a/Tests/PostgresNIOTests/New/Data/Float+PSQLCodableTests.swift
+++ b/Tests/PostgresNIOTests/New/Data/Float+PSQLCodableTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import NIOCore
 @testable import PostgresNIO
 
 class Float_PSQLCodableTests: XCTestCase {

--- a/Tests/PostgresNIOTests/New/Data/JSON+PSQLCodableTests.swift
+++ b/Tests/PostgresNIOTests/New/Data/JSON+PSQLCodableTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import NIOCore
 @testable import PostgresNIO
 
 class JSON_PSQLCodableTests: XCTestCase {

--- a/Tests/PostgresNIOTests/New/Data/Optional+PSQLCodableTests.swift
+++ b/Tests/PostgresNIOTests/New/Data/Optional+PSQLCodableTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import NIOCore
 @testable import PostgresNIO
 
 class Optional_PSQLCodableTests: XCTestCase {

--- a/Tests/PostgresNIOTests/New/Data/RawRepresentable+PSQLCodableTests.swift
+++ b/Tests/PostgresNIOTests/New/Data/RawRepresentable+PSQLCodableTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import NIOCore
 @testable import PostgresNIO
 
 class RawRepresentable_PSQLCodableTests: XCTestCase {

--- a/Tests/PostgresNIOTests/New/Data/String+PSQLCodableTests.swift
+++ b/Tests/PostgresNIOTests/New/Data/String+PSQLCodableTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import NIOCore
 @testable import PostgresNIO
 
 class String_PSQLCodableTests: XCTestCase {

--- a/Tests/PostgresNIOTests/New/Data/UUID+PSQLCodableTests.swift
+++ b/Tests/PostgresNIOTests/New/Data/UUID+PSQLCodableTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import NIOCore
 @testable import PostgresNIO
 
 class UUID_PSQLCodableTests: XCTestCase {

--- a/Tests/PostgresNIOTests/New/Extensions/ByteBuffer+Utils.swift
+++ b/Tests/PostgresNIOTests/New/Extensions/ByteBuffer+Utils.swift
@@ -1,4 +1,4 @@
-import NIO
+import NIOCore
 @testable import PostgresNIO
 
 extension ByteBuffer {

--- a/Tests/PostgresNIOTests/New/Extensions/ConnectionAction+TestUtils.swift
+++ b/Tests/PostgresNIOTests/New/Extensions/ConnectionAction+TestUtils.swift
@@ -1,4 +1,5 @@
 import class Foundation.JSONEncoder
+import NIOCore
 @testable import PostgresNIO
 
 extension ConnectionStateMachine.ConnectionAction: Equatable {

--- a/Tests/PostgresNIOTests/New/Extensions/LoggingUtils.swift
+++ b/Tests/PostgresNIOTests/New/Extensions/LoggingUtils.swift
@@ -1,2 +1,0 @@
-import Logging
-

--- a/Tests/PostgresNIOTests/New/Extensions/PSQLFrontendMessage+Equatable.swift
+++ b/Tests/PostgresNIOTests/New/Extensions/PSQLFrontendMessage+Equatable.swift
@@ -1,6 +1,7 @@
+import NIOCore
+@testable import PostgresNIO
 import class Foundation.JSONEncoder
 import class Foundation.JSONDecoder
-@testable import PostgresNIO
 
 extension PSQLFrontendMessage.Bind: Equatable {
     public static func ==(lhs: Self, rhs: Self) -> Bool {

--- a/Tests/PostgresNIOTests/New/Messages/AuthenticationTests.swift
+++ b/Tests/PostgresNIOTests/New/Messages/AuthenticationTests.swift
@@ -1,6 +1,6 @@
-import NIO
-import NIOTestUtils
 import XCTest
+import NIOCore
+import NIOTestUtils
 @testable import PostgresNIO
 
 class AuthenticationTests: XCTestCase {

--- a/Tests/PostgresNIOTests/New/Messages/BackendKeyDataTests.swift
+++ b/Tests/PostgresNIOTests/New/Messages/BackendKeyDataTests.swift
@@ -1,6 +1,6 @@
-import NIO
-import NIOTestUtils
 import XCTest
+import NIOCore
+import NIOTestUtils
 @testable import PostgresNIO
 
 class BackendKeyDataTests: XCTestCase {

--- a/Tests/PostgresNIOTests/New/Messages/BindTests.swift
+++ b/Tests/PostgresNIOTests/New/Messages/BindTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import NIOCore
 @testable import PostgresNIO
 
 class BindTests: XCTestCase {

--- a/Tests/PostgresNIOTests/New/Messages/CancelTests.swift
+++ b/Tests/PostgresNIOTests/New/Messages/CancelTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import NIOCore
 @testable import PostgresNIO
 
 class CancelTests: XCTestCase {

--- a/Tests/PostgresNIOTests/New/Messages/CloseTests.swift
+++ b/Tests/PostgresNIOTests/New/Messages/CloseTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import NIOCore
 @testable import PostgresNIO
 
 class CloseTests: XCTestCase {

--- a/Tests/PostgresNIOTests/New/Messages/DataRowTests.swift
+++ b/Tests/PostgresNIOTests/New/Messages/DataRowTests.swift
@@ -1,6 +1,6 @@
-import NIO
-import NIOTestUtils
 import XCTest
+import NIOCore
+import NIOTestUtils
 @testable import PostgresNIO
 
 class DataRowTests: XCTestCase {

--- a/Tests/PostgresNIOTests/New/Messages/DescribeTests.swift
+++ b/Tests/PostgresNIOTests/New/Messages/DescribeTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import NIOCore
 @testable import PostgresNIO
 
 class DescribeTests: XCTestCase {

--- a/Tests/PostgresNIOTests/New/Messages/ErrorResponseTests.swift
+++ b/Tests/PostgresNIOTests/New/Messages/ErrorResponseTests.swift
@@ -1,6 +1,6 @@
-import NIO
-import NIOTestUtils
 import XCTest
+import NIOCore
+import NIOTestUtils
 @testable import PostgresNIO
 
 class ErrorResponseTests: XCTestCase {

--- a/Tests/PostgresNIOTests/New/Messages/ExecuteTests.swift
+++ b/Tests/PostgresNIOTests/New/Messages/ExecuteTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import NIOCore
 @testable import PostgresNIO
 
 class ExecuteTests: XCTestCase {

--- a/Tests/PostgresNIOTests/New/Messages/NotificationResponseTests.swift
+++ b/Tests/PostgresNIOTests/New/Messages/NotificationResponseTests.swift
@@ -1,6 +1,6 @@
-import NIO
-import NIOTestUtils
 import XCTest
+import NIOCore
+import NIOTestUtils
 @testable import PostgresNIO
 
 class NotificationResponseTests: XCTestCase {

--- a/Tests/PostgresNIOTests/New/Messages/ParameterDescriptionTests.swift
+++ b/Tests/PostgresNIOTests/New/Messages/ParameterDescriptionTests.swift
@@ -1,6 +1,6 @@
-import NIO
-import NIOTestUtils
 import XCTest
+import NIOCore
+import NIOTestUtils
 @testable import PostgresNIO
 
 class ParameterDescriptionTests: XCTestCase {

--- a/Tests/PostgresNIOTests/New/Messages/ParameterStatusTests.swift
+++ b/Tests/PostgresNIOTests/New/Messages/ParameterStatusTests.swift
@@ -1,6 +1,6 @@
-import NIO
-import NIOTestUtils
 import XCTest
+import NIOCore
+import NIOTestUtils
 @testable import PostgresNIO
 
 class ParameterStatusTests: XCTestCase {

--- a/Tests/PostgresNIOTests/New/Messages/ParseTests.swift
+++ b/Tests/PostgresNIOTests/New/Messages/ParseTests.swift
@@ -1,6 +1,5 @@
-import NIO
-import NIOTestUtils
 import XCTest
+import NIOCore
 @testable import PostgresNIO
 
 class ParseTests: XCTestCase {

--- a/Tests/PostgresNIOTests/New/Messages/PasswordTests.swift
+++ b/Tests/PostgresNIOTests/New/Messages/PasswordTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import NIOCore
 @testable import PostgresNIO
 
 class PasswordTests: XCTestCase {

--- a/Tests/PostgresNIOTests/New/Messages/ReadyForQueryTests.swift
+++ b/Tests/PostgresNIOTests/New/Messages/ReadyForQueryTests.swift
@@ -1,6 +1,6 @@
-import NIO
-import NIOTestUtils
 import XCTest
+import NIOCore
+import NIOTestUtils
 @testable import PostgresNIO
 
 class ReadyForQueryTests: XCTestCase {

--- a/Tests/PostgresNIOTests/New/Messages/RowDescriptionTests.swift
+++ b/Tests/PostgresNIOTests/New/Messages/RowDescriptionTests.swift
@@ -1,6 +1,6 @@
-import NIO
-import NIOTestUtils
 import XCTest
+import NIOCore
+import NIOTestUtils
 @testable import PostgresNIO
 
 class RowDescriptionTests: XCTestCase {

--- a/Tests/PostgresNIOTests/New/Messages/SASLInitialResponseTests.swift
+++ b/Tests/PostgresNIOTests/New/Messages/SASLInitialResponseTests.swift
@@ -1,6 +1,5 @@
-import NIO
-import NIOTestUtils
 import XCTest
+import NIOCore
 @testable import PostgresNIO
 
 class SASLInitialResponseTests: XCTestCase {

--- a/Tests/PostgresNIOTests/New/Messages/SASLResponseTests.swift
+++ b/Tests/PostgresNIOTests/New/Messages/SASLResponseTests.swift
@@ -1,6 +1,5 @@
-import NIO
-import NIOTestUtils
 import XCTest
+import NIOCore
 @testable import PostgresNIO
 
 class SASLResponseTests: XCTestCase {

--- a/Tests/PostgresNIOTests/New/Messages/SSLRequestTests.swift
+++ b/Tests/PostgresNIOTests/New/Messages/SSLRequestTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import NIOCore
 @testable import PostgresNIO
 
 class SSLRequestTests: XCTestCase {

--- a/Tests/PostgresNIOTests/New/Messages/StartupTests.swift
+++ b/Tests/PostgresNIOTests/New/Messages/StartupTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import NIOCore
 @testable import PostgresNIO
 
 class StartupTests: XCTestCase {

--- a/Tests/PostgresNIOTests/New/PSQLBackendMessageTests.swift
+++ b/Tests/PostgresNIOTests/New/PSQLBackendMessageTests.swift
@@ -1,4 +1,5 @@
-import NIO
+import NIOCore
+import NIOEmbedded
 import NIOTestUtils
 import XCTest
 @testable import PostgresNIO

--- a/Tests/PostgresNIOTests/New/PSQLChannelHandlerTests.swift
+++ b/Tests/PostgresNIOTests/New/PSQLChannelHandlerTests.swift
@@ -1,6 +1,8 @@
 import XCTest
-import NIO
+import NIOCore
 import NIOTLS
+import NIOSSL
+import NIOEmbedded
 @testable import PostgresNIO
 
 class PSQLChannelHandlerTests: XCTestCase {

--- a/Tests/PostgresNIOTests/New/PSQLConnectionTests.swift
+++ b/Tests/PostgresNIOTests/New/PSQLConnectionTests.swift
@@ -1,4 +1,5 @@
-import NIO
+import NIOCore
+import NIOPosix
 import XCTest
 import Logging
 @testable import PostgresNIO

--- a/Tests/PostgresNIOTests/New/PSQLDataTests.swift
+++ b/Tests/PostgresNIOTests/New/PSQLDataTests.swift
@@ -1,4 +1,4 @@
-import NIO
+import NIOCore
 import XCTest
 @testable import PostgresNIO
 

--- a/Tests/PostgresNIOTests/New/PSQLFrontendMessageTests.swift
+++ b/Tests/PostgresNIOTests/New/PSQLFrontendMessageTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import NIOCore
 @testable import PostgresNIO
 
 class PSQLFrontendMessageTests: XCTestCase {

--- a/Tests/PostgresNIOTests/New/PSQLMetadataTests.swift
+++ b/Tests/PostgresNIOTests/New/PSQLMetadataTests.swift
@@ -1,4 +1,4 @@
-import NIO
+import NIOCore
 import XCTest
 @testable import PostgresNIO
 


### PR DESCRIPTION
### Motivation

- SwiftNIO 2.32.0 introduces explicit modules for its Core and Posix.
- To write great platform independent code in most parts we should only ever import `NIOCore`

### Changes

- This pr explicitly imports NIOCore, NIOPosix and NIOEmbedded where needed.