### PR TITLE
Batch rows for consumption

### DIFF
--- a/Sources/PostgresNIO/New/Connection State Machine/ConnectionStateMachine.swift
+++ b/Sources/PostgresNIO/New/Connection State Machine/ConnectionStateMachine.swift
@@ -92,12 +92,9 @@ struct ConnectionStateMachine {
         
         // --- streaming actions
         // actions if query has requested next row but we are waiting for backend
-        case forwardRow(PSQLBackendMessage.DataRow, to: EventLoopPromise<StateMachineStreamNextResult>)
-        case forwardCommandComplete(CircularBuffer<PSQLBackendMessage.DataRow>, commandTag: String, to: EventLoopPromise<StateMachineStreamNextResult>)
-        case forwardStreamError(PSQLError, to: EventLoopPromise<StateMachineStreamNextResult>, cleanupContext: CleanUpContext?)
-        // actions if query has not asked for next row but are pushing the final bytes to it
-        case forwardStreamErrorToCurrentQuery(PSQLError, read: Bool, cleanupContext: CleanUpContext?)
-        case forwardStreamCompletedToCurrentQuery(CircularBuffer<PSQLBackendMessage.DataRow>, commandTag: String, read: Bool)
+        case forwardRows(CircularBuffer<PSQLBackendMessage.DataRow>)
+        case forwardStreamComplete(CircularBuffer<PSQLBackendMessage.DataRow>, commandTag: String)
+        case forwardStreamError(PSQLError, read: Bool, cleanupContext: CleanUpContext?)
         
         // Prepare statement actions
         case sendParseDescribeSync(name: String, query: String)
@@ -172,8 +169,10 @@ struct ConnectionStateMachine {
         switch self.state {
         case .initialized:
             preconditionFailure("How can a connection be closed, if it was never connected.")
+        
         case .closed:
             preconditionFailure("How can a connection be closed, if it is already closed.")
+        
         case .authenticated,
              .sslRequestSent,
              .sslNegotiated,
@@ -185,10 +184,12 @@ struct ConnectionStateMachine {
              .prepareStatement,
              .closeCommand:
             return self.errorHappened(.uncleanShutdown)
+            
         case .error, .closing:
             self.state = .closed
             self.quiescingState = .notQuiescing
             return .fireChannelInactive
+            
         case .modifying:
             preconditionFailure("Invalid state")
         }
@@ -199,8 +200,24 @@ struct ConnectionStateMachine {
         case .sslRequestSent:
             self.state = .sslNegotiated
             return .establishSSLConnection
-        default:
+            
+        case .initialized,
+             .sslNegotiated,
+             .sslHandlerAdded,
+             .waitingToStartAuthentication,
+             .authenticating,
+             .authenticated,
+             .readyForQuery,
+             .extendedQuery,
+             .prepareStatement,
+             .closeCommand,
+             .error,
+             .closing,
+             .closed:
             return self.closeConnectionAndCleanup(.unexpectedBackendMessage(.sslSupported))
+            
+        case .modifying:
+            preconditionFailure("Invalid state: \(self.state)")
         }
     }
     
@@ -208,27 +225,77 @@ struct ConnectionStateMachine {
         switch self.state {
         case .sslRequestSent:
             return self.closeConnectionAndCleanup(.sslUnsupported)
-        default:
+        
+        case .initialized,
+             .sslNegotiated,
+             .sslHandlerAdded,
+             .waitingToStartAuthentication,
+             .authenticating,
+             .authenticated,
+             .readyForQuery,
+             .extendedQuery,
+             .prepareStatement,
+             .closeCommand,
+             .error,
+             .closing,
+             .closed:
             return self.closeConnectionAndCleanup(.unexpectedBackendMessage(.sslSupported))
+            
+        case .modifying:
+            preconditionFailure("Invalid state: \(self.state)")
         }
     }
     
     mutating func sslHandlerAdded() -> ConnectionAction {
-        guard case .sslNegotiated = self.state else {
-            preconditionFailure("Can only add a ssl handler after negotiation")
+        switch self.state {
+        case .initialized,
+             .sslRequestSent,
+             .sslHandlerAdded,
+             .waitingToStartAuthentication,
+             .authenticating,
+             .authenticated,
+             .readyForQuery,
+             .extendedQuery,
+             .prepareStatement,
+             .closeCommand,
+             .error,
+             .closing,
+             .closed:
+            preconditionFailure("Can only add a ssl handler after negotiation: \(self.state)")
+            
+        case .sslNegotiated:
+            self.state = .sslHandlerAdded
+            return .wait
+
+        case .modifying:
+            preconditionFailure("Invalid state: \(self.state)")
         }
-        
-        self.state = .sslHandlerAdded
-        return .wait
     }
     
     mutating func sslEstablished() -> ConnectionAction {
-        guard case .sslHandlerAdded = self.state else {
-            preconditionFailure("Can only establish a ssl connection after adding a ssl handler")
+        switch self.state {
+        case .initialized,
+             .sslRequestSent,
+             .sslNegotiated,
+             .waitingToStartAuthentication,
+             .authenticating,
+             .authenticated,
+             .readyForQuery,
+             .extendedQuery,
+             .prepareStatement,
+             .closeCommand,
+             .error,
+             .closing,
+             .closed:
+            preconditionFailure("Can only establish a ssl connection after adding a ssl handler: \(self.state)")
+            
+        case .sslHandlerAdded:
+            self.state = .waitingToStartAuthentication
+            return .provideAuthenticationContext
+
+        case .modifying:
+            preconditionFailure("Invalid state: \(self.state)")
         }
-        
-        self.state = .waitingToStartAuthentication
-        return .provideAuthenticationContext
     }
     
     mutating func authenticationMessageReceived(_ message: PSQLBackendMessage.Authentication) -> ConnectionAction {
@@ -518,6 +585,35 @@ struct ConnectionStateMachine {
         }
     }
     
+    mutating func channelReadComplete() -> ConnectionAction {
+        switch self.state {
+        case .initialized,
+             .sslRequestSent,
+             .sslNegotiated,
+             .sslHandlerAdded,
+             .waitingToStartAuthentication,
+             .authenticating,
+             .authenticated,
+             .readyForQuery,
+             .prepareStatement,
+             .closeCommand,
+             .error,
+             .closing,
+             .closed:
+            return .wait
+            
+        case .extendedQuery(var extendedQuery, let connectionContext):
+            return self.avoidingStateMachineCoW { machine in
+                let action = extendedQuery.channelReadComplete()
+                machine.state = .extendedQuery(extendedQuery, connectionContext)
+                return machine.modify(with: action)
+            }
+        
+        case .modifying:
+            preconditionFailure("Invalid state")
+        }
+    }
+    
     mutating func readEventCaught() -> ConnectionAction {
         switch self.state {
         case .initialized:
@@ -562,7 +658,6 @@ struct ConnectionStateMachine {
             preconditionFailure("How can we receive a read, if the connection is closed")
         case .modifying:
             preconditionFailure("Invalid state")
-
         }
     }
     
@@ -714,13 +809,13 @@ struct ConnectionStateMachine {
         preconditionFailure("Unimplemented")
     }
     
-    mutating func consumeNextQueryRow(promise: EventLoopPromise<StateMachineStreamNextResult>) -> ConnectionAction {
+    mutating func requestQueryRows() -> ConnectionAction {
         guard case .extendedQuery(var queryState, let connectionContext) = self.state, !queryState.isComplete else {
             preconditionFailure("Tried to consume next row, without active query")
         }
         
         return self.avoidingStateMachineCoW { machine -> ConnectionAction in
-            let action = queryState.consumeNextRow(promise: promise)
+            let action = queryState.requestQueryRows()
             machine.state = .extendedQuery(queryState, connectionContext)
             return machine.modify(with: action)
         }
@@ -783,18 +878,15 @@ struct ConnectionStateMachine {
                  .sendBindExecuteSync,
                  .succeedQuery,
                  .succeedQueryNoRowsComming,
-                 .forwardRow,
-                 .forwardCommandComplete,
-                 .forwardStreamCompletedToCurrentQuery,
+                 .forwardRows,
+                 .forwardStreamComplete,
                  .wait,
                  .read:
                 preconditionFailure("Expecting only failure actions if an error happened")
             case .failQuery(let queryContext, with: let error):
                 return .failQuery(queryContext, with: error, cleanupContext: cleanupContext)
-            case .forwardStreamError(let error, to: let promise):
-                return .forwardStreamError(error, to: promise, cleanupContext: cleanupContext)
-            case .forwardStreamErrorToCurrentQuery(let error, read: let read):
-                return .forwardStreamErrorToCurrentQuery(error, read: read, cleanupContext: cleanupContext)
+            case .forwardStreamError(let error, let read):
+                return .forwardStreamError(error, read: read, cleanupContext: cleanupContext)
             }
         case .prepareStatement(var prepareStateMachine, _):
             let cleanupContext = self.setErrorAndCreateCleanupContext(error)
@@ -1025,18 +1117,13 @@ extension ConnectionStateMachine {
             return .succeedQuery(requestContext, columns: columns)
         case .succeedQueryNoRowsComming(let requestContext, let commandTag):
             return .succeedQueryNoRowsComming(requestContext, commandTag: commandTag)
-        case .forwardRow(let data, to: let promise):
-            return .forwardRow(data, to: promise)
-        case .forwardCommandComplete(let buffer, let commandTag, to: let promise):
-            return .forwardCommandComplete(buffer, commandTag: commandTag, to: promise)
-        case .forwardStreamError(let error, to: let promise):
+        case .forwardRows(let buffer):
+            return .forwardRows(buffer)
+        case .forwardStreamComplete(let buffer, let commandTag):
+            return .forwardStreamComplete(buffer, commandTag: commandTag)
+        case .forwardStreamError(let error, let read):
             let cleanupContext = self.setErrorAndCreateCleanupContextIfNeeded(error)
-            return .forwardStreamError(error, to: promise, cleanupContext: cleanupContext)
-        case .forwardStreamErrorToCurrentQuery(let error, let read):
-            let cleanupContext = self.setErrorAndCreateCleanupContextIfNeeded(error)
-            return .forwardStreamErrorToCurrentQuery(error, read: read, cleanupContext: cleanupContext)
-        case .forwardStreamCompletedToCurrentQuery(let buffer, let commandTag, let read):
-            return .forwardStreamCompletedToCurrentQuery(buffer, commandTag: commandTag, read: read)
+            return .forwardStreamError(error, read: read, cleanupContext: cleanupContext)
         case .read:
             return .read
         case .wait:
@@ -1102,14 +1189,6 @@ extension ConnectionStateMachine {
             return .wait
         }
     }
-}
-
-enum StateMachineStreamNextResult {
-    /// the next row
-    case row(PSQLBackendMessage.DataRow)
-    
-    /// the query has completed, all remaining rows and the command completion tag
-    case complete(CircularBuffer<PSQLBackendMessage.DataRow>, commandTag: String)
 }
 
 struct SendPrepareStatement {

--- a/Sources/PostgresNIO/New/Connection State Machine/ExtendedQueryStateMachine.swift
+++ b/Sources/PostgresNIO/New/Connection State Machine/ExtendedQueryStateMachine.swift
@@ -14,8 +14,7 @@ struct ExtendedQueryStateMachine {
         /// A state that is used if a noData message was received before. If a row description was received `bufferingRows` is
         /// used after receiving a `bindComplete` message
         case bindCompleteReceived(ExtendedQueryContext)
-        case bufferingRows([PSQLBackendMessage.RowDescription.Column], CircularBuffer<PSQLBackendMessage.DataRow>, readOnEmpty: Bool)
-        case waitingForNextRow([PSQLBackendMessage.RowDescription.Column], CircularBuffer<PSQLBackendMessage.DataRow>, EventLoopPromise<StateMachineStreamNextResult>)
+        case streaming([PSQLBackendMessage.RowDescription.Column], RowStreamStateMachine)
         
         case commandComplete(commandTag: String)
         case error(PSQLError)
@@ -34,12 +33,9 @@ struct ExtendedQueryStateMachine {
         
         // --- streaming actions
         // actions if query has requested next row but we are waiting for backend
-        case forwardRow(PSQLBackendMessage.DataRow, to: EventLoopPromise<StateMachineStreamNextResult>)
-        case forwardCommandComplete(CircularBuffer<PSQLBackendMessage.DataRow>, commandTag: String, to: EventLoopPromise<StateMachineStreamNextResult>)
-        case forwardStreamError(PSQLError, to: EventLoopPromise<StateMachineStreamNextResult>)
-        // actions if query has not asked for next row but are pushing the final bytes to it
-        case forwardStreamErrorToCurrentQuery(PSQLError, read: Bool)
-        case forwardStreamCompletedToCurrentQuery(CircularBuffer<PSQLBackendMessage.DataRow>, commandTag: String, read: Bool)
+        case forwardRows(CircularBuffer<PSQLBackendMessage.DataRow>)
+        case forwardStreamComplete(CircularBuffer<PSQLBackendMessage.DataRow>, commandTag: String)
+        case forwardStreamError(PSQLError, read: Bool)
 
         case read
         case wait
@@ -137,7 +133,7 @@ struct ExtendedQueryStateMachine {
         switch self.state {
         case .rowDescriptionReceived(let context, let columns):
             return self.avoidingStateMachineCoW { state -> Action in
-                state = .bufferingRows(columns, CircularBuffer(), readOnEmpty: false)
+                state = .streaming(columns, .init())
                 return .succeedQuery(context, columns: columns)
             }
         case .noDataMessageReceived(let queryContext):
@@ -150,8 +146,7 @@ struct ExtendedQueryStateMachine {
              .parseCompleteReceived,
              .parameterDescriptionReceived,
              .bindCompleteReceived,
-             .bufferingRows,
-             .waitingForNextRow,
+             .streaming,
              .commandComplete,
              .error:
             return self.setAndFireError(.unexpectedBackendMessage(.bindComplete))
@@ -162,7 +157,7 @@ struct ExtendedQueryStateMachine {
     
     mutating func dataRowReceived(_ dataRow: PSQLBackendMessage.DataRow) -> Action {
         switch self.state {
-        case .bufferingRows(let columns, var buffer, let readOnEmpty):
+        case .streaming(let columns, var demandStateMachine):
             // When receiving a data row, we must ensure that the data row column count
             // matches the previously received row description column count.
             guard dataRow.columns.count == columns.count else {
@@ -170,22 +165,9 @@ struct ExtendedQueryStateMachine {
             }
             
             return self.avoidingStateMachineCoW { state -> Action in
-                buffer.append(dataRow)
-                state = .bufferingRows(columns, buffer, readOnEmpty: readOnEmpty)
+                demandStateMachine.receivedRow(dataRow)
+                state = .streaming(columns, demandStateMachine)
                 return .wait
-            }
-            
-        case .waitingForNextRow(let columns, let buffer, let promise):
-            // When receiving a data row, we must ensure that the data row column count
-            // matches the previously received row description column count.
-            guard dataRow.columns.count == columns.count else {
-                return self.setAndFireError(.unexpectedBackendMessage(.dataRow(dataRow)))
-            }
-            
-            return self.avoidingStateMachineCoW { state -> Action in
-                precondition(buffer.isEmpty, "Expected the buffer to be empty")
-                state = .bufferingRows(columns, buffer, readOnEmpty: false)
-                return .forwardRow(dataRow, to: promise)
             }
             
         case .initialized,
@@ -211,17 +193,10 @@ struct ExtendedQueryStateMachine {
                 return .succeedQueryNoRowsComming(context, commandTag: commandTag)
             }
             
-        case .bufferingRows(_, let buffer, let readOnEmpty):
+        case .streaming(_, var demandStateMachine):
             return self.avoidingStateMachineCoW { state -> Action in
                 state = .commandComplete(commandTag: commandTag)
-                return .forwardStreamCompletedToCurrentQuery(buffer, commandTag: commandTag, read: readOnEmpty)
-            }
-            
-        case .waitingForNextRow(_, let buffer, let promise):
-            return self.avoidingStateMachineCoW { state -> Action in
-                precondition(buffer.isEmpty, "Expected the buffer to be empty")
-                state = .commandComplete(commandTag: commandTag)
-                return .forwardCommandComplete(buffer, commandTag: commandTag, to: promise)
+                return .forwardStreamComplete(demandStateMachine.end(), commandTag: commandTag)
             }
         
         case .initialized,
@@ -254,9 +229,7 @@ struct ExtendedQueryStateMachine {
             return self.setAndFireError(error)
         case .rowDescriptionReceived, .noDataMessageReceived:
             return self.setAndFireError(error)
-        case .bufferingRows:
-            return self.setAndFireError(error)
-        case .waitingForNextRow:
+        case .streaming:
             return self.setAndFireError(error)
         case .commandComplete:
             return self.setAndFireError(.unexpectedBackendMessage(.error(errorMessage)))
@@ -282,20 +255,18 @@ struct ExtendedQueryStateMachine {
             
     // MARK: Customer Actions
     
-    mutating func consumeNextRow(promise: EventLoopPromise<StateMachineStreamNextResult>) -> Action {
+    mutating func requestQueryRows() -> Action {
         switch self.state {
-        case .waitingForNextRow:
-            preconditionFailure("Too greedy. `consumeNextRow()` only needs to be called once.")
-            
-        case .bufferingRows(let columns, var buffer, let readOnEmpty):
+        case .streaming(let columns, var demandStateMachine):
             return self.avoidingStateMachineCoW { state -> Action in
-                guard let row = buffer.popFirst() else {
-                    state = .waitingForNextRow(columns, buffer, promise)
-                    return readOnEmpty ? .read : .wait
+                let action = demandStateMachine.demandMoreResponseBodyParts()
+                state = .streaming(columns, demandStateMachine)
+                switch action {
+                case .read:
+                    return .read
+                case .wait:
+                    return .wait
                 }
-                
-                state = .bufferingRows(columns, buffer, readOnEmpty: readOnEmpty)
-                return .forwardRow(row, to: promise)
             }
 
         case .initialized,
@@ -316,29 +287,56 @@ struct ExtendedQueryStateMachine {
     
     // MARK: Channel actions
     
+    mutating func channelReadComplete() -> Action {
+        switch self.state {
+        case .initialized,
+             .commandComplete,
+             .error,
+             .parseDescribeBindExecuteSyncSent,
+             .parseCompleteReceived,
+             .parameterDescriptionReceived,
+             .noDataMessageReceived,
+             .rowDescriptionReceived,
+             .bindCompleteReceived:
+            return .wait
+            
+        case .streaming(let columns, var demandStateMachine):
+            return self.avoidingStateMachineCoW { state -> Action in
+                let rows = demandStateMachine.channelReadComplete()
+                state = .streaming(columns, demandStateMachine)
+                switch rows {
+                case .some(let rows):
+                    return .forwardRows(rows)
+                case .none:
+                    return .wait
+                }
+            }
+
+        case .modifying:
+            preconditionFailure("Invalid state")
+        }
+    }
+    
     mutating func readEventCaught() -> Action {
         switch self.state {
-        case .parseDescribeBindExecuteSyncSent:
+        case .parseDescribeBindExecuteSyncSent,
+             .parseCompleteReceived,
+             .parameterDescriptionReceived,
+             .noDataMessageReceived,
+             .rowDescriptionReceived,
+             .bindCompleteReceived:
             return .read
-        case .parseCompleteReceived:
-            return .read
-        case .parameterDescriptionReceived:
-            return .read
-        case .noDataMessageReceived:
-            return .read
-        case .rowDescriptionReceived:
-            return .read
-        case .bindCompleteReceived:
-            return .read
-        case .bufferingRows(let columns, let buffer, _):
+        case .streaming(let columns, var demandStateMachine):
             return self.avoidingStateMachineCoW { state -> Action in
-                state = .bufferingRows(columns, buffer, readOnEmpty: true)
-                return .wait
+                let action = demandStateMachine.read()
+                state = .streaming(columns, demandStateMachine)
+                switch action {
+                case .wait:
+                    return .wait
+                case .read:
+                    return .read
+                }
             }
-        case .waitingForNextRow:
-            // we are in the stream and the consumer has already asked us for more rows,
-            // therefore we need to read!
-            return .read
         case .initialized,
              .commandComplete,
              .error:
@@ -363,12 +361,11 @@ struct ExtendedQueryStateMachine {
              .bindCompleteReceived(let context):
             self.state = .error(error)
             return .failQuery(context, with: error)
-        case .bufferingRows(_, _, readOnEmpty: let readOnEmpty):
+            
+        case .streaming:
             self.state = .error(error)
-            return .forwardStreamErrorToCurrentQuery(error, read: readOnEmpty)
-        case .waitingForNextRow(_, _, let promise):
-            self.state = .error(error)
-            return .forwardStreamError(error, to: promise)
+            return .forwardStreamError(error, read: false)
+            
         case .commandComplete, .error:
             preconditionFailure("""
                 This state must not be reached. If the query `.isComplete`, the

--- a/Tests/PostgresNIOTests/New/Extensions/ConnectionAction+TestUtils.swift
+++ b/Tests/PostgresNIOTests/New/Extensions/ConnectionAction+TestUtils.swift
@@ -67,10 +67,10 @@ extension ConnectionStateMachine.ConnectionAction: Equatable {
             return lhsContext === rhsContext && lhsRowDescription == rhsRowDescription
         case (.failQuery(let lhsContext, let lhsError, let lhsCleanupContext), .failQuery(let rhsContext, let rhsError, let rhsCleanupContext)):
             return lhsContext === rhsContext && lhsError == rhsError && lhsCleanupContext == rhsCleanupContext
-        case (.forwardRow(let lhsColumns, let lhsPromise), .forwardRow(let rhsColumns, let rhsPromise)):
-            return lhsColumns == rhsColumns && lhsPromise.futureResult === rhsPromise.futureResult
-        case (.forwardStreamCompletedToCurrentQuery(let lhsBuffer, let lhsCommandTag, let lhsRead), .forwardStreamCompletedToCurrentQuery(let rhsBuffer, let rhsCommandTag, let rhsRead)):
-            return lhsBuffer == rhsBuffer && lhsCommandTag == rhsCommandTag && lhsRead == rhsRead
+        case (.forwardRows(let lhsRows), .forwardRows(let rhsRows)):
+            return lhsRows == rhsRows
+        case (.forwardStreamComplete(let lhsBuffer, let lhsCommandTag), .forwardStreamComplete(let rhsBuffer, let rhsCommandTag)):
+            return lhsBuffer == rhsBuffer && lhsCommandTag == rhsCommandTag
         case (.sendParseDescribeSync(let lhsName, let lhsQuery), .sendParseDescribeSync(let rhsName, let rhsQuery)):
             return lhsName == rhsName && lhsQuery == rhsQuery
         case (.succeedPreparedStatementCreation(let lhsContext, let lhsRowDescription), .succeedPreparedStatementCreation(let rhsContext, let rhsRowDescription)):

--- a/Tests/PostgresNIOTests/New/Extensions/PSQLBackendMessage+Equatable.swift
+++ b/Tests/PostgresNIOTests/New/Extensions/PSQLBackendMessage+Equatable.swift
@@ -47,3 +47,11 @@ extension PSQLBackendMessage: Equatable {
         }
     }
 }
+
+extension PSQLBackendMessage.DataRow: ExpressibleByArrayLiteral {
+    public typealias ArrayLiteralElement = ByteBuffer
+
+    public init(arrayLiteral elements: ByteBuffer...) {
+        self.init(columns: elements)
+    }
+}


### PR DESCRIPTION
### Motivation

To allow faster processing of incoming `DataRow`s, we should batch them up in channelRead events and forward them as a batch for consumption in `PSQLRowStream`. This work is the foundation for AsyncSequence support in the future.

### Modifications

- Extends `ExtendedQueryStateMachine` to use `RowStreamStateMachine` internally
- Refactor `PSQLRowStream` to work with batches of rows.