### PR TITLE
Add conveniences to PSQLFrontendMessage

### DIFF
--- a/Sources/PostgresNIO/New/Extensions/ByteBuffer+PSQL.swift
+++ b/Sources/PostgresNIO/New/Extensions/ByteBuffer+PSQL.swift
@@ -20,7 +20,7 @@ internal extension ByteBuffer {
     }
     
     mutating func writeFrontendMessageID(_ messageID: PSQLFrontendMessage.ID) {
-        self.writeInteger(messageID.byte)
+        self.writeInteger(messageID.rawValue)
     }
 
     mutating func readFloat() -> Float? {

--- a/Sources/PostgresNIO/New/Messages/Cancel.swift
+++ b/Sources/PostgresNIO/New/Messages/Cancel.swift
@@ -2,7 +2,7 @@ import NIOCore
 
 extension PSQLFrontendMessage {
     
-    struct Cancel: PayloadEncodable, Equatable {
+    struct Cancel: PSQLMessagePayloadEncodable, Equatable {
         /// The cancel request code. The value is chosen to contain 1234 in the most significant 16 bits,
         /// and 5678 in the least significant 16 bits. (To avoid confusion, this code must not be the same
         /// as any protocol version number.)

--- a/Sources/PostgresNIO/New/Messages/Close.swift
+++ b/Sources/PostgresNIO/New/Messages/Close.swift
@@ -2,7 +2,7 @@ import NIOCore
 
 extension PSQLFrontendMessage {
     
-    enum Close: PayloadEncodable, Equatable {
+    enum Close: PSQLMessagePayloadEncodable, Equatable {
         case preparedStatement(String)
         case portal(String)
         

--- a/Sources/PostgresNIO/New/Messages/Describe.swift
+++ b/Sources/PostgresNIO/New/Messages/Describe.swift
@@ -2,7 +2,7 @@ import NIOCore
 
 extension PSQLFrontendMessage {
     
-    enum Describe: PayloadEncodable, Equatable {
+    enum Describe: PSQLMessagePayloadEncodable, Equatable {
         
         case preparedStatement(String)
         case portal(String)

--- a/Sources/PostgresNIO/New/Messages/Execute.swift
+++ b/Sources/PostgresNIO/New/Messages/Execute.swift
@@ -2,7 +2,7 @@ import NIOCore
 
 extension PSQLFrontendMessage {
     
-    struct Execute: PayloadEncodable, Equatable {
+    struct Execute: PSQLMessagePayloadEncodable, Equatable {
         /// The name of the portal to execute (an empty string selects the unnamed portal).
         let portalName: String
         

--- a/Sources/PostgresNIO/New/Messages/Parse.swift
+++ b/Sources/PostgresNIO/New/Messages/Parse.swift
@@ -2,7 +2,7 @@ import NIOCore
 
 extension PSQLFrontendMessage {
     
-    struct Parse: PayloadEncodable, Equatable {
+    struct Parse: PSQLMessagePayloadEncodable, Equatable {
         /// The name of the destination prepared statement (an empty string selects the unnamed prepared statement).
         let preparedStatementName: String
         

--- a/Sources/PostgresNIO/New/Messages/Password.swift
+++ b/Sources/PostgresNIO/New/Messages/Password.swift
@@ -2,7 +2,7 @@ import NIOCore
 
 extension PSQLFrontendMessage {
     
-    struct Password: PayloadEncodable, Equatable {
+    struct Password: PSQLMessagePayloadEncodable, Equatable {
         let value: String
         
         func encode(into buffer: inout ByteBuffer) {

--- a/Sources/PostgresNIO/New/Messages/SASLInitialResponse.swift
+++ b/Sources/PostgresNIO/New/Messages/SASLInitialResponse.swift
@@ -2,7 +2,7 @@ import NIOCore
 
 extension PSQLFrontendMessage {
     
-    struct SASLInitialResponse: PayloadEncodable, Equatable {
+    struct SASLInitialResponse: PSQLMessagePayloadEncodable, Equatable {
         
         let saslMechanism: String
         let initialData: [UInt8]

--- a/Sources/PostgresNIO/New/Messages/SASLResponse.swift
+++ b/Sources/PostgresNIO/New/Messages/SASLResponse.swift
@@ -2,7 +2,7 @@ import NIOCore
 
 extension PSQLFrontendMessage {
     
-    struct SASLResponse: PayloadEncodable, Equatable {
+    struct SASLResponse: PSQLMessagePayloadEncodable, Equatable {
         
         let data: [UInt8]
         

--- a/Sources/PostgresNIO/New/Messages/SSLRequest.swift
+++ b/Sources/PostgresNIO/New/Messages/SSLRequest.swift
@@ -3,7 +3,7 @@ import NIOCore
 extension PSQLFrontendMessage {
     /// A message asking the PostgreSQL server if TLS is supported
     /// For more info, see https://www.postgresql.org/docs/10/static/protocol-flow.html#id-1.10.5.7.11
-    struct SSLRequest: PayloadEncodable, Equatable {
+    struct SSLRequest: PSQLMessagePayloadEncodable, Equatable {
         /// The SSL request code. The value is chosen to contain 1234 in the most significant 16 bits,
         /// and 5679 in the least significant 16 bits.
         let code: Int32

--- a/Sources/PostgresNIO/New/Messages/Startup.swift
+++ b/Sources/PostgresNIO/New/Messages/Startup.swift
@@ -1,7 +1,7 @@
 import NIOCore
 
 extension PSQLFrontendMessage {
-    struct Startup: PayloadEncodable, Equatable {
+    struct Startup: PSQLMessagePayloadEncodable, Equatable {
 
         /// Creates a `Startup` with "3.0" as the protocol version.
         static func versionThree(parameters: Parameters) -> Startup {

--- a/Sources/PostgresNIO/New/PSQLFrontendMessage.swift
+++ b/Sources/PostgresNIO/New/PSQLFrontendMessage.swift
@@ -20,8 +20,7 @@ enum PSQLFrontendMessage {
     case startup(Startup)
     case terminate
     
-    enum ID: RawRepresentable, Equatable {
-        typealias RawValue = UInt8
+    enum ID: UInt8, Equatable {
         
         case bind
         case close

--- a/Sources/PostgresNIO/New/PSQLFrontendMessage.swift
+++ b/Sources/PostgresNIO/New/PSQLFrontendMessage.swift
@@ -5,8 +5,6 @@ import NIOCore
 /// All messages are defined in the official Postgres Documentation in the section
 /// [Frontend/Backend Protocol – Message Formats](https://www.postgresql.org/docs/13/protocol-message-formats.html)
 enum PSQLFrontendMessage {
-    typealias PayloadEncodable = PSQLFrontendMessagePayloadEncodable
-    
     case bind(Bind)
     case cancel(Cancel)
     case close(Close)
@@ -112,11 +110,11 @@ extension PSQLFrontendMessage {
         }
         
         func encode(data message: PSQLFrontendMessage, out buffer: inout ByteBuffer) throws {
-            struct EmptyPayload: PayloadEncodable {
+            struct EmptyPayload: PSQLMessagePayloadEncodable {
                 func encode(into buffer: inout ByteBuffer) {}
             }
             
-            func encode<Payload: PayloadEncodable>(_ payload: Payload, into buffer: inout ByteBuffer) {
+            func encode<Payload: PSQLMessagePayloadEncodable>(_ payload: Payload, into buffer: inout ByteBuffer) {
                 let startIndex = buffer.writerIndex
                 buffer.writeInteger(Int32(0)) // placeholder for length
                 payload.encode(into: &buffer)
@@ -177,6 +175,6 @@ extension PSQLFrontendMessage {
     }
 }
 
-protocol PSQLFrontendMessagePayloadEncodable {
+protocol PSQLMessagePayloadEncodable {
     func encode(into buffer: inout ByteBuffer)
 }

--- a/Sources/PostgresNIO/New/PSQLFrontendMessage.swift
+++ b/Sources/PostgresNIO/New/PSQLFrontendMessage.swift
@@ -20,7 +20,9 @@ enum PSQLFrontendMessage {
     case startup(Startup)
     case terminate
     
-    enum ID {
+    enum ID: RawRepresentable, Equatable {
+        typealias RawValue = UInt8
+        
         case bind
         case close
         case describe
@@ -33,7 +35,36 @@ enum PSQLFrontendMessage {
         case sync
         case terminate
         
-        var byte: UInt8 {
+        init?(rawValue: UInt8) {
+            switch rawValue {
+            case UInt8(ascii: "B"):
+                self = .bind
+            case UInt8(ascii: "C"):
+                self = .close
+            case UInt8(ascii: "D"):
+                self = .describe
+            case UInt8(ascii: "E"):
+                self = .execute
+            case UInt8(ascii: "H"):
+                self = .flush
+            case UInt8(ascii: "P"):
+                self = .parse
+            case UInt8(ascii: "p"):
+                self = .password
+            case UInt8(ascii: "p"):
+                self = .saslInitialResponse
+            case UInt8(ascii: "p"):
+                self = .saslResponse
+            case UInt8(ascii: "S"):
+                self = .sync
+            case UInt8(ascii: "X"):
+                self = .terminate
+            default:
+                return nil
+            }
+        }
+
+        var rawValue: UInt8 {
             switch self {
             case .bind:
                 return UInt8(ascii: "B")
@@ -124,7 +155,7 @@ extension PSQLFrontendMessage {
             
             switch message {
             case .bind(let bind):
-                buffer.writeInteger(message.id.byte)
+                buffer.writeInteger(message.id.rawValue)
                 let startIndex = buffer.writerIndex
                 buffer.writeInteger(Int32(0)) // placeholder for length
                 try bind.encode(into: &buffer, using: self.jsonEncoder)

--- a/Tests/PostgresNIOTests/New/Messages/BindTests.swift
+++ b/Tests/PostgresNIOTests/New/Messages/BindTests.swift
@@ -12,7 +12,7 @@ class BindTests: XCTestCase {
         XCTAssertNoThrow(try encoder.encode(data: message, out: &byteBuffer))
         
         XCTAssertEqual(byteBuffer.readableBytes, 37)
-        XCTAssertEqual(PSQLFrontendMessage.ID.bind.byte, byteBuffer.readInteger(as: UInt8.self))
+        XCTAssertEqual(PSQLFrontendMessage.ID.bind.rawValue, byteBuffer.readInteger(as: UInt8.self))
         XCTAssertEqual(byteBuffer.readInteger(as: Int32.self), 36)
         XCTAssertEqual("", byteBuffer.readNullTerminatedString())
         XCTAssertEqual("", byteBuffer.readNullTerminatedString())

--- a/Tests/PostgresNIOTests/New/Messages/CloseTests.swift
+++ b/Tests/PostgresNIOTests/New/Messages/CloseTests.swift
@@ -11,7 +11,7 @@ class CloseTests: XCTestCase {
         XCTAssertNoThrow(try encoder.encode(data: message, out: &byteBuffer))
         
         XCTAssertEqual(byteBuffer.readableBytes, 12)
-        XCTAssertEqual(PSQLFrontendMessage.ID.close.byte, byteBuffer.readInteger(as: UInt8.self))
+        XCTAssertEqual(PSQLFrontendMessage.ID.close.rawValue, byteBuffer.readInteger(as: UInt8.self))
         XCTAssertEqual(11, byteBuffer.readInteger(as: Int32.self))
         XCTAssertEqual(UInt8(ascii: "P"), byteBuffer.readInteger(as: UInt8.self))
         XCTAssertEqual("Hello", byteBuffer.readNullTerminatedString())
@@ -25,7 +25,7 @@ class CloseTests: XCTestCase {
         XCTAssertNoThrow(try encoder.encode(data: message, out: &byteBuffer))
         
         XCTAssertEqual(byteBuffer.readableBytes, 7)
-        XCTAssertEqual(PSQLFrontendMessage.ID.close.byte, byteBuffer.readInteger(as: UInt8.self))
+        XCTAssertEqual(PSQLFrontendMessage.ID.close.rawValue, byteBuffer.readInteger(as: UInt8.self))
         XCTAssertEqual(6, byteBuffer.readInteger(as: Int32.self))
         XCTAssertEqual(UInt8(ascii: "S"), byteBuffer.readInteger(as: UInt8.self))
         XCTAssertEqual("", byteBuffer.readNullTerminatedString())

--- a/Tests/PostgresNIOTests/New/Messages/DescribeTests.swift
+++ b/Tests/PostgresNIOTests/New/Messages/DescribeTests.swift
@@ -11,7 +11,7 @@ class DescribeTests: XCTestCase {
         XCTAssertNoThrow(try encoder.encode(data: message, out: &byteBuffer))
         
         XCTAssertEqual(byteBuffer.readableBytes, 12)
-        XCTAssertEqual(PSQLFrontendMessage.ID.describe.byte, byteBuffer.readInteger(as: UInt8.self))
+        XCTAssertEqual(PSQLFrontendMessage.ID.describe.rawValue, byteBuffer.readInteger(as: UInt8.self))
         XCTAssertEqual(11, byteBuffer.readInteger(as: Int32.self))
         XCTAssertEqual(UInt8(ascii: "P"), byteBuffer.readInteger(as: UInt8.self))
         XCTAssertEqual("Hello", byteBuffer.readNullTerminatedString())
@@ -25,7 +25,7 @@ class DescribeTests: XCTestCase {
         XCTAssertNoThrow(try encoder.encode(data: message, out: &byteBuffer))
         
         XCTAssertEqual(byteBuffer.readableBytes, 7)
-        XCTAssertEqual(PSQLFrontendMessage.ID.describe.byte, byteBuffer.readInteger(as: UInt8.self))
+        XCTAssertEqual(PSQLFrontendMessage.ID.describe.rawValue, byteBuffer.readInteger(as: UInt8.self))
         XCTAssertEqual(6, byteBuffer.readInteger(as: Int32.self))
         XCTAssertEqual(UInt8(ascii: "S"), byteBuffer.readInteger(as: UInt8.self))
         XCTAssertEqual("", byteBuffer.readNullTerminatedString())

--- a/Tests/PostgresNIOTests/New/Messages/ExecuteTests.swift
+++ b/Tests/PostgresNIOTests/New/Messages/ExecuteTests.swift
@@ -11,7 +11,7 @@ class ExecuteTests: XCTestCase {
         XCTAssertNoThrow(try encoder.encode(data: message, out: &byteBuffer))
         
         XCTAssertEqual(byteBuffer.readableBytes, 10) // 1 (id) + 4 (length) + 1 (empty null terminated string) + 4 (count)
-        XCTAssertEqual(PSQLFrontendMessage.ID.execute.byte, byteBuffer.readInteger(as: UInt8.self))
+        XCTAssertEqual(PSQLFrontendMessage.ID.execute.rawValue, byteBuffer.readInteger(as: UInt8.self))
         XCTAssertEqual(9, byteBuffer.readInteger(as: Int32.self)) // length
         XCTAssertEqual("", byteBuffer.readNullTerminatedString())
         XCTAssertEqual(0, byteBuffer.readInteger(as: Int32.self))

--- a/Tests/PostgresNIOTests/New/Messages/ParseTests.swift
+++ b/Tests/PostgresNIOTests/New/Messages/ParseTests.swift
@@ -22,7 +22,7 @@ class ParseTests: XCTestCase {
         // + 1 query ()
         
         XCTAssertEqual(byteBuffer.readableBytes, length)
-        XCTAssertEqual(byteBuffer.readInteger(as: UInt8.self), PSQLFrontendMessage.ID.parse.byte)
+        XCTAssertEqual(byteBuffer.readInteger(as: UInt8.self), PSQLFrontendMessage.ID.parse.rawValue)
         XCTAssertEqual(byteBuffer.readInteger(as: Int32.self), Int32(length - 1))
         XCTAssertEqual(byteBuffer.readNullTerminatedString(), parse.preparedStatementName)
         XCTAssertEqual(byteBuffer.readNullTerminatedString(), parse.query)

--- a/Tests/PostgresNIOTests/New/Messages/PasswordTests.swift
+++ b/Tests/PostgresNIOTests/New/Messages/PasswordTests.swift
@@ -14,7 +14,7 @@ class PasswordTests: XCTestCase {
         let expectedLength = 41 // 1 (id) + 4 (length) + 35 (string) + 1 (null termination)
         
         XCTAssertEqual(byteBuffer.readableBytes, expectedLength)
-        XCTAssertEqual(byteBuffer.readInteger(as: UInt8.self), PSQLFrontendMessage.ID.password.byte)
+        XCTAssertEqual(byteBuffer.readInteger(as: UInt8.self), PSQLFrontendMessage.ID.password.rawValue)
         XCTAssertEqual(byteBuffer.readInteger(as: Int32.self), Int32(expectedLength - 1)) // length
         XCTAssertEqual(byteBuffer.readNullTerminatedString(), "md522d085ed8dc3377968dc1c1a40519a2a")
     }

--- a/Tests/PostgresNIOTests/New/Messages/SASLInitialResponseTests.swift
+++ b/Tests/PostgresNIOTests/New/Messages/SASLInitialResponseTests.swift
@@ -21,7 +21,7 @@ class SASLInitialResponseTests: XCTestCase {
         // + 8 initialData
         
         XCTAssertEqual(byteBuffer.readableBytes, length)
-        XCTAssertEqual(byteBuffer.readInteger(as: UInt8.self), PSQLFrontendMessage.ID.saslInitialResponse.byte)
+        XCTAssertEqual(byteBuffer.readInteger(as: UInt8.self), PSQLFrontendMessage.ID.saslInitialResponse.rawValue)
         XCTAssertEqual(byteBuffer.readInteger(as: Int32.self), Int32(length - 1))
         XCTAssertEqual(byteBuffer.readNullTerminatedString(), sasl.saslMechanism)
         XCTAssertEqual(byteBuffer.readInteger(as: Int32.self), Int32(sasl.initialData.count))
@@ -46,7 +46,7 @@ class SASLInitialResponseTests: XCTestCase {
         // + 0 initialData
         
         XCTAssertEqual(byteBuffer.readableBytes, length)
-        XCTAssertEqual(byteBuffer.readInteger(as: UInt8.self), PSQLFrontendMessage.ID.saslInitialResponse.byte)
+        XCTAssertEqual(byteBuffer.readInteger(as: UInt8.self), PSQLFrontendMessage.ID.saslInitialResponse.rawValue)
         XCTAssertEqual(byteBuffer.readInteger(as: Int32.self), Int32(length - 1))
         XCTAssertEqual(byteBuffer.readNullTerminatedString(), sasl.saslMechanism)
         XCTAssertEqual(byteBuffer.readInteger(as: Int32.self), Int32(-1))

--- a/Tests/PostgresNIOTests/New/Messages/SASLResponseTests.swift
+++ b/Tests/PostgresNIOTests/New/Messages/SASLResponseTests.swift
@@ -14,7 +14,7 @@ class SASLResponseTests: XCTestCase {
         let length: Int = 1 + 4 + (sasl.data.count)
         
         XCTAssertEqual(byteBuffer.readableBytes, length)
-        XCTAssertEqual(byteBuffer.readInteger(as: UInt8.self), PSQLFrontendMessage.ID.saslResponse.byte)
+        XCTAssertEqual(byteBuffer.readInteger(as: UInt8.self), PSQLFrontendMessage.ID.saslResponse.rawValue)
         XCTAssertEqual(byteBuffer.readInteger(as: Int32.self), Int32(length - 1))
         XCTAssertEqual(byteBuffer.readBytes(length: sasl.data.count), sasl.data)
         XCTAssertEqual(byteBuffer.readableBytes, 0)
@@ -30,7 +30,7 @@ class SASLResponseTests: XCTestCase {
         let length: Int = 1 + 4
         
         XCTAssertEqual(byteBuffer.readableBytes, length)
-        XCTAssertEqual(byteBuffer.readInteger(as: UInt8.self), PSQLFrontendMessage.ID.saslResponse.byte)
+        XCTAssertEqual(byteBuffer.readInteger(as: UInt8.self), PSQLFrontendMessage.ID.saslResponse.rawValue)
         XCTAssertEqual(byteBuffer.readInteger(as: Int32.self), Int32(length - 1))
         XCTAssertEqual(byteBuffer.readableBytes, 0)
     }

--- a/Tests/PostgresNIOTests/New/PSQLFrontendMessageTests.swift
+++ b/Tests/PostgresNIOTests/New/PSQLFrontendMessageTests.swift
@@ -7,17 +7,17 @@ class PSQLFrontendMessageTests: XCTestCase {
     // MARK: ID
     
     func testMessageIDs() {
-        XCTAssertEqual(PSQLFrontendMessage.ID.bind.byte, UInt8(ascii: "B"))
-        XCTAssertEqual(PSQLFrontendMessage.ID.close.byte, UInt8(ascii: "C"))
-        XCTAssertEqual(PSQLFrontendMessage.ID.describe.byte, UInt8(ascii: "D"))
-        XCTAssertEqual(PSQLFrontendMessage.ID.execute.byte, UInt8(ascii: "E"))
-        XCTAssertEqual(PSQLFrontendMessage.ID.flush.byte, UInt8(ascii: "H"))
-        XCTAssertEqual(PSQLFrontendMessage.ID.parse.byte, UInt8(ascii: "P"))
-        XCTAssertEqual(PSQLFrontendMessage.ID.password.byte, UInt8(ascii: "p"))
-        XCTAssertEqual(PSQLFrontendMessage.ID.saslInitialResponse.byte, UInt8(ascii: "p"))
-        XCTAssertEqual(PSQLFrontendMessage.ID.saslResponse.byte, UInt8(ascii: "p"))
-        XCTAssertEqual(PSQLFrontendMessage.ID.sync.byte, UInt8(ascii: "S"))
-        XCTAssertEqual(PSQLFrontendMessage.ID.terminate.byte, UInt8(ascii: "X"))
+        XCTAssertEqual(PSQLFrontendMessage.ID.bind.rawValue, UInt8(ascii: "B"))
+        XCTAssertEqual(PSQLFrontendMessage.ID.close.rawValue, UInt8(ascii: "C"))
+        XCTAssertEqual(PSQLFrontendMessage.ID.describe.rawValue, UInt8(ascii: "D"))
+        XCTAssertEqual(PSQLFrontendMessage.ID.execute.rawValue, UInt8(ascii: "E"))
+        XCTAssertEqual(PSQLFrontendMessage.ID.flush.rawValue, UInt8(ascii: "H"))
+        XCTAssertEqual(PSQLFrontendMessage.ID.parse.rawValue, UInt8(ascii: "P"))
+        XCTAssertEqual(PSQLFrontendMessage.ID.password.rawValue, UInt8(ascii: "p"))
+        XCTAssertEqual(PSQLFrontendMessage.ID.saslInitialResponse.rawValue, UInt8(ascii: "p"))
+        XCTAssertEqual(PSQLFrontendMessage.ID.saslResponse.rawValue, UInt8(ascii: "p"))
+        XCTAssertEqual(PSQLFrontendMessage.ID.sync.rawValue, UInt8(ascii: "S"))
+        XCTAssertEqual(PSQLFrontendMessage.ID.terminate.rawValue, UInt8(ascii: "X"))
     }
     
     // MARK: Encoder
@@ -28,7 +28,7 @@ class PSQLFrontendMessageTests: XCTestCase {
         XCTAssertNoThrow(try encoder.encode(data: .flush, out: &byteBuffer))
         
         XCTAssertEqual(byteBuffer.readableBytes, 5)
-        XCTAssertEqual(PSQLFrontendMessage.ID.flush.byte, byteBuffer.readInteger(as: UInt8.self))
+        XCTAssertEqual(PSQLFrontendMessage.ID.flush.rawValue, byteBuffer.readInteger(as: UInt8.self))
         XCTAssertEqual(4, byteBuffer.readInteger(as: Int32.self)) // payload length
     }
     
@@ -38,7 +38,7 @@ class PSQLFrontendMessageTests: XCTestCase {
         XCTAssertNoThrow(try encoder.encode(data: .sync, out: &byteBuffer))
         
         XCTAssertEqual(byteBuffer.readableBytes, 5)
-        XCTAssertEqual(PSQLFrontendMessage.ID.sync.byte, byteBuffer.readInteger(as: UInt8.self))
+        XCTAssertEqual(PSQLFrontendMessage.ID.sync.rawValue, byteBuffer.readInteger(as: UInt8.self))
         XCTAssertEqual(4, byteBuffer.readInteger(as: Int32.self)) // payload length
     }
     
@@ -48,7 +48,7 @@ class PSQLFrontendMessageTests: XCTestCase {
         XCTAssertNoThrow(try encoder.encode(data: .terminate, out: &byteBuffer))
         
         XCTAssertEqual(byteBuffer.readableBytes, 5)
-        XCTAssertEqual(PSQLFrontendMessage.ID.terminate.byte, byteBuffer.readInteger(as: UInt8.self))
+        XCTAssertEqual(PSQLFrontendMessage.ID.terminate.rawValue, byteBuffer.readInteger(as: UInt8.self))
         XCTAssertEqual(4, byteBuffer.readInteger(as: Int32.self)) // payload length
     }
 


### PR DESCRIPTION
### Motivation

We want to use the `NIOSingleStepByteToMessageDecoder` within the `PSQLChannelHandler` in the future. For this reason it is important that we will be able to decode PSQLFrontendMessages for tests in the future.

### Changes

- Rename protocol `PSQLFrontendMessagePayloadEncodable` to `PSQLMessagePayloadEncodable`
- `PSQLFrontendMessage.ID` is now `RawRepresentable`

### Result

Code that makes testing easier in the future.

Note: Please don't auto release this. Follow up prs incoming.