### PR TITLE
Move pre 1.5.0 unit tests into the unit test target

### DIFF
--- a/Tests/PostgresNIOTests/Data/PostgresData+JSONTests.swift
+++ b/Tests/PostgresNIOTests/Data/PostgresData+JSONTests.swift
@@ -1,0 +1,20 @@
+import PostgresNIO
+import XCTest
+
+class PostgresData_JSONTests: XCTestCase {
+    func testJSONBConvertible() {
+        struct Object: PostgresJSONBCodable {
+            let foo: Int
+            let bar: Int
+        }
+
+        XCTAssertEqual(Object.postgresDataType, .jsonb)
+
+        let postgresData = Object(foo: 1, bar: 2).postgresData
+        XCTAssertEqual(postgresData?.type, .jsonb)
+
+        let object = Object(postgresData: postgresData!)
+        XCTAssertEqual(object?.foo, 1)
+        XCTAssertEqual(object?.bar, 2)
+    }
+}

--- a/Tests/PostgresNIOTests/Message/PostgresMessageDecoderTests.swift
+++ b/Tests/PostgresNIOTests/Message/PostgresMessageDecoderTests.swift
@@ -1,0 +1,37 @@
+import PostgresNIO
+import XCTest
+import NIOTestUtils
+
+class PostgresMessageDecoderTests: XCTestCase {
+    func testMessageDecoder() {
+        let sample: [UInt8] = [
+            0x52, // R - authentication
+                0x00, 0x00, 0x00, 0x0C, // length = 12
+                0x00, 0x00, 0x00, 0x05, // md5
+                0x01, 0x02, 0x03, 0x04, // salt
+            0x4B, // B - backend key data
+                0x00, 0x00, 0x00, 0x0C, // length = 12
+                0x05, 0x05, 0x05, 0x05, // process id
+                0x01, 0x01, 0x01, 0x01, // secret key
+        ]
+        var input = ByteBufferAllocator().buffer(capacity: 0)
+        input.writeBytes(sample)
+
+        let output: [PostgresMessage] = [
+            PostgresMessage(identifier: .authentication, bytes: [
+                0x00, 0x00, 0x00, 0x05,
+                0x01, 0x02, 0x03, 0x04,
+            ]),
+            PostgresMessage(identifier: .backendKeyData, bytes: [
+                0x05, 0x05, 0x05, 0x05,
+                0x01, 0x01, 0x01, 0x01,
+            ])
+        ]
+        XCTAssertNoThrow(try XCTUnwrap(ByteToMessageDecoderVerifier.verifyDecoder(
+            inputOutputPairs: [(input, output)],
+            decoderFactory: {
+                PostgresMessageDecoder()
+            }
+        )))
+    }
+}

--- a/Tests/PostgresNIOTests/Utilities/PostgresJSONCodingTests.swift
+++ b/Tests/PostgresNIOTests/Utilities/PostgresJSONCodingTests.swift
@@ -1,0 +1,61 @@
+import NIOCore
+import XCTest
+import PostgresNIO
+
+class PostgresJSONCodingTests: XCTestCase {
+    // https://github.com/vapor/postgres-nio/issues/126
+    func testCustomJSONEncoder() {
+        let previousDefaultJSONEncoder = PostgresNIO._defaultJSONEncoder
+        defer {
+            PostgresNIO._defaultJSONEncoder = previousDefaultJSONEncoder
+        }
+        final class CustomJSONEncoder: PostgresJSONEncoder {
+            var didEncode = false
+            func encode<T>(_ value: T) throws -> Data where T : Encodable {
+                self.didEncode = true
+                return try JSONEncoder().encode(value)
+            }
+        }
+        struct Object: Codable {
+            var foo: Int
+            var bar: Int
+        }
+        let customJSONEncoder = CustomJSONEncoder()
+        PostgresNIO._defaultJSONEncoder = customJSONEncoder
+        XCTAssertNoThrow(try PostgresData(json: Object(foo: 1, bar: 2)))
+        XCTAssert(customJSONEncoder.didEncode)
+
+        let customJSONBEncoder = CustomJSONEncoder()
+        PostgresNIO._defaultJSONEncoder = customJSONBEncoder
+        XCTAssertNoThrow(try PostgresData(json: Object(foo: 1, bar: 2)))
+        XCTAssert(customJSONBEncoder.didEncode)
+    }
+
+    // https://github.com/vapor/postgres-nio/issues/126
+    func testCustomJSONDecoder() {
+        let previousDefaultJSONDecoder = PostgresNIO._defaultJSONDecoder
+        defer {
+            PostgresNIO._defaultJSONDecoder = previousDefaultJSONDecoder
+        }
+        final class CustomJSONDecoder: PostgresJSONDecoder {
+            var didDecode = false
+            func decode<T>(_ type: T.Type, from data: Data) throws -> T where T : Decodable {
+                self.didDecode = true
+                return try JSONDecoder().decode(type, from: data)
+            }
+        }
+        struct Object: Codable {
+            var foo: Int
+            var bar: Int
+        }
+        let customJSONDecoder = CustomJSONDecoder()
+        PostgresNIO._defaultJSONDecoder = customJSONDecoder
+        XCTAssertNoThrow(try PostgresData(json: Object(foo: 1, bar: 2)).json(as: Object.self))
+        XCTAssert(customJSONDecoder.didDecode)
+
+        let customJSONBDecoder = CustomJSONDecoder()
+        PostgresNIO._defaultJSONDecoder = customJSONBDecoder
+        XCTAssertNoThrow(try PostgresData(json: Object(foo: 1, bar: 2)).json(as: Object.self))
+        XCTAssert(customJSONBDecoder.didDecode)
+    }
+}


### PR DESCRIPTION
To make sure the unit test codecov report is correct, move pre 1.5.0 unit tests into the unit test target.