### PR TITLE
Extract PSQLRow

### DIFF
--- a/Sources/PostgresNIO/Connection/PostgresConnection+Database.swift
+++ b/Sources/PostgresNIO/Connection/PostgresConnection+Database.swift
@@ -78,7 +78,7 @@ internal enum PostgresCommands: PostgresRequest {
     }
 }
 
-extension PSQLRows {
+extension PSQLRowStream {
     
     func iterateRowsWithoutBackpressureOption(lookupTable: PostgresRow.LookupTable, onRow: @escaping (PostgresRow) throws -> ()) -> EventLoopFuture<Void> {
         self.onRow { psqlRow in

--- a/Sources/PostgresNIO/Connection/PostgresConnection+Database.swift
+++ b/Sources/PostgresNIO/Connection/PostgresConnection+Database.swift
@@ -82,8 +82,8 @@ extension PSQLRows {
     
     func iterateRowsWithoutBackpressureOption(lookupTable: PostgresRow.LookupTable, onRow: @escaping (PostgresRow) throws -> ()) -> EventLoopFuture<Void> {
         self.onRow { psqlRow in
-            let columns = psqlRow.data.map { psqlData in
-                PostgresMessage.DataRow.Column(value: psqlData.bytes)
+            let columns = psqlRow.data.columns.map { bytes in
+                PostgresMessage.DataRow.Column(value: bytes)
             }
             
             let row = PostgresRow(dataRow: .init(columns: columns), lookupTable: lookupTable)

--- a/Sources/PostgresNIO/New/Connection State Machine/ConnectionStateMachine.swift
+++ b/Sources/PostgresNIO/New/Connection State Machine/ConnectionStateMachine.swift
@@ -92,12 +92,12 @@ struct ConnectionStateMachine {
         
         // --- streaming actions
         // actions if query has requested next row but we are waiting for backend
-        case forwardRow([PSQLData], to: EventLoopPromise<StateMachineStreamNextResult>)
-        case forwardCommandComplete(CircularBuffer<[PSQLData]>, commandTag: String, to: EventLoopPromise<StateMachineStreamNextResult>)
+        case forwardRow(PSQLBackendMessage.DataRow, to: EventLoopPromise<StateMachineStreamNextResult>)
+        case forwardCommandComplete(CircularBuffer<PSQLBackendMessage.DataRow>, commandTag: String, to: EventLoopPromise<StateMachineStreamNextResult>)
         case forwardStreamError(PSQLError, to: EventLoopPromise<StateMachineStreamNextResult>, cleanupContext: CleanUpContext?)
         // actions if query has not asked for next row but are pushing the final bytes to it
         case forwardStreamErrorToCurrentQuery(PSQLError, read: Bool, cleanupContext: CleanUpContext?)
-        case forwardStreamCompletedToCurrentQuery(CircularBuffer<[PSQLData]>, commandTag: String, read: Bool)
+        case forwardStreamCompletedToCurrentQuery(CircularBuffer<PSQLBackendMessage.DataRow>, commandTag: String, read: Bool)
         
         // Prepare statement actions
         case sendParseDescribeSync(name: String, query: String)
@@ -1106,10 +1106,10 @@ extension ConnectionStateMachine {
 
 enum StateMachineStreamNextResult {
     /// the next row
-    case row([PSQLData])
+    case row(PSQLBackendMessage.DataRow)
     
     /// the query has completed, all remaining rows and the command completion tag
-    case complete(CircularBuffer<[PSQLData]>, commandTag: String)
+    case complete(CircularBuffer<PSQLBackendMessage.DataRow>, commandTag: String)
 }
 
 struct SendPrepareStatement {

--- a/Sources/PostgresNIO/New/PSQLChannelHandler.swift
+++ b/Sources/PostgresNIO/New/PSQLChannelHandler.swift
@@ -458,7 +458,7 @@ final class PSQLChannelHandler: ChannelDuplexHandler {
             cancel: {
                 // ignore...
             }, next: {
-                let emptyBuffer = CircularBuffer<[PSQLData]>(initialCapacity: 0)
+                let emptyBuffer = CircularBuffer<PSQLBackendMessage.DataRow>(initialCapacity: 0)
                 return eventLoop.makeSucceededFuture(.complete(emptyBuffer, commandTag: commandTag))
             })
         queryContext.promise.succeed(rows)

--- a/Sources/PostgresNIO/New/PSQLChannelHandler.swift
+++ b/Sources/PostgresNIO/New/PSQLChannelHandler.swift
@@ -18,7 +18,7 @@ final class PSQLChannelHandler: ChannelDuplexHandler {
             self.logger.trace("Connection state changed", metadata: [.connectionState: "\(self.state)"])
         }
     }
-    private var currentQuery: PSQLRows?
+    private var currentQuery: PSQLRowStream?
     private let authentificationConfiguration: PSQLConnection.Configuration.Authentication?
     private let configureSSLCallback: ((Channel) throws -> Void)?
     
@@ -426,7 +426,7 @@ final class PSQLChannelHandler: ChannelDuplexHandler {
             self.run(action, with: context)
             return promise.futureResult
         }
-        let rows = PSQLRows(
+        let rows = PSQLRowStream(
             rowDescription: columns,
             queryContext: queryContext,
             eventLoop: context.channel.eventLoop,
@@ -451,7 +451,7 @@ final class PSQLChannelHandler: ChannelDuplexHandler {
         context: ChannelHandlerContext)
     {
         let eventLoop = context.channel.eventLoop
-        let rows = PSQLRows(
+        let rows = PSQLRowStream(
             rowDescription: [],
             queryContext: queryContext,
             eventLoop: context.channel.eventLoop,

--- a/Sources/PostgresNIO/New/PSQLConnection.swift
+++ b/Sources/PostgresNIO/New/PSQLConnection.swift
@@ -121,17 +121,17 @@ final class PSQLConnection {
     
     // MARK: Query
             
-    func query(_ query: String, logger: Logger) -> EventLoopFuture<PSQLRows> {
+    func query(_ query: String, logger: Logger) -> EventLoopFuture<PSQLRowStream> {
         self.query(query, [], logger: logger)
     }
     
-    func query(_ query: String, _ bind: [PSQLEncodable], logger: Logger) -> EventLoopFuture<PSQLRows> {
+    func query(_ query: String, _ bind: [PSQLEncodable], logger: Logger) -> EventLoopFuture<PSQLRowStream> {
         var logger = logger
         logger[postgresMetadataKey: .connectionID] = "\(self.connectionID)"
         guard bind.count <= Int(Int16.max) else {
             return self.channel.eventLoop.makeFailedFuture(PSQLError.tooManyParameters)
         }
-        let promise = self.channel.eventLoop.makePromise(of: PSQLRows.self)
+        let promise = self.channel.eventLoop.makePromise(of: PSQLRowStream.self)
         let context = ExtendedQueryContext(
             query: query,
             bind: bind,
@@ -161,12 +161,12 @@ final class PSQLConnection {
     }
     
     func execute(_ preparedStatement: PSQLPreparedStatement,
-                 _ bind: [PSQLEncodable], logger: Logger) -> EventLoopFuture<PSQLRows>
+                 _ bind: [PSQLEncodable], logger: Logger) -> EventLoopFuture<PSQLRowStream>
     {
         guard bind.count <= Int(Int16.max) else {
             return self.channel.eventLoop.makeFailedFuture(PSQLError.tooManyParameters)
         }
-        let promise = self.channel.eventLoop.makePromise(of: PSQLRows.self)
+        let promise = self.channel.eventLoop.makePromise(of: PSQLRowStream.self)
         let context = ExtendedQueryContext(
             preparedStatement: preparedStatement,
             bind: bind,

--- a/Sources/PostgresNIO/New/PSQLRow.swift
+++ b/Sources/PostgresNIO/New/PSQLRow.swift
@@ -1,0 +1,66 @@
+
+/// `PSQLRow` represents a single row that was received from the Postgres Server.
+struct PSQLRow {
+    internal let lookupTable: [String: Int]
+    internal let data: PSQLBackendMessage.DataRow
+    
+    internal let columns: [PSQLBackendMessage.RowDescription.Column]
+    internal let jsonDecoder: PSQLJSONDecoder
+    
+    internal init(data: PSQLBackendMessage.DataRow, lookupTable: [String: Int], columns: [PSQLBackendMessage.RowDescription.Column], jsonDecoder: PSQLJSONDecoder) {
+        self.data = data
+        self.lookupTable = lookupTable
+        self.columns = columns
+        self.jsonDecoder = jsonDecoder
+    }
+    
+    /// Access the raw Postgres data in the n-th column
+    subscript(index: Int) -> PSQLData {
+        PSQLData(bytes: self.data.columns[index], dataType: self.columns[index].dataType, format: self.columns[index].format)
+    }
+    
+    // TBD: Should this be optional?
+    /// Access the raw Postgres data in the column indentified by name
+    subscript(column columnName: String) -> PSQLData? {
+        guard let index = self.lookupTable[columnName] else {
+            return nil
+        }
+        
+        return self[index]
+    }
+    
+    /// Access the data in the provided column and decode it into the target type.
+    ///
+    /// - Parameters:
+    ///   - column: The column name to read the data from
+    ///   - type: The type to decode the data into
+    /// - Throws: The error of the decoding implementation. See also `PSQLDecodable` protocol for this.
+    /// - Returns: The decoded value of Type T.
+    func decode<T: PSQLDecodable>(column: String, as type: T.Type, file: String = #file, line: Int = #line) throws -> T {
+        guard let index = self.lookupTable[column] else {
+            preconditionFailure("A column '\(column)' does not exist.")
+        }
+        
+        return try self.decode(column: index, as: type, file: file, line: line)
+    }
+    
+    /// Access the data in the provided column and decode it into the target type.
+    ///
+    /// - Parameters:
+    ///   - column: The column index to read the data from
+    ///   - type: The type to decode the data into
+    /// - Throws: The error of the decoding implementation. See also `PSQLDecodable` protocol for this.
+    /// - Returns: The decoded value of Type T.
+    func decode<T: PSQLDecodable>(column index: Int, as type: T.Type, file: String = #file, line: Int = #line) throws -> T {
+        let column = self.columns[index]
+        
+        let decodingContext = PSQLDecodingContext(
+            jsonDecoder: jsonDecoder,
+            columnName: column.name,
+            columnIndex: index,
+            file: file,
+            line: line)
+        
+        return try self[index].decode(as: T.self, context: decodingContext)
+    }
+}

--- a/Sources/PostgresNIO/New/PSQLRowStream.swift
+++ b/Sources/PostgresNIO/New/PSQLRowStream.swift
@@ -1,7 +1,7 @@
 import NIOCore
 import Logging
 
-final class PSQLRows {
+final class PSQLRowStream {
     
     let eventLoop: EventLoop
     let logger: Logger

--- a/Sources/PostgresNIO/New/PSQLTask.swift
+++ b/Sources/PostgresNIO/New/PSQLTask.swift
@@ -29,13 +29,13 @@ final class ExtendedQueryContext {
     let logger: Logger
     
     let jsonDecoder: PSQLJSONDecoder
-    let promise: EventLoopPromise<PSQLRows>
+    let promise: EventLoopPromise<PSQLRowStream>
     
     init(query: String,
          bind: [PSQLEncodable],
          logger: Logger,
          jsonDecoder: PSQLJSONDecoder,
-         promise: EventLoopPromise<PSQLRows>)
+         promise: EventLoopPromise<PSQLRowStream>)
     {
         self.query = .unnamed(query)
         self.bind = bind
@@ -48,7 +48,7 @@ final class ExtendedQueryContext {
          bind: [PSQLEncodable],
          logger: Logger,
          jsonDecoder: PSQLJSONDecoder,
-         promise: EventLoopPromise<PSQLRows>)
+         promise: EventLoopPromise<PSQLRowStream>)
     {
         self.query = .preparedStatement(
             name: preparedStatement.name,

--- a/Tests/IntegrationTests/PSQLIntegrationTests.swift
+++ b/Tests/IntegrationTests/PSQLIntegrationTests.swift
@@ -54,7 +54,7 @@ final class IntegrationTests: XCTestCase {
         XCTAssertNoThrow(conn = try PSQLConnection.test(on: eventLoop).wait())
         defer { XCTAssertNoThrow(try conn?.close().wait()) }
         
-        var rows: PSQLRows?
+        var rows: PSQLRowStream?
         XCTAssertNoThrow(rows = try conn?.query("SELECT version()", logger: .psqlTest).wait())
         var row: PSQLRow?
         XCTAssertNoThrow(row = try rows?.next().wait())
@@ -73,7 +73,7 @@ final class IntegrationTests: XCTestCase {
         XCTAssertNoThrow(conn = try PSQLConnection.test(on: eventLoop).wait())
         defer { XCTAssertNoThrow(try conn?.close().wait()) }
         
-        var rows: PSQLRows?
+        var rows: PSQLRowStream?
         XCTAssertNoThrow(rows = try conn?.query("SELECT generate_series(1, 10000);", logger: .psqlTest).wait())
         
         var expected: Int64 = 1
@@ -109,7 +109,7 @@ final class IntegrationTests: XCTestCase {
         defer { XCTAssertNoThrow(try conn?.close().wait()) }
         
         for _ in 0..<1_000 {
-            var rows: PSQLRows?
+            var rows: PSQLRowStream?
             XCTAssertNoThrow(rows = try conn?.query("SELECT version()", logger: .psqlTest).wait())
             var row: PSQLRow?
             XCTAssertNoThrow(row = try rows?.next().wait())
@@ -129,7 +129,7 @@ final class IntegrationTests: XCTestCase {
         XCTAssertNoThrow(conn = try PSQLConnection.test(on: eventLoop).wait())
         defer { XCTAssertNoThrow(try conn?.close().wait()) }
         
-        var rows: PSQLRows?
+        var rows: PSQLRowStream?
         XCTAssertNoThrow(rows = try conn?.query("SELECT $1::TEXT as foo", ["hello"], logger: .psqlTest).wait())
         var row: PSQLRow?
         XCTAssertNoThrow(row = try rows?.next().wait())
@@ -148,7 +148,7 @@ final class IntegrationTests: XCTestCase {
         XCTAssertNoThrow(conn = try PSQLConnection.test(on: eventLoop).wait())
         defer { XCTAssertNoThrow(try conn?.close().wait()) }
         
-        var rows: PSQLRows?
+        var rows: PSQLRowStream?
         XCTAssertNoThrow(rows = try conn?.query("""
         SELECT
             1::SMALLINT                   as smallint,
@@ -187,7 +187,7 @@ final class IntegrationTests: XCTestCase {
         XCTAssertNoThrow(conn = try PSQLConnection.test(on: eventLoop).wait())
         defer { XCTAssertNoThrow(try conn?.close().wait()) }
         
-        var rows: PSQLRows?
+        var rows: PSQLRowStream?
         let array: [Int64] = [1, 2, 3]
         XCTAssertNoThrow(rows = try conn?.query("SELECT $1::int8[] as array", [array], logger: .psqlTest).wait())
         
@@ -207,7 +207,7 @@ final class IntegrationTests: XCTestCase {
         XCTAssertNoThrow(conn = try PSQLConnection.test(on: eventLoop).wait())
         defer { XCTAssertNoThrow(try conn?.close().wait()) }
         
-        var rows: PSQLRows?
+        var rows: PSQLRowStream?
         XCTAssertNoThrow(rows = try conn?.query("SELECT '{}'::int[] as array", logger: .psqlTest).wait())
         
         var row: PSQLRow?
@@ -226,7 +226,7 @@ final class IntegrationTests: XCTestCase {
         XCTAssertNoThrow(conn = try PSQLConnection.test(on: eventLoop).wait())
         defer { XCTAssertNoThrow(try conn?.close().wait()) }
         
-        var rows: PSQLRows?
+        var rows: PSQLRowStream?
         let doubles: [Double] = [3.14, 42]
         XCTAssertNoThrow(rows = try conn?.query("SELECT $1::double precision[] as doubles", [doubles], logger: .psqlTest).wait())
         
@@ -246,7 +246,7 @@ final class IntegrationTests: XCTestCase {
         XCTAssertNoThrow(conn = try PSQLConnection.test(on: eventLoop).wait())
         defer { XCTAssertNoThrow(try conn?.close().wait()) }
         
-        var rows: PSQLRows?
+        var rows: PSQLRowStream?
         XCTAssertNoThrow(rows = try conn?.query("""
             SELECT
                 '2016-01-18 01:02:03 +0042'::DATE         as date,
@@ -273,7 +273,7 @@ final class IntegrationTests: XCTestCase {
         XCTAssertNoThrow(conn = try PSQLConnection.test(on: eventLoop).wait())
         defer { XCTAssertNoThrow(try conn?.close().wait()) }
         
-        var rows: PSQLRows?
+        var rows: PSQLRowStream?
         XCTAssertNoThrow(rows = try conn?.query("""
             SELECT '2c68f645-9ca6-468b-b193-ee97f241c2f8'::UUID as uuid
             """, logger: .psqlTest).wait())
@@ -301,7 +301,7 @@ final class IntegrationTests: XCTestCase {
         defer { XCTAssertNoThrow(try conn?.close().wait()) }
         
         do {
-            var rows: PSQLRows?
+            var rows: PSQLRowStream?
             XCTAssertNoThrow(rows = try conn?.query("""
                 select $1::jsonb as jsonb
                 """, [Object(foo: 1, bar: 2)], logger: .psqlTest).wait())
@@ -317,7 +317,7 @@ final class IntegrationTests: XCTestCase {
         }
         
         do {
-            var rows: PSQLRows?
+            var rows: PSQLRowStream?
             XCTAssertNoThrow(rows = try conn?.query("""
                 select $1::json as json
                 """, [Object(foo: 1, bar: 2)], logger: .psqlTest).wait())

--- a/Tests/IntegrationTests/PSQLIntegrationTests.swift
+++ b/Tests/IntegrationTests/PSQLIntegrationTests.swift
@@ -54,14 +54,14 @@ final class IntegrationTests: XCTestCase {
         XCTAssertNoThrow(conn = try PSQLConnection.test(on: eventLoop).wait())
         defer { XCTAssertNoThrow(try conn?.close().wait()) }
         
-        var rows: PSQLRowStream?
-        XCTAssertNoThrow(rows = try conn?.query("SELECT version()", logger: .psqlTest).wait())
+        var stream: PSQLRowStream?
+        XCTAssertNoThrow(stream = try conn?.query("SELECT version()", logger: .psqlTest).wait())
         var row: PSQLRow?
-        XCTAssertNoThrow(row = try rows?.next().wait())
+        XCTAssertNoThrow(row = try stream?.next().wait())
         var version: String?
         XCTAssertNoThrow(version = try row?.decode(column: 0, as: String.self))
         XCTAssertEqual(version?.contains("PostgreSQL"), true)
-        XCTAssertNil(try rows?.next().wait())
+        XCTAssertNil(try stream?.next().wait())
     }
     
     func testQuery10kItems() {
@@ -73,12 +73,12 @@ final class IntegrationTests: XCTestCase {
         XCTAssertNoThrow(conn = try PSQLConnection.test(on: eventLoop).wait())
         defer { XCTAssertNoThrow(try conn?.close().wait()) }
         
-        var rows: PSQLRowStream?
-        XCTAssertNoThrow(rows = try conn?.query("SELECT generate_series(1, 10000);", logger: .psqlTest).wait())
+        var stream: PSQLRowStream?
+        XCTAssertNoThrow(stream = try conn?.query("SELECT generate_series(1, 10000);", logger: .psqlTest).wait())
         
         var expected: Int64 = 1
         
-        XCTAssertNoThrow(try rows?.onRow { row in
+        XCTAssertNoThrow(try stream?.onRow { row in
             let promise = eventLoop.makePromise(of: Void.self)
             
             func workaround() {
@@ -109,14 +109,14 @@ final class IntegrationTests: XCTestCase {
         defer { XCTAssertNoThrow(try conn?.close().wait()) }
         
         for _ in 0..<1_000 {
-            var rows: PSQLRowStream?
-            XCTAssertNoThrow(rows = try conn?.query("SELECT version()", logger: .psqlTest).wait())
+            var stream: PSQLRowStream?
+            XCTAssertNoThrow(stream = try conn?.query("SELECT version()", logger: .psqlTest).wait())
             var row: PSQLRow?
-            XCTAssertNoThrow(row = try rows?.next().wait())
+            XCTAssertNoThrow(row = try stream?.next().wait())
             var version: String?
             XCTAssertNoThrow(version = try row?.decode(column: 0, as: String.self))
             XCTAssertEqual(version?.contains("PostgreSQL"), true)
-            XCTAssertNil(try rows?.next().wait())
+            XCTAssertNil(try stream?.next().wait())
         }
     }
     
@@ -129,14 +129,14 @@ final class IntegrationTests: XCTestCase {
         XCTAssertNoThrow(conn = try PSQLConnection.test(on: eventLoop).wait())
         defer { XCTAssertNoThrow(try conn?.close().wait()) }
         
-        var rows: PSQLRowStream?
-        XCTAssertNoThrow(rows = try conn?.query("SELECT $1::TEXT as foo", ["hello"], logger: .psqlTest).wait())
+        var stream: PSQLRowStream?
+        XCTAssertNoThrow(stream = try conn?.query("SELECT $1::TEXT as foo", ["hello"], logger: .psqlTest).wait())
         var row: PSQLRow?
-        XCTAssertNoThrow(row = try rows?.next().wait())
+        XCTAssertNoThrow(row = try stream?.next().wait())
         var foo: String?
         XCTAssertNoThrow(foo = try row?.decode(column: 0, as: String.self))
         XCTAssertEqual(foo, "hello")
-        XCTAssertNil(try rows?.next().wait())
+        XCTAssertNil(try stream?.next().wait())
     }
     
     func testDecodeIntegers() {
@@ -148,8 +148,8 @@ final class IntegrationTests: XCTestCase {
         XCTAssertNoThrow(conn = try PSQLConnection.test(on: eventLoop).wait())
         defer { XCTAssertNoThrow(try conn?.close().wait()) }
         
-        var rows: PSQLRowStream?
-        XCTAssertNoThrow(rows = try conn?.query("""
+        var stream: PSQLRowStream?
+        XCTAssertNoThrow(stream = try conn?.query("""
         SELECT
             1::SMALLINT                   as smallint,
             -32767::SMALLINT              as smallint_min,
@@ -163,7 +163,7 @@ final class IntegrationTests: XCTestCase {
         """, logger: .psqlTest).wait())
         
         var row: PSQLRow?
-        XCTAssertNoThrow(row = try rows?.next().wait())
+        XCTAssertNoThrow(row = try stream?.next().wait())
         
         XCTAssertEqual(try row?.decode(column: "smallint", as: Int16.self), 1)
         XCTAssertEqual(try row?.decode(column: "smallint_min", as: Int16.self), -32_767)
@@ -175,7 +175,7 @@ final class IntegrationTests: XCTestCase {
         XCTAssertEqual(try row?.decode(column: "bigint_min", as: Int64.self), -9_223_372_036_854_775_807)
         XCTAssertEqual(try row?.decode(column: "bigint_max", as: Int64.self), 9_223_372_036_854_775_807)
         
-        XCTAssertNil(try rows?.next().wait())
+        XCTAssertNil(try stream?.next().wait())
     }
     
     func testEncodeAndDecodeIntArray() {
@@ -187,15 +187,15 @@ final class IntegrationTests: XCTestCase {
         XCTAssertNoThrow(conn = try PSQLConnection.test(on: eventLoop).wait())
         defer { XCTAssertNoThrow(try conn?.close().wait()) }
         
-        var rows: PSQLRowStream?
+        var stream: PSQLRowStream?
         let array: [Int64] = [1, 2, 3]
-        XCTAssertNoThrow(rows = try conn?.query("SELECT $1::int8[] as array", [array], logger: .psqlTest).wait())
+        XCTAssertNoThrow(stream = try conn?.query("SELECT $1::int8[] as array", [array], logger: .psqlTest).wait())
         
         var row: PSQLRow?
-        XCTAssertNoThrow(row = try rows?.next().wait())
+        XCTAssertNoThrow(row = try stream?.next().wait())
         
         XCTAssertEqual(try row?.decode(column: "array", as: [Int64].self), array)
-        XCTAssertNil(try rows?.next().wait())
+        XCTAssertNil(try stream?.next().wait())
     }
     
     func testDecodeEmptyIntegerArray() {
@@ -207,14 +207,14 @@ final class IntegrationTests: XCTestCase {
         XCTAssertNoThrow(conn = try PSQLConnection.test(on: eventLoop).wait())
         defer { XCTAssertNoThrow(try conn?.close().wait()) }
         
-        var rows: PSQLRowStream?
-        XCTAssertNoThrow(rows = try conn?.query("SELECT '{}'::int[] as array", logger: .psqlTest).wait())
+        var stream: PSQLRowStream?
+        XCTAssertNoThrow(stream = try conn?.query("SELECT '{}'::int[] as array", logger: .psqlTest).wait())
         
         var row: PSQLRow?
-        XCTAssertNoThrow(row = try rows?.next().wait())
+        XCTAssertNoThrow(row = try stream?.next().wait())
         
         XCTAssertEqual(try row?.decode(column: "array", as: [Int64].self), [])
-        XCTAssertNil(try rows?.next().wait())
+        XCTAssertNil(try stream?.next().wait())
     }
     
     func testDoubleArraySerialization() {
@@ -226,15 +226,15 @@ final class IntegrationTests: XCTestCase {
         XCTAssertNoThrow(conn = try PSQLConnection.test(on: eventLoop).wait())
         defer { XCTAssertNoThrow(try conn?.close().wait()) }
         
-        var rows: PSQLRowStream?
+        var stream: PSQLRowStream?
         let doubles: [Double] = [3.14, 42]
-        XCTAssertNoThrow(rows = try conn?.query("SELECT $1::double precision[] as doubles", [doubles], logger: .psqlTest).wait())
+        XCTAssertNoThrow(stream = try conn?.query("SELECT $1::double precision[] as doubles", [doubles], logger: .psqlTest).wait())
         
         var row: PSQLRow?
-        XCTAssertNoThrow(row = try rows?.next().wait())
+        XCTAssertNoThrow(row = try stream?.next().wait())
         
         XCTAssertEqual(try row?.decode(column: "doubles", as: [Double].self), doubles)
-        XCTAssertNil(try rows?.next().wait())
+        XCTAssertNil(try stream?.next().wait())
     }
     
     func testDecodeDates() {
@@ -246,8 +246,8 @@ final class IntegrationTests: XCTestCase {
         XCTAssertNoThrow(conn = try PSQLConnection.test(on: eventLoop).wait())
         defer { XCTAssertNoThrow(try conn?.close().wait()) }
         
-        var rows: PSQLRowStream?
-        XCTAssertNoThrow(rows = try conn?.query("""
+        var stream: PSQLRowStream?
+        XCTAssertNoThrow(stream = try conn?.query("""
             SELECT
                 '2016-01-18 01:02:03 +0042'::DATE         as date,
                 '2016-01-18 01:02:03 +0042'::TIMESTAMP    as timestamp,
@@ -255,13 +255,13 @@ final class IntegrationTests: XCTestCase {
             """, logger: .psqlTest).wait())
         
         var row: PSQLRow?
-        XCTAssertNoThrow(row = try rows?.next().wait())
+        XCTAssertNoThrow(row = try stream?.next().wait())
         
         XCTAssertEqual(try row?.decode(column: "date", as: Date.self).description, "2016-01-18 00:00:00 +0000")
         XCTAssertEqual(try row?.decode(column: "timestamp", as: Date.self).description, "2016-01-18 01:02:03 +0000")
         XCTAssertEqual(try row?.decode(column: "timestamptz", as: Date.self).description, "2016-01-18 00:20:03 +0000")
         
-        XCTAssertNil(try rows?.next().wait())
+        XCTAssertNil(try stream?.next().wait())
     }
     
     func testDecodeUUID() {
@@ -273,17 +273,17 @@ final class IntegrationTests: XCTestCase {
         XCTAssertNoThrow(conn = try PSQLConnection.test(on: eventLoop).wait())
         defer { XCTAssertNoThrow(try conn?.close().wait()) }
         
-        var rows: PSQLRowStream?
-        XCTAssertNoThrow(rows = try conn?.query("""
+        var stream: PSQLRowStream?
+        XCTAssertNoThrow(stream = try conn?.query("""
             SELECT '2c68f645-9ca6-468b-b193-ee97f241c2f8'::UUID as uuid
             """, logger: .psqlTest).wait())
         
         var row: PSQLRow?
-        XCTAssertNoThrow(row = try rows?.next().wait())
+        XCTAssertNoThrow(row = try stream?.next().wait())
         
         XCTAssertEqual(try row?.decode(column: "uuid", as: UUID.self), UUID(uuidString: "2c68f645-9ca6-468b-b193-ee97f241c2f8"))
         
-        XCTAssertNil(try rows?.next().wait())
+        XCTAssertNil(try stream?.next().wait())
     }
     
     func testRoundTripJSONB() {
@@ -301,35 +301,35 @@ final class IntegrationTests: XCTestCase {
         defer { XCTAssertNoThrow(try conn?.close().wait()) }
         
         do {
-            var rows: PSQLRowStream?
-            XCTAssertNoThrow(rows = try conn?.query("""
+            var stream: PSQLRowStream?
+            XCTAssertNoThrow(stream = try conn?.query("""
                 select $1::jsonb as jsonb
                 """, [Object(foo: 1, bar: 2)], logger: .psqlTest).wait())
             
             var row: PSQLRow?
-            XCTAssertNoThrow(row = try rows?.next().wait())
+            XCTAssertNoThrow(row = try stream?.next().wait())
             var result: Object?
             XCTAssertNoThrow(result = try row?.decode(column: "jsonb", as: Object.self))
             XCTAssertEqual(result?.foo, 1)
             XCTAssertEqual(result?.bar, 2)
             
-            XCTAssertNil(try rows?.next().wait())
+            XCTAssertNil(try stream?.next().wait())
         }
         
         do {
-            var rows: PSQLRowStream?
-            XCTAssertNoThrow(rows = try conn?.query("""
+            var stream: PSQLRowStream?
+            XCTAssertNoThrow(stream = try conn?.query("""
                 select $1::json as json
                 """, [Object(foo: 1, bar: 2)], logger: .psqlTest).wait())
             
             var row: PSQLRow?
-            XCTAssertNoThrow(row = try rows?.next().wait())
+            XCTAssertNoThrow(row = try stream?.next().wait())
             var result: Object?
             XCTAssertNoThrow(result = try row?.decode(column: "json", as: Object.self))
             XCTAssertEqual(result?.foo, 1)
             XCTAssertEqual(result?.bar, 2)
             
-            XCTAssertNil(try rows?.next().wait())
+            XCTAssertNil(try stream?.next().wait())
         }
     }
 }

--- a/Tests/IntegrationTests/PSQLIntegrationTests.swift
+++ b/Tests/IntegrationTests/PSQLIntegrationTests.swift
@@ -56,7 +56,7 @@ final class IntegrationTests: XCTestCase {
         
         var rows: PSQLRows?
         XCTAssertNoThrow(rows = try conn?.query("SELECT version()", logger: .psqlTest).wait())
-        var row: PSQLRows.Row?
+        var row: PSQLRow?
         XCTAssertNoThrow(row = try rows?.next().wait())
         var version: String?
         XCTAssertNoThrow(version = try row?.decode(column: 0, as: String.self))
@@ -111,7 +111,7 @@ final class IntegrationTests: XCTestCase {
         for _ in 0..<1_000 {
             var rows: PSQLRows?
             XCTAssertNoThrow(rows = try conn?.query("SELECT version()", logger: .psqlTest).wait())
-            var row: PSQLRows.Row?
+            var row: PSQLRow?
             XCTAssertNoThrow(row = try rows?.next().wait())
             var version: String?
             XCTAssertNoThrow(version = try row?.decode(column: 0, as: String.self))
@@ -131,7 +131,7 @@ final class IntegrationTests: XCTestCase {
         
         var rows: PSQLRows?
         XCTAssertNoThrow(rows = try conn?.query("SELECT $1::TEXT as foo", ["hello"], logger: .psqlTest).wait())
-        var row: PSQLRows.Row?
+        var row: PSQLRow?
         XCTAssertNoThrow(row = try rows?.next().wait())
         var foo: String?
         XCTAssertNoThrow(foo = try row?.decode(column: 0, as: String.self))
@@ -162,7 +162,7 @@ final class IntegrationTests: XCTestCase {
             9223372036854775807::BIGINT   as bigint_max
         """, logger: .psqlTest).wait())
         
-        var row: PSQLRows.Row?
+        var row: PSQLRow?
         XCTAssertNoThrow(row = try rows?.next().wait())
         
         XCTAssertEqual(try row?.decode(column: "smallint", as: Int16.self), 1)
@@ -191,7 +191,7 @@ final class IntegrationTests: XCTestCase {
         let array: [Int64] = [1, 2, 3]
         XCTAssertNoThrow(rows = try conn?.query("SELECT $1::int8[] as array", [array], logger: .psqlTest).wait())
         
-        var row: PSQLRows.Row?
+        var row: PSQLRow?
         XCTAssertNoThrow(row = try rows?.next().wait())
         
         XCTAssertEqual(try row?.decode(column: "array", as: [Int64].self), array)
@@ -210,7 +210,7 @@ final class IntegrationTests: XCTestCase {
         var rows: PSQLRows?
         XCTAssertNoThrow(rows = try conn?.query("SELECT '{}'::int[] as array", logger: .psqlTest).wait())
         
-        var row: PSQLRows.Row?
+        var row: PSQLRow?
         XCTAssertNoThrow(row = try rows?.next().wait())
         
         XCTAssertEqual(try row?.decode(column: "array", as: [Int64].self), [])
@@ -230,7 +230,7 @@ final class IntegrationTests: XCTestCase {
         let doubles: [Double] = [3.14, 42]
         XCTAssertNoThrow(rows = try conn?.query("SELECT $1::double precision[] as doubles", [doubles], logger: .psqlTest).wait())
         
-        var row: PSQLRows.Row?
+        var row: PSQLRow?
         XCTAssertNoThrow(row = try rows?.next().wait())
         
         XCTAssertEqual(try row?.decode(column: "doubles", as: [Double].self), doubles)
@@ -254,7 +254,7 @@ final class IntegrationTests: XCTestCase {
                 '2016-01-18 01:02:03 +0042'::TIMESTAMPTZ  as timestamptz
             """, logger: .psqlTest).wait())
         
-        var row: PSQLRows.Row?
+        var row: PSQLRow?
         XCTAssertNoThrow(row = try rows?.next().wait())
         
         XCTAssertEqual(try row?.decode(column: "date", as: Date.self).description, "2016-01-18 00:00:00 +0000")
@@ -278,7 +278,7 @@ final class IntegrationTests: XCTestCase {
             SELECT '2c68f645-9ca6-468b-b193-ee97f241c2f8'::UUID as uuid
             """, logger: .psqlTest).wait())
         
-        var row: PSQLRows.Row?
+        var row: PSQLRow?
         XCTAssertNoThrow(row = try rows?.next().wait())
         
         XCTAssertEqual(try row?.decode(column: "uuid", as: UUID.self), UUID(uuidString: "2c68f645-9ca6-468b-b193-ee97f241c2f8"))
@@ -306,7 +306,7 @@ final class IntegrationTests: XCTestCase {
                 select $1::jsonb as jsonb
                 """, [Object(foo: 1, bar: 2)], logger: .psqlTest).wait())
             
-            var row: PSQLRows.Row?
+            var row: PSQLRow?
             XCTAssertNoThrow(row = try rows?.next().wait())
             var result: Object?
             XCTAssertNoThrow(result = try row?.decode(column: "jsonb", as: Object.self))
@@ -322,7 +322,7 @@ final class IntegrationTests: XCTestCase {
                 select $1::json as json
                 """, [Object(foo: 1, bar: 2)], logger: .psqlTest).wait())
             
-            var row: PSQLRows.Row?
+            var row: PSQLRow?
             XCTAssertNoThrow(row = try rows?.next().wait())
             var result: Object?
             XCTAssertNoThrow(result = try row?.decode(column: "json", as: Object.self))

--- a/Tests/PostgresNIOTests/New/Connection State Machine/ConnectionStateMachineTests.swift
+++ b/Tests/PostgresNIOTests/New/Connection State Machine/ConnectionStateMachineTests.swift
@@ -125,7 +125,7 @@ class ConnectionStateMachineTests: XCTestCase {
         let salt: (UInt8, UInt8, UInt8, UInt8) = (0, 1, 2, 3)
 
         let jsonDecoder = JSONDecoder()
-        let queryPromise = eventLoopGroup.next().makePromise(of: PSQLRows.self)
+        let queryPromise = eventLoopGroup.next().makePromise(of: PSQLRowStream.self)
 
         var state = ConnectionStateMachine()
         let extendedQueryContext = ExtendedQueryContext(

--- a/Tests/PostgresNIOTests/New/Connection State Machine/ExtendedQueryStateMachineTests.swift
+++ b/Tests/PostgresNIOTests/New/Connection State Machine/ExtendedQueryStateMachineTests.swift
@@ -56,7 +56,7 @@ class ExtendedQueryStateMachineTests: XCTestCase {
         
         let rowPromise = EmbeddedEventLoop().makePromise(of: StateMachineStreamNextResult.self)
         rowPromise.fail(PSQLError.uncleanShutdown) // we don't care about the error at all.
-        XCTAssertEqual(state.consumeNextQueryRow(promise: rowPromise), .forwardRow([.init(bytes: rowContent, dataType: .text, format: .binary)], to: rowPromise))
+        XCTAssertEqual(state.consumeNextQueryRow(promise: rowPromise), .forwardRow(.init(columns: [rowContent]), to: rowPromise))
         
         XCTAssertEqual(state.commandCompletedReceived("SELECT 1"), .forwardStreamCompletedToCurrentQuery(CircularBuffer(), commandTag: "SELECT 1", read: true))
         XCTAssertEqual(state.readyForQueryReceived(.idle), .fireEventReadyForQuery)

--- a/Tests/PostgresNIOTests/New/Connection State Machine/ExtendedQueryStateMachineTests.swift
+++ b/Tests/PostgresNIOTests/New/Connection State Machine/ExtendedQueryStateMachineTests.swift
@@ -10,7 +10,7 @@ class ExtendedQueryStateMachineTests: XCTestCase {
         var state = ConnectionStateMachine.readyForQuery()
         
         let logger = Logger.psqlTest
-        let promise = EmbeddedEventLoop().makePromise(of: PSQLRows.self)
+        let promise = EmbeddedEventLoop().makePromise(of: PSQLRowStream.self)
         promise.fail(PSQLError.uncleanShutdown) // we don't care about the error at all.
         let query = "DELETE FROM table WHERE id=$0"
         let queryContext = ExtendedQueryContext(query: query, bind: [1], logger: logger, jsonDecoder: JSONDecoder(), promise: promise)
@@ -28,7 +28,7 @@ class ExtendedQueryStateMachineTests: XCTestCase {
         var state = ConnectionStateMachine.readyForQuery()
         
         let logger = Logger.psqlTest
-        let queryPromise = EmbeddedEventLoop().makePromise(of: PSQLRows.self)
+        let queryPromise = EmbeddedEventLoop().makePromise(of: PSQLRowStream.self)
         queryPromise.fail(PSQLError.uncleanShutdown) // we don't care about the error at all.
         let query = "SELECT version()"
         let queryContext = ExtendedQueryContext(query: query, bind: [], logger: logger, jsonDecoder: JSONDecoder(), promise: queryPromise)
@@ -66,7 +66,7 @@ class ExtendedQueryStateMachineTests: XCTestCase {
         var state = ConnectionStateMachine.readyForQuery()
         
         let logger = Logger.psqlTest
-        let promise = EmbeddedEventLoop().makePromise(of: PSQLRows.self)
+        let promise = EmbeddedEventLoop().makePromise(of: PSQLRowStream.self)
         promise.fail(PSQLError.uncleanShutdown) // we don't care about the error at all.
         let query = "DELETE FROM table WHERE id=$0"
         let queryContext = ExtendedQueryContext(query: query, bind: [1], logger: logger, jsonDecoder: JSONDecoder(), promise: promise)


### PR DESCRIPTION
### Motivation

In #135, I did some naming things just wrong. `PSQLRows` is a stupid name. We should name it `PSQLRowStream`. `PSQLRows.Row` is a stupid name for a single table row. We should name it `PSQLRow`. Transforming an incoming data row packet to a `[PSQLData]` array early is expensive and stupid. Let's not do this anymore.

### Changes

Consume this pr in the three change steps (separate commit for each):

1. Extract `PSQLRows.Row` to `PSQLRows` (Got its own file). Stop the early `[PSQLData]` madness.
2. Rename `PSQLRows` to `PSQLRowStream`
3. Fix naming in integration tests to match `PSQLRowStream `

### Result

I feel less embarrassed about my code. It might be a little faster.