### PR TITLE
PSQLBackendMessageDecoder is a SingleStepDecoder

### DIFF
--- a/Sources/PostgresNIO/New/Messages/Authentication.swift
+++ b/Sources/PostgresNIO/New/Messages/Authentication.swift
@@ -16,7 +16,7 @@ extension PSQLBackendMessage {
         case saslFinal(data: ByteBuffer)
         
         static func decode(from buffer: inout ByteBuffer) throws -> Self {
-            try PSQLBackendMessage.ensureAtLeastNBytesRemaining(2, in: buffer)
+            try buffer.ensureAtLeastNBytesRemaining(2)
             
             // we have at least two bytes remaining, therefore we can force unwrap this read.
             let authID = buffer.readInteger(as: Int32.self)!
@@ -29,7 +29,7 @@ extension PSQLBackendMessage {
             case 3:
                 return .plaintext
             case 5:
-                try PSQLBackendMessage.ensureExactNBytesRemaining(4, in: buffer)
+                try buffer.ensureExactNBytesRemaining(4)
                 let salt1 = buffer.readInteger(as: UInt8.self)!
                 let salt2 = buffer.readInteger(as: UInt8.self)!
                 let salt3 = buffer.readInteger(as: UInt8.self)!
@@ -59,7 +59,7 @@ extension PSQLBackendMessage {
                 let data = buffer.readSlice(length: buffer.readableBytes)!
                 return .saslFinal(data: data)
             default:
-                throw PartialDecodingError.unexpectedValue(value: authID)
+                throw PSQLPartialDecodingError.unexpectedValue(value: authID)
             }
         }
         

--- a/Sources/PostgresNIO/New/Messages/BackendKeyData.swift
+++ b/Sources/PostgresNIO/New/Messages/BackendKeyData.swift
@@ -7,7 +7,7 @@ extension PSQLBackendMessage {
         let secretKey: Int32
         
         static func decode(from buffer: inout ByteBuffer) throws -> Self {
-            try PSQLBackendMessage.ensureExactNBytesRemaining(8, in: buffer)
+            try buffer.ensureExactNBytesRemaining(8)
             
             // We have verified the correct length before, this means we have exactly eight bytes
             // to read. If we have enough readable bytes, a read of Int32 should always succeed.

--- a/Sources/PostgresNIO/New/Messages/DataRow.swift
+++ b/Sources/PostgresNIO/New/Messages/DataRow.swift
@@ -7,14 +7,14 @@ extension PSQLBackendMessage {
         var columns: [ByteBuffer?]
         
         static func decode(from buffer: inout ByteBuffer) throws -> Self {
-            try PSQLBackendMessage.ensureAtLeastNBytesRemaining(2, in: buffer)
+            try buffer.ensureAtLeastNBytesRemaining(2)
             let columnCount = buffer.readInteger(as: Int16.self)!
             
             var result = [ByteBuffer?]()
             result.reserveCapacity(Int(columnCount))
             
             for _ in 0..<columnCount {
-                try PSQLBackendMessage.ensureAtLeastNBytesRemaining(2, in: buffer)
+                try buffer.ensureAtLeastNBytesRemaining(2)
                 let bufferLength = Int(buffer.readInteger(as: Int32.self)!)
                 
                 guard bufferLength >= 0 else {
@@ -22,7 +22,7 @@ extension PSQLBackendMessage {
                     continue
                 }
                 
-                try PSQLBackendMessage.ensureAtLeastNBytesRemaining(bufferLength, in: buffer)
+                try buffer.ensureAtLeastNBytesRemaining(bufferLength)
                 let columnBuffer = buffer.readSlice(length: Int(bufferLength))!
                 
                 result.append(columnBuffer)

--- a/Sources/PostgresNIO/New/Messages/ErrorResponse.swift
+++ b/Sources/PostgresNIO/New/Messages/ErrorResponse.swift
@@ -112,13 +112,13 @@ extension PSQLBackendMessage.PayloadDecodable where Self: PSQLMessageNotice {
                 break
             }
             guard let field = PSQLBackendMessage.Field(rawValue: id) else {
-                throw PSQLBackendMessage.PartialDecodingError.valueNotRawRepresentable(
+                throw PSQLPartialDecodingError.valueNotRawRepresentable(
                     value: id,
                     asType: PSQLBackendMessage.Field.self)
             }
             
             guard let string = buffer.readNullTerminatedString() else {
-                throw PSQLBackendMessage.PartialDecodingError.fieldNotDecodable(type: String.self)
+                throw PSQLPartialDecodingError.fieldNotDecodable(type: String.self)
             }
             fields[field] = string
         }

--- a/Sources/PostgresNIO/New/Messages/NotificationResponse.swift
+++ b/Sources/PostgresNIO/New/Messages/NotificationResponse.swift
@@ -8,14 +8,14 @@ extension PSQLBackendMessage {
         let payload: String
         
         static func decode(from buffer: inout ByteBuffer) throws -> PSQLBackendMessage.NotificationResponse {
-            try PSQLBackendMessage.ensureAtLeastNBytesRemaining(6, in: buffer)
+            try buffer.ensureAtLeastNBytesRemaining(6)
             let backendPID = buffer.readInteger(as: Int32.self)!
             
             guard let channel = buffer.readNullTerminatedString() else {
-                throw PartialDecodingError.fieldNotDecodable(type: String.self)
+                throw PSQLPartialDecodingError.fieldNotDecodable(type: String.self)
             }
             guard let payload = buffer.readNullTerminatedString() else {
-                throw PartialDecodingError.fieldNotDecodable(type: String.self)
+                throw PSQLPartialDecodingError.fieldNotDecodable(type: String.self)
             }
             
             return NotificationResponse(backendPID: backendPID, channel: channel, payload: payload)

--- a/Sources/PostgresNIO/New/Messages/ParameterDescription.swift
+++ b/Sources/PostgresNIO/New/Messages/ParameterDescription.swift
@@ -7,14 +7,14 @@ extension PSQLBackendMessage {
         var dataTypes: [PSQLDataType]
         
         static func decode(from buffer: inout ByteBuffer) throws -> Self {
-            try PSQLBackendMessage.ensureAtLeastNBytesRemaining(2, in: buffer)
+            try buffer.ensureAtLeastNBytesRemaining(2)
             
             let parameterCount = buffer.readInteger(as: Int16.self)!
             guard parameterCount >= 0 else {
-                throw PartialDecodingError.integerMustBePositiveOrNull(parameterCount)
+                throw PSQLPartialDecodingError.integerMustBePositiveOrNull(parameterCount)
             }
             
-            try PSQLBackendMessage.ensureExactNBytesRemaining(Int(parameterCount) * 4, in: buffer)
+            try buffer.ensureExactNBytesRemaining(Int(parameterCount) * 4)
             
             var result = [PSQLDataType]()
             result.reserveCapacity(Int(parameterCount))

--- a/Sources/PostgresNIO/New/Messages/ParameterStatus.swift
+++ b/Sources/PostgresNIO/New/Messages/ParameterStatus.swift
@@ -11,11 +11,11 @@ extension PSQLBackendMessage {
         
         static func decode(from buffer: inout ByteBuffer) throws -> Self {            
             guard let name = buffer.readNullTerminatedString() else {
-                throw PartialDecodingError.fieldNotDecodable(type: String.self)
+                throw PSQLPartialDecodingError.fieldNotDecodable(type: String.self)
             }
             
             guard let value = buffer.readNullTerminatedString() else {
-                throw PartialDecodingError.fieldNotDecodable(type: String.self)
+                throw PSQLPartialDecodingError.fieldNotDecodable(type: String.self)
             }
             
             return ParameterStatus(parameter: name, value: value)

--- a/Sources/PostgresNIO/New/Messages/ReadyForQuery.swift
+++ b/Sources/PostgresNIO/New/Messages/ReadyForQuery.swift
@@ -33,14 +33,12 @@ extension PSQLBackendMessage {
         }
         
         static func decode(from buffer: inout ByteBuffer) throws -> Self {
-            guard buffer.readableBytes == 1 else {
-                throw PartialDecodingError.expectedExactlyNRemainingBytes(1, actual: buffer.readableBytes)
-            }
+            try buffer.ensureExactNBytesRemaining(1)
             
             // Exactly one byte is readable. For this reason, we can force unwrap the UInt8 below
             let value = buffer.readInteger(as: UInt8.self)!
             guard let state = Self.init(rawValue: value) else {
-                throw PartialDecodingError.valueNotRawRepresentable(value: value, asType: TransactionState.self)
+                throw PSQLPartialDecodingError.valueNotRawRepresentable(value: value, asType: TransactionState.self)
             }
             
             return state

--- a/Sources/PostgresNIO/New/Messages/RowDescription.swift
+++ b/Sources/PostgresNIO/New/Messages/RowDescription.swift
@@ -31,11 +31,11 @@ extension PSQLBackendMessage {
         }
         
         static func decode(from buffer: inout ByteBuffer) throws -> Self {
-            try PSQLBackendMessage.ensureAtLeastNBytesRemaining(2, in: buffer)
+            try buffer.ensureAtLeastNBytesRemaining(2)
             let columnCount = buffer.readInteger(as: Int16.self)!
             
             guard columnCount >= 0 else {
-                throw PartialDecodingError.integerMustBePositiveOrNull(columnCount)
+                throw PSQLPartialDecodingError.integerMustBePositiveOrNull(columnCount)
             }
             
             var result = [Column]()
@@ -43,10 +43,10 @@ extension PSQLBackendMessage {
             
             for _ in 0..<columnCount {
                 guard let name = buffer.readNullTerminatedString() else {
-                    throw PartialDecodingError.fieldNotDecodable(type: String.self)
+                    throw PSQLPartialDecodingError.fieldNotDecodable(type: String.self)
                 }
                 
-                try PSQLBackendMessage.ensureAtLeastNBytesRemaining(18, in: buffer)
+                try buffer.ensureAtLeastNBytesRemaining(18)
                 
                 let tableOID = buffer.readInteger(as: Int32.self)!
                 let columnAttributeNumber = buffer.readInteger(as: Int16.self)!
@@ -56,7 +56,7 @@ extension PSQLBackendMessage {
                 let formatCodeInt16 = buffer.readInteger(as: Int16.self)!
                 
                 guard let format = PSQLFormat(rawValue: formatCodeInt16) else {
-                    throw PartialDecodingError.valueNotRawRepresentable(value: formatCodeInt16, asType: PSQLFormat.self)
+                    throw PSQLPartialDecodingError.valueNotRawRepresentable(value: formatCodeInt16, asType: PSQLFormat.self)
                 }
                 
                 let field = Column(

--- a/Sources/PostgresNIO/New/PSQLBackendMessageDecoder.swift
+++ b/Sources/PostgresNIO/New/PSQLBackendMessageDecoder.swift
@@ -1,0 +1,207 @@
+struct PSQLBackendMessageDecoder: NIOSingleStepByteToMessageDecoder {
+    typealias InboundOut = PSQLBackendMessage
+    
+    private(set) var hasAlreadyReceivedBytes: Bool
+    
+    init(hasAlreadyReceivedBytes: Bool = false) {
+        self.hasAlreadyReceivedBytes = hasAlreadyReceivedBytes
+    }
+    
+    mutating func decode(buffer: inout ByteBuffer) throws -> PSQLBackendMessage? {
+        // make sure we have at least one byte to read
+        guard buffer.readableBytes > 0 else {
+            return nil
+        }
+        
+        if !self.hasAlreadyReceivedBytes {
+            // We have not received any bytes yet! Let's peek at the first message id. If it
+            // is a "S" or "N" we assume that it is connected to an SSL upgrade request. All
+            // other messages that we expect now, don't start with either "S" or "N"
+            
+            // we made sure, we have at least one byte available, above, thus force unwrap is okay
+            let firstByte = buffer.getInteger(at: buffer.readerIndex, as: UInt8.self)!
+            
+            switch firstByte {
+            case UInt8(ascii: "S"):
+                // mark byte as read
+                buffer.moveReaderIndex(forwardBy: 1)
+                self.hasAlreadyReceivedBytes = true
+                return .sslSupported
+            case UInt8(ascii: "N"):
+                // mark byte as read
+                buffer.moveReaderIndex(forwardBy: 1)
+                self.hasAlreadyReceivedBytes = true
+                return .sslUnsupported
+            default:
+                self.hasAlreadyReceivedBytes = true
+            }
+        }
+        
+        // all other packages have an Int32 after the identifier that determines their length.
+        // do we have enough bytes for that?
+        guard buffer.readableBytes >= 5 else {
+            return nil
+        }
+        
+        let idByte = buffer.getInteger(at: buffer.readerIndex, as: UInt8.self)!
+        let length = buffer.getInteger(at: buffer.readerIndex + 1, as: Int32.self)!
+        
+        guard length + 1 <= buffer.readableBytes else {
+            return nil
+        }
+        
+        // At this point we are sure, that we have enough bytes to decode the next message.
+        // 1. Create a byteBuffer that represents exactly the next message. This can be force
+        //    unwrapped, since it was verified that enough bytes are available.
+        let completeMessageBuffer = buffer.readSlice(length: 1 + Int(length))!
+        
+        // 2. make sure we have a known message identifier
+        guard let messageID = PSQLBackendMessage.ID(rawValue: idByte) else {
+            throw PSQLDecodingError.unknownMessageIDReceived(messageID: idByte, messageBytes: completeMessageBuffer)
+        }
+        
+        // 3. decode the message
+        do {
+            // get a mutable byteBuffer copy
+            var slice = completeMessageBuffer
+            // move reader index forward by five bytes
+            slice.moveReaderIndex(forwardBy: 5)
+            
+            return try PSQLBackendMessage.decode(from: &slice, for: messageID)
+        } catch let error as PSQLPartialDecodingError {
+            throw PSQLDecodingError.withPartialError(error, messageID: messageID, messageBytes: completeMessageBuffer)
+        } catch {
+            preconditionFailure("Expected to only see `PartialDecodingError`s here.")
+        }
+    }
+    
+    mutating func decodeLast(buffer: inout ByteBuffer, seenEOF: Bool) throws -> PSQLBackendMessage? {
+        try self.decode(buffer: &buffer)
+    }
+}
+
+
+    
+/// An error representing a failure to decode [a Postgres wire message](https://www.postgresql.org/docs/13/protocol-message-formats.html)
+/// to the Swift structure `PSQLBackendMessage`.
+///
+/// If you encounter a `DecodingError` when using a trusted Postgres server please make to file an issue at:
+/// [https://github.com/vapor/postgres-nio/issues](https://github.com/vapor/postgres-nio/issues)
+struct PSQLDecodingError: Error {
+    
+    /// The backend message ID bytes
+    let messageID: UInt8
+    
+    /// The backend message's payload encoded in base64
+    let payload: String
+    
+    /// A textual description of the error
+    let description: String
+    
+    /// The file this error was thrown in
+    let file: String
+    
+    /// The line in `file` this error was thrown
+    let line: Int
+    
+    static func withPartialError(
+        _ partialError: PSQLPartialDecodingError,
+        messageID: PSQLBackendMessage.ID,
+        messageBytes: ByteBuffer) -> Self
+    {
+        var byteBuffer = messageBytes
+        let data = byteBuffer.readData(length: byteBuffer.readableBytes)!
+        
+        return PSQLDecodingError(
+            messageID: messageID.rawValue,
+            payload: data.base64EncodedString(),
+            description: partialError.description,
+            file: partialError.file,
+            line: partialError.line)
+    }
+    
+    static func unknownMessageIDReceived(
+        messageID: UInt8,
+        messageBytes: ByteBuffer,
+        file: String = #file,
+        line: Int = #line) -> Self
+    {
+        var byteBuffer = messageBytes
+        let data = byteBuffer.readData(length: byteBuffer.readableBytes)!
+        
+        return PSQLDecodingError(
+            messageID: messageID,
+            payload: data.base64EncodedString(),
+            description: "Received a message with messageID '\(Character(UnicodeScalar(messageID)))'. There is no message type associated with this message identifier.",
+            file: file,
+            line: line)
+    }
+    
+}
+
+struct PSQLPartialDecodingError: Error {
+    /// A textual description of the error
+    let description: String
+    
+    /// The file this error was thrown in
+    let file: String
+    
+    /// The line in `file` this error was thrown
+    let line: Int
+    
+    static func valueNotRawRepresentable<Target: RawRepresentable>(
+        value: Target.RawValue,
+        asType: Target.Type,
+        file: String = #file,
+        line: Int = #line) -> Self
+    {
+        return PSQLPartialDecodingError(
+            description: "Can not represent '\(value)' with type '\(asType)'.",
+            file: file, line: line)
+    }
+    
+    static func unexpectedValue(value: Any, file: String = #file, line: Int = #line) -> Self {
+        return PSQLPartialDecodingError(
+            description: "Value '\(value)' is not expected.",
+            file: file, line: line)
+    }
+    
+    static func expectedAtLeastNRemainingBytes(_ expected: Int, actual: Int, file: String = #file, line: Int = #line) -> Self {
+        return PSQLPartialDecodingError(
+            description: "Expected at least '\(expected)' remaining bytes. But only found \(actual).",
+            file: file, line: line)
+    }
+    
+    static func expectedExactlyNRemainingBytes(_ expected: Int, actual: Int, file: String = #file, line: Int = #line) -> Self {
+        return PSQLPartialDecodingError(
+            description: "Expected exactly '\(expected)' remaining bytes. But found \(actual).",
+            file: file, line: line)
+    }
+    
+    static func fieldNotDecodable(type: Any.Type, file: String = #file, line: Int = #line) -> Self {
+        return PSQLPartialDecodingError(
+            description: "Could not read '\(type)' from ByteBuffer.",
+            file: file, line: line)
+    }
+    
+    static func integerMustBePositiveOrNull<Number: FixedWidthInteger>(_ actual: Number, file: String = #file, line: Int = #line) -> Self {
+        return PSQLPartialDecodingError(
+            description: "Expected the integer to be positive or null, but got \(actual).",
+            file: file, line: line)
+    }
+}
+
+extension ByteBuffer {
+    func ensureAtLeastNBytesRemaining(_ n: Int, file: String = #file, line: Int = #line) throws {
+        guard self.readableBytes >= n else {
+            throw PSQLPartialDecodingError.expectedAtLeastNRemainingBytes(2, actual: self.readableBytes, file: file, line: line)
+        }
+    }
+
+    func ensureExactNBytesRemaining(_ n: Int, file: String = #file, line: Int = #line) throws {
+        guard self.readableBytes == n else {
+            throw PSQLPartialDecodingError.expectedExactlyNRemainingBytes(n, actual: self.readableBytes, file: file, line: line)
+        }
+    }
+}
+

--- a/Sources/PostgresNIO/New/PSQLConnection.swift
+++ b/Sources/PostgresNIO/New/PSQLConnection.swift
@@ -214,7 +214,7 @@ final class PSQLConnection {
             }.flatMap { address -> EventLoopFuture<Channel> in
                 let bootstrap = ClientBootstrap(group: eventLoop)
                     .channelInitializer { channel in
-                        let decoder = ByteToMessageHandler(PSQLBackendMessage.Decoder())
+                        let decoder = ByteToMessageHandler(PSQLBackendMessageDecoder())
                         
                         var configureSSLCallback: ((Channel) throws -> ())? = nil
                         if let tlsConfiguration = configuration.tlsConfiguration {

--- a/Sources/PostgresNIO/New/PSQLError.swift
+++ b/Sources/PostgresNIO/New/PSQLError.swift
@@ -6,7 +6,7 @@ struct PSQLError: Error {
         case sslUnsupported
         case failedToAddSSLHandler(underlying: Error)
         case server(PSQLBackendMessage.ErrorResponse)
-        case decoding(PSQLBackendMessage.DecodingError)
+        case decoding(PSQLDecodingError)
         case unexpectedBackendMessage(PSQLBackendMessage)
         case unsupportedAuthMechanism(PSQLAuthScheme)
         case authMechanismRequiresPassword
@@ -39,7 +39,7 @@ struct PSQLError: Error {
         Self.init(.server(message))
     }
     
-    static func decoding(_ error: PSQLBackendMessage.DecodingError) -> PSQLError {
+    static func decoding(_ error: PSQLDecodingError) -> PSQLError {
         Self.init(.decoding(error))
     }
     

--- a/Tests/PostgresNIOTests/New/Messages/AuthenticationTests.swift
+++ b/Tests/PostgresNIOTests/New/Messages/AuthenticationTests.swift
@@ -58,6 +58,6 @@ class AuthenticationTests: XCTestCase {
         
         XCTAssertNoThrow(try ByteToMessageDecoderVerifier.verifyDecoder(
             inputOutputPairs: [(buffer, expected)],
-            decoderFactory: { PSQLBackendMessage.Decoder(hasAlreadyReceivedBytes: false) }))
+            decoderFactory: { PSQLBackendMessageDecoder(hasAlreadyReceivedBytes: false) }))
     }
 }

--- a/Tests/PostgresNIOTests/New/Messages/BackendKeyDataTests.swift
+++ b/Tests/PostgresNIOTests/New/Messages/BackendKeyDataTests.swift
@@ -16,7 +16,7 @@ class BackendKeyDataTests: XCTestCase {
         
         XCTAssertNoThrow(try ByteToMessageDecoderVerifier.verifyDecoder(
             inputOutputPairs: expectedInOuts,
-            decoderFactory: { PSQLBackendMessage.Decoder(hasAlreadyReceivedBytes: false) }))
+            decoderFactory: { PSQLBackendMessageDecoder(hasAlreadyReceivedBytes: false) }))
     }
     
     func testDecodeInvalidLength() {
@@ -32,8 +32,8 @@ class BackendKeyDataTests: XCTestCase {
         
         XCTAssertThrowsError(try ByteToMessageDecoderVerifier.verifyDecoder(
             inputOutputPairs: expected,
-            decoderFactory: { PSQLBackendMessage.Decoder(hasAlreadyReceivedBytes: false) })) {
-            XCTAssert($0 is PSQLBackendMessage.DecodingError)
+            decoderFactory: { PSQLBackendMessageDecoder(hasAlreadyReceivedBytes: false) })) {
+            XCTAssert($0 is PSQLDecodingError)
         }
     }
 }

--- a/Tests/PostgresNIOTests/New/Messages/DataRowTests.swift
+++ b/Tests/PostgresNIOTests/New/Messages/DataRowTests.swift
@@ -32,6 +32,6 @@ class DataRowTests: XCTestCase {
         
         XCTAssertNoThrow(try ByteToMessageDecoderVerifier.verifyDecoder(
             inputOutputPairs: expectedInOuts,
-            decoderFactory: { PSQLBackendMessage.Decoder(hasAlreadyReceivedBytes: false) }))
+            decoderFactory: { PSQLBackendMessageDecoder(hasAlreadyReceivedBytes: false) }))
     }
 }

--- a/Tests/PostgresNIOTests/New/Messages/ErrorResponseTests.swift
+++ b/Tests/PostgresNIOTests/New/Messages/ErrorResponseTests.swift
@@ -30,6 +30,6 @@ class ErrorResponseTests: XCTestCase {
         
         XCTAssertNoThrow(try ByteToMessageDecoderVerifier.verifyDecoder(
             inputOutputPairs: expectedInOuts,
-            decoderFactory: { PSQLBackendMessage.Decoder(hasAlreadyReceivedBytes: false) }))
+            decoderFactory: { PSQLBackendMessageDecoder(hasAlreadyReceivedBytes: false) }))
     }
 }

--- a/Tests/PostgresNIOTests/New/Messages/NotificationResponseTests.swift
+++ b/Tests/PostgresNIOTests/New/Messages/NotificationResponseTests.swift
@@ -27,7 +27,7 @@ class NotificationResponseTests: XCTestCase {
         
         XCTAssertNoThrow(try ByteToMessageDecoderVerifier.verifyDecoder(
             inputOutputPairs: [(buffer, expected)],
-            decoderFactory: { PSQLBackendMessage.Decoder(hasAlreadyReceivedBytes: true) }))
+            decoderFactory: { PSQLBackendMessageDecoder(hasAlreadyReceivedBytes: true) }))
     }
     
     func testDecodeFailureBecauseOfMissingNullTermination() {
@@ -40,8 +40,8 @@ class NotificationResponseTests: XCTestCase {
         
         XCTAssertThrowsError(try ByteToMessageDecoderVerifier.verifyDecoder(
             inputOutputPairs: [(buffer, [])],
-            decoderFactory: { PSQLBackendMessage.Decoder(hasAlreadyReceivedBytes: true) })) {
-            XCTAssert($0 is PSQLBackendMessage.DecodingError)
+            decoderFactory: { PSQLBackendMessageDecoder(hasAlreadyReceivedBytes: true) })) {
+            XCTAssert($0 is PSQLDecodingError)
         }
     }
     
@@ -55,8 +55,8 @@ class NotificationResponseTests: XCTestCase {
         
         XCTAssertThrowsError(try ByteToMessageDecoderVerifier.verifyDecoder(
             inputOutputPairs: [(buffer, [])],
-            decoderFactory: { PSQLBackendMessage.Decoder(hasAlreadyReceivedBytes: true) })) {
-            XCTAssert($0 is PSQLBackendMessage.DecodingError)
+            decoderFactory: { PSQLBackendMessageDecoder(hasAlreadyReceivedBytes: true) })) {
+            XCTAssert($0 is PSQLDecodingError)
         }
     }
 }

--- a/Tests/PostgresNIOTests/New/Messages/ParameterDescriptionTests.swift
+++ b/Tests/PostgresNIOTests/New/Messages/ParameterDescriptionTests.swift
@@ -27,7 +27,7 @@ class ParameterDescriptionTests: XCTestCase {
         
         XCTAssertNoThrow(try ByteToMessageDecoderVerifier.verifyDecoder(
             inputOutputPairs: [(buffer, expected)],
-            decoderFactory: { PSQLBackendMessage.Decoder(hasAlreadyReceivedBytes: true) }))
+            decoderFactory: { PSQLBackendMessageDecoder(hasAlreadyReceivedBytes: true) }))
     }
     
     func testDecodeWithNegativeCount() {
@@ -43,8 +43,8 @@ class ParameterDescriptionTests: XCTestCase {
         
         XCTAssertThrowsError(try ByteToMessageDecoderVerifier.verifyDecoder(
             inputOutputPairs: [(buffer, [])],
-            decoderFactory: { PSQLBackendMessage.Decoder(hasAlreadyReceivedBytes: true) })) {
-            XCTAssert($0 is PSQLBackendMessage.DecodingError)
+            decoderFactory: { PSQLBackendMessageDecoder(hasAlreadyReceivedBytes: true) })) {
+            XCTAssert($0 is PSQLDecodingError)
         }
     }
     
@@ -62,8 +62,8 @@ class ParameterDescriptionTests: XCTestCase {
         
         XCTAssertThrowsError(try ByteToMessageDecoderVerifier.verifyDecoder(
             inputOutputPairs: [(buffer, [])],
-            decoderFactory: { PSQLBackendMessage.Decoder(hasAlreadyReceivedBytes: true) })) {
-            XCTAssert($0 is PSQLBackendMessage.DecodingError)
+            decoderFactory: { PSQLBackendMessageDecoder(hasAlreadyReceivedBytes: true) })) {
+            XCTAssert($0 is PSQLDecodingError)
         }
     }
 }

--- a/Tests/PostgresNIOTests/New/Messages/ParameterStatusTests.swift
+++ b/Tests/PostgresNIOTests/New/Messages/ParameterStatusTests.swift
@@ -42,7 +42,7 @@ class ParameterStatusTests: XCTestCase {
         
         XCTAssertNoThrow(try ByteToMessageDecoderVerifier.verifyDecoder(
             inputOutputPairs: [(buffer, expected)],
-            decoderFactory: { PSQLBackendMessage.Decoder(hasAlreadyReceivedBytes: true) }))
+            decoderFactory: { PSQLBackendMessageDecoder(hasAlreadyReceivedBytes: true) }))
     }
     
     func testDecodeFailureBecauseOfMissingNullTermination() {
@@ -54,8 +54,8 @@ class ParameterStatusTests: XCTestCase {
         
         XCTAssertThrowsError(try ByteToMessageDecoderVerifier.verifyDecoder(
             inputOutputPairs: [(buffer, [])],
-            decoderFactory: { PSQLBackendMessage.Decoder(hasAlreadyReceivedBytes: true) })) {
-            XCTAssert($0 is PSQLBackendMessage.DecodingError)
+            decoderFactory: { PSQLBackendMessageDecoder(hasAlreadyReceivedBytes: true) })) {
+            XCTAssert($0 is PSQLDecodingError)
         }
     }
     
@@ -68,8 +68,8 @@ class ParameterStatusTests: XCTestCase {
         
         XCTAssertThrowsError(try ByteToMessageDecoderVerifier.verifyDecoder(
             inputOutputPairs: [(buffer, [])],
-            decoderFactory: { PSQLBackendMessage.Decoder(hasAlreadyReceivedBytes: true) })) {
-            XCTAssert($0 is PSQLBackendMessage.DecodingError)
+            decoderFactory: { PSQLBackendMessageDecoder(hasAlreadyReceivedBytes: true) })) {
+            XCTAssert($0 is PSQLDecodingError)
         }
     }
 }

--- a/Tests/PostgresNIOTests/New/Messages/ReadyForQueryTests.swift
+++ b/Tests/PostgresNIOTests/New/Messages/ReadyForQueryTests.swift
@@ -33,7 +33,7 @@ class ReadyForQueryTests: XCTestCase {
         
         XCTAssertNoThrow(try ByteToMessageDecoderVerifier.verifyDecoder(
             inputOutputPairs: [(buffer, expected)],
-            decoderFactory: { PSQLBackendMessage.Decoder(hasAlreadyReceivedBytes: true) }))
+            decoderFactory: { PSQLBackendMessageDecoder(hasAlreadyReceivedBytes: true) }))
 
     }
     
@@ -47,8 +47,8 @@ class ReadyForQueryTests: XCTestCase {
         
         XCTAssertThrowsError(try ByteToMessageDecoderVerifier.verifyDecoder(
             inputOutputPairs: [(buffer, [])],
-            decoderFactory: { PSQLBackendMessage.Decoder(hasAlreadyReceivedBytes: true) })) {
-            XCTAssert($0 is PSQLBackendMessage.DecodingError)
+            decoderFactory: { PSQLBackendMessageDecoder(hasAlreadyReceivedBytes: true) })) {
+            XCTAssert($0 is PSQLDecodingError)
         }
     }
     
@@ -61,8 +61,8 @@ class ReadyForQueryTests: XCTestCase {
         
         XCTAssertThrowsError(try ByteToMessageDecoderVerifier.verifyDecoder(
             inputOutputPairs: [(buffer, [])],
-            decoderFactory: { PSQLBackendMessage.Decoder(hasAlreadyReceivedBytes: true) })) {
-            XCTAssert($0 is PSQLBackendMessage.DecodingError)
+            decoderFactory: { PSQLBackendMessageDecoder(hasAlreadyReceivedBytes: true) })) {
+            XCTAssert($0 is PSQLDecodingError)
         }
     }
     

--- a/Tests/PostgresNIOTests/New/Messages/RowDescriptionTests.swift
+++ b/Tests/PostgresNIOTests/New/Messages/RowDescriptionTests.swift
@@ -38,7 +38,7 @@ class RowDescriptionTests: XCTestCase {
         
         XCTAssertNoThrow(try ByteToMessageDecoderVerifier.verifyDecoder(
             inputOutputPairs: [(buffer, expected)],
-            decoderFactory: { PSQLBackendMessage.Decoder(hasAlreadyReceivedBytes: true) }))
+            decoderFactory: { PSQLBackendMessageDecoder(hasAlreadyReceivedBytes: true) }))
     }
     
     func testDecodeFailureBecauseOfMissingNullTerminationInColumnName() {
@@ -59,8 +59,8 @@ class RowDescriptionTests: XCTestCase {
         
         XCTAssertThrowsError(try ByteToMessageDecoderVerifier.verifyDecoder(
             inputOutputPairs: [(buffer, [])],
-            decoderFactory: { PSQLBackendMessage.Decoder(hasAlreadyReceivedBytes: true) })) {
-            XCTAssert($0 is PSQLBackendMessage.DecodingError)
+            decoderFactory: { PSQLBackendMessageDecoder(hasAlreadyReceivedBytes: true) })) {
+            XCTAssert($0 is PSQLDecodingError)
         }
     }
     
@@ -81,8 +81,8 @@ class RowDescriptionTests: XCTestCase {
         
         XCTAssertThrowsError(try ByteToMessageDecoderVerifier.verifyDecoder(
             inputOutputPairs: [(buffer, [])],
-            decoderFactory: { PSQLBackendMessage.Decoder(hasAlreadyReceivedBytes: true) })) {
-            XCTAssert($0 is PSQLBackendMessage.DecodingError)
+            decoderFactory: { PSQLBackendMessageDecoder(hasAlreadyReceivedBytes: true) })) {
+            XCTAssert($0 is PSQLDecodingError)
         }
     }
     
@@ -104,8 +104,8 @@ class RowDescriptionTests: XCTestCase {
         
         XCTAssertThrowsError(try ByteToMessageDecoderVerifier.verifyDecoder(
             inputOutputPairs: [(buffer, [])],
-            decoderFactory: { PSQLBackendMessage.Decoder(hasAlreadyReceivedBytes: true) })) {
-            XCTAssert($0 is PSQLBackendMessage.DecodingError)
+            decoderFactory: { PSQLBackendMessageDecoder(hasAlreadyReceivedBytes: true) })) {
+            XCTAssert($0 is PSQLDecodingError)
         }
     }
     
@@ -127,8 +127,8 @@ class RowDescriptionTests: XCTestCase {
         
         XCTAssertThrowsError(try ByteToMessageDecoderVerifier.verifyDecoder(
             inputOutputPairs: [(buffer, [])],
-            decoderFactory: { PSQLBackendMessage.Decoder(hasAlreadyReceivedBytes: true) })) {
-            XCTAssert($0 is PSQLBackendMessage.DecodingError)
+            decoderFactory: { PSQLBackendMessageDecoder(hasAlreadyReceivedBytes: true) })) {
+            XCTAssert($0 is PSQLDecodingError)
         }
     }
 

--- a/Tests/PostgresNIOTests/New/PSQLBackendMessageTests.swift
+++ b/Tests/PostgresNIOTests/New/PSQLBackendMessageTests.swift
@@ -97,7 +97,7 @@ class PSQLBackendMessageTests: XCTestCase {
             expectedMessages.append(.parameterStatus(parameterStatus))
         }
         
-        let handler = ByteToMessageHandler(PSQLBackendMessage.Decoder())
+        let handler = ByteToMessageHandler(PSQLBackendMessageDecoder())
         let embedded = EmbeddedChannel(handler: handler)
         XCTAssertNoThrow(try embedded.writeInbound(buffer))
         
@@ -137,7 +137,7 @@ class PSQLBackendMessageTests: XCTestCase {
             buffer.writeInteger(0, as: UInt8.self) // signal done
         }
         
-        let handler = ByteToMessageHandler(PSQLBackendMessage.Decoder())
+        let handler = ByteToMessageHandler(PSQLBackendMessageDecoder())
         let embedded = EmbeddedChannel(handler: handler)
         XCTAssertNoThrow(try embedded.writeInbound(buffer))
         
@@ -174,7 +174,7 @@ class PSQLBackendMessageTests: XCTestCase {
         
         XCTAssertNoThrow(try ByteToMessageDecoderVerifier.verifyDecoder(
             inputOutputPairs: [(buffer, expected)],
-            decoderFactory: { PSQLBackendMessage.Decoder(hasAlreadyReceivedBytes: false) }))
+            decoderFactory: { PSQLBackendMessageDecoder(hasAlreadyReceivedBytes: false) }))
     }
     
     func testPayloadsWithoutAssociatedValuesInvalidLength() {
@@ -195,8 +195,8 @@ class PSQLBackendMessageTests: XCTestCase {
             
             XCTAssertThrowsError(try ByteToMessageDecoderVerifier.verifyDecoder(
                 inputOutputPairs: [(buffer, [])],
-                decoderFactory: { PSQLBackendMessage.Decoder(hasAlreadyReceivedBytes: false) })) {
-                XCTAssert($0 is PSQLBackendMessage.DecodingError)
+                decoderFactory: { PSQLBackendMessageDecoder(hasAlreadyReceivedBytes: false) })) {
+                XCTAssert($0 is PSQLDecodingError)
             }
         }
     }
@@ -222,7 +222,7 @@ class PSQLBackendMessageTests: XCTestCase {
         
         XCTAssertNoThrow(try ByteToMessageDecoderVerifier.verifyDecoder(
             inputOutputPairs: [(okBuffer, expected)],
-            decoderFactory: { PSQLBackendMessage.Decoder(hasAlreadyReceivedBytes: false) }))
+            decoderFactory: { PSQLBackendMessageDecoder(hasAlreadyReceivedBytes: false) }))
         
         // test commandTag is not null terminated
         for message in expected {
@@ -237,8 +237,8 @@ class PSQLBackendMessageTests: XCTestCase {
             
             XCTAssertThrowsError(try ByteToMessageDecoderVerifier.verifyDecoder(
                 inputOutputPairs: [(failBuffer, [])],
-                decoderFactory: { PSQLBackendMessage.Decoder(hasAlreadyReceivedBytes: false) })) {
-                XCTAssert($0 is PSQLBackendMessage.DecodingError)
+                decoderFactory: { PSQLBackendMessageDecoder(hasAlreadyReceivedBytes: false) })) {
+                XCTAssert($0 is PSQLDecodingError)
             }
         }
     }
@@ -250,8 +250,8 @@ class PSQLBackendMessageTests: XCTestCase {
         
         XCTAssertThrowsError(try ByteToMessageDecoderVerifier.verifyDecoder(
             inputOutputPairs: [(buffer, [])],
-            decoderFactory: { PSQLBackendMessage.Decoder(hasAlreadyReceivedBytes: false) })) {
-            XCTAssert($0 is PSQLBackendMessage.DecodingError)
+            decoderFactory: { PSQLBackendMessageDecoder(hasAlreadyReceivedBytes: false) })) {
+            XCTAssert($0 is PSQLDecodingError)
         }
     }
     


### PR DESCRIPTION
### Motivation

We want to use the `PSQLBackendMessageDecoder` as `NIOSingleStepByteToMessageDecoder` in the future.

### Changes

- Rename `PSQLBackendMessage.Decoder` to `PSQLBackendMessageDecoder`. Namespacing the Decoder in its own MessageType was a stupid idea. Sorry. Reverting this now.
- `PSQLBackendMessageDecoder` get's its own file. Implementation copy and pasted.
- `PSQLBackendMessageDecoder` implements `NIOSingleStepByteToMessageDecoder` protocol, which has an auto-conformance to `ByteToMessageDecoder`
- Move `PSQLBackendMessage.ensureAtLeastNBytesRemaining` into an internal extension on `ByteBuffer`

### Result

- Cleaner, less clever code.

### Notes

- `PSQLBackendMessageDecoder` has a very high test code coverage. For this reason