### PR TITLE
Fix PostgresNumeric.init crash at large number

### DIFF
--- a/Sources/PostgresNIO/Data/PostgresData+Numeric.swift
+++ b/Sources/PostgresNIO/Data/PostgresData+Numeric.swift
@@ -268,16 +268,13 @@ private extension Collection {
     // splits the collection into chunks of the supplied size
     // if the collection is not evenly divisible, the first chunk will be smaller
     func reverseChunked(by maxSize: Int) -> [SubSequence] {
-        var lastDistance = 0
+        let firstChunkSize = self.count % maxSize
+        if firstChunkSize == 0 {
+            return self.chunked(by: maxSize)
+        }
         var chunkStartIndex = self.startIndex
-        return stride(from: 0, to: self.count, by: maxSize).reversed().map { current in
-            let distance = (self.count - current) - lastDistance
-            lastDistance = distance
-            let chunkEndOffset = Swift.min(
-                self.distance(from: chunkStartIndex, to: self.endIndex),
-                distance
-            )
-            let chunkEndIndex = self.index(chunkStartIndex, offsetBy: chunkEndOffset)
+        return stride(from: firstChunkSize, through: self.count, by: maxSize).map { current in
+            let chunkEndIndex = self.index(self.startIndex, offsetBy: current)
             defer { chunkStartIndex = chunkEndIndex }
             return self[chunkStartIndex..<chunkEndIndex]
         }

--- a/Tests/IntegrationTests/PostgresNIOTests.swift
+++ b/Tests/IntegrationTests/PostgresNIOTests.swift
@@ -463,20 +463,24 @@ final class PostgresNIOTests: XCTestCase {
         let a = PostgresNumeric(string: "123456.789123")!
         let b = PostgresNumeric(string: "-123456.789123")!
         let c = PostgresNumeric(string: "3.14159265358979")!
+        let d = PostgresNumeric(string: "1234567890123")!
         var rows: PostgresQueryResult?
         XCTAssertNoThrow(rows = try conn?.query("""
         select
             $1::numeric::text as a,
             $2::numeric::text as b,
-            $3::numeric::text as c
+            $3::numeric::text as c,
+            $4::numeric::text as d
         """, [
             .init(numeric: a),
             .init(numeric: b),
-            .init(numeric: c)
+            .init(numeric: c),
+            .init(numeric: d)
         ]).wait())
         XCTAssertEqual(rows?.first?.column("a")?.string, "123456.789123")
         XCTAssertEqual(rows?.first?.column("b")?.string, "-123456.789123")
         XCTAssertEqual(rows?.first?.column("c")?.string, "3.14159265358979")
+        XCTAssertEqual(rows?.first?.column("d")?.string, "1234567890123")
     }
 
     func testMoney() {


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->
Fix #186

Fix `reverseChunked` to comply with `maxSize`.
<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
