### PR TITLE
DataRow without allocation; DataRow as Collection; RowDescription top level

### DIFF
--- a/Sources/PostgresNIO/Connection/PostgresConnection+Database.swift
+++ b/Sources/PostgresNIO/Connection/PostgresConnection+Database.swift
@@ -50,7 +50,7 @@ extension PostgresConnection: PostgresDatabase {
                 let lookupTable = PostgresRow.LookupTable(rowDescription: .init(fields: fields), resultFormat: [.binary])
                 return rows.all().map { allrows in
                     let r = allrows.map { psqlRow -> PostgresRow in
-                        let columns = psqlRow.data.columns.map {
+                        let columns = psqlRow.data.map {
                             PostgresMessage.DataRow.Column(value: $0)
                         }
                         return PostgresRow(dataRow: .init(columns: columns), lookupTable: lookupTable)
@@ -112,7 +112,7 @@ extension PSQLRowStream {
     
     func iterateRowsWithoutBackpressureOption(lookupTable: PostgresRow.LookupTable, onRow: @escaping (PostgresRow) throws -> ()) -> EventLoopFuture<Void> {
         self.onRow { psqlRow in
-            let columns = psqlRow.data.columns.map {
+            let columns = psqlRow.data.map {
                 PostgresMessage.DataRow.Column(value: $0)
             }
             

--- a/Sources/PostgresNIO/New/Connection State Machine/PrepareStatementStateMachine.swift
+++ b/Sources/PostgresNIO/New/Connection State Machine/PrepareStatementStateMachine.swift
@@ -15,7 +15,7 @@ struct PrepareStatementStateMachine {
     
     enum Action {
         case sendParseDescribeSync(name: String, query: String)
-        case succeedPreparedStatementCreation(PrepareStatementContext, with: PSQLBackendMessage.RowDescription?)
+        case succeedPreparedStatementCreation(PrepareStatementContext, with: RowDescription?)
         case failPreparedStatementCreation(PrepareStatementContext, with: PSQLError)
 
         case read
@@ -72,7 +72,7 @@ struct PrepareStatementStateMachine {
         return .succeedPreparedStatementCreation(queryContext, with: nil)
     }
     
-    mutating func rowDescriptionReceived(_ rowDescription: PSQLBackendMessage.RowDescription) -> Action {
+    mutating func rowDescriptionReceived(_ rowDescription: RowDescription) -> Action {
         guard case .parameterDescriptionReceived(let queryContext) = self.state else {
             return self.setAndFireError(.unexpectedBackendMessage(.rowDescription(rowDescription)))
         }

--- a/Sources/PostgresNIO/New/Messages/DataRow.swift
+++ b/Sources/PostgresNIO/New/Messages/DataRow.swift
@@ -58,24 +58,9 @@ extension DataRow: Collection {
             self.offset = index
         }
         
-        static func == (lhs: Self, rhs: Self) -> Bool {
-            lhs.offset == rhs.offset
-        }
-        
+        // Only needed implementation for comparable. The compiler synthesizes the rest from this.
         static func < (lhs: Self, rhs: Self) -> Bool {
             lhs.offset < rhs.offset
-        }
-
-        static func <= (lhs: Self, rhs: Self) -> Bool {
-            lhs.offset <= rhs.offset
-        }
-
-        static func >= (lhs: Self, rhs: Self) -> Bool {
-            lhs.offset >= rhs.offset
-        }
-
-        static func > (lhs: Self, rhs: Self) -> Bool {
-            lhs.offset > rhs.offset
         }
     }
     

--- a/Sources/PostgresNIO/New/Messages/DataRow.swift
+++ b/Sources/PostgresNIO/New/Messages/DataRow.swift
@@ -1,34 +1,132 @@
 import NIOCore
 
-extension PSQLBackendMessage {
+/// A backend data row message.
+///
+/// - NOTE: This struct is not part of the ``PSQLBackendMessage`` namespace even
+///         though this is where it actually belongs. The reason for this is, that we want
+///         this type to be @usableFromInline. If a type is made @usableFromInline in an
+///         enclosing type, the enclosing type must be @usableFromInline as well.
+///         Not putting `DataRow` in ``PSQLBackendMessage`` is our way to trick
+///         the Swift compiler
+struct DataRow: PSQLBackendMessage.PayloadDecodable, Equatable {
     
-    struct DataRow: PayloadDecodable, Equatable {
+    var columnCount: Int16
+    
+    var bytes: ByteBuffer
+    
+    static func decode(from buffer: inout ByteBuffer) throws -> Self {
+        try buffer.ensureAtLeastNBytesRemaining(2)
+        let columnCount = buffer.readInteger(as: Int16.self)!
+        let firstColumnIndex = buffer.readerIndex
         
-        var columns: [ByteBuffer?]
-        
-        static func decode(from buffer: inout ByteBuffer) throws -> Self {
+        for _ in 0..<columnCount {
             try buffer.ensureAtLeastNBytesRemaining(2)
-            let columnCount = buffer.readInteger(as: Int16.self)!
+            let bufferLength = Int(buffer.readInteger(as: Int32.self)!)
             
-            var result = [ByteBuffer?]()
-            result.reserveCapacity(Int(columnCount))
-            
-            for _ in 0..<columnCount {
-                try buffer.ensureAtLeastNBytesRemaining(2)
-                let bufferLength = Int(buffer.readInteger(as: Int32.self)!)
-                
-                guard bufferLength >= 0 else {
-                    result.append(nil)
-                    continue
-                }
-                
-                try buffer.ensureAtLeastNBytesRemaining(bufferLength)
-                let columnBuffer = buffer.readSlice(length: Int(bufferLength))!
-                
-                result.append(columnBuffer)
+            guard bufferLength >= 0 else {
+                // if buffer length is negative, this means that the value is null
+                continue
             }
             
-            return DataRow(columns: result)
+            try buffer.ensureAtLeastNBytesRemaining(bufferLength)
+            buffer.moveReaderIndex(forwardBy: bufferLength)
         }
+        
+        try buffer.ensureExactNBytesRemaining(0)
+        
+        buffer.moveReaderIndex(to: firstColumnIndex)
+        let columnSlice = buffer.readSlice(length: buffer.readableBytes)!
+        return DataRow(columnCount: columnCount, bytes: columnSlice)
+    }
+}
+
+extension DataRow: Sequence {
+    typealias Element = ByteBuffer?
+    
+    // There is no contiguous storage available... Sadly
+    func withContiguousStorageIfAvailable<R>(_ body: (UnsafeBufferPointer<ByteBuffer?>) throws -> R) rethrows -> R? {
+        nil
+    }
+}
+
+extension DataRow: Collection {
+    
+    struct ColumnIndex: Comparable {
+        var offset: Int
+        
+        init(_ index: Int) {
+            self.offset = index
+        }
+        
+        static func == (lhs: Self, rhs: Self) -> Bool {
+            lhs.offset == rhs.offset
+        }
+        
+        static func < (lhs: Self, rhs: Self) -> Bool {
+            lhs.offset < rhs.offset
+        }
+
+        static func <= (lhs: Self, rhs: Self) -> Bool {
+            lhs.offset <= rhs.offset
+        }
+
+        static func >= (lhs: Self, rhs: Self) -> Bool {
+            lhs.offset >= rhs.offset
+        }
+
+        static func > (lhs: Self, rhs: Self) -> Bool {
+            lhs.offset > rhs.offset
+        }
+    }
+    
+    typealias Index = DataRow.ColumnIndex
+    
+    var startIndex: ColumnIndex {
+        ColumnIndex(self.bytes.readerIndex)
+    }
+    
+    var endIndex: ColumnIndex {
+        ColumnIndex(self.bytes.readerIndex + self.bytes.readableBytes)
+    }
+    
+    var count: Int {
+        Int(self.columnCount)
+    }
+    
+    func index(after index: ColumnIndex) -> ColumnIndex {
+        guard index < self.endIndex else {
+            preconditionFailure("index out of bounds")
+        }
+        var elementLength = Int(self.bytes.getInteger(at: index.offset, as: Int32.self)!)
+        if elementLength < 0 {
+            elementLength = 0
+        }
+        return ColumnIndex(index.offset + MemoryLayout<Int32>.size + elementLength)
+    }
+    
+    subscript(index: ColumnIndex) -> Element {
+        guard index < self.endIndex else {
+            preconditionFailure("index out of bounds")
+        }
+        let elementLength = Int(self.bytes.getInteger(at: index.offset, as: Int32.self)!)
+        if elementLength < 0 {
+            return nil
+        }
+        return self.bytes.getSlice(at: index.offset + MemoryLayout<Int32>.size, length: elementLength)!
+    }
+}
+
+extension DataRow {
+    subscript(column index: Int) -> Element {
+        guard index < self.columnCount else {
+            preconditionFailure("index out of bounds")
+        }
+        
+        var byteIndex = self.startIndex
+        for _ in 0..<index {
+            byteIndex = self.index(after: byteIndex)
+        }
+        
+        return self[byteIndex]
     }
 }

--- a/Sources/PostgresNIO/New/Messages/RowDescription.swift
+++ b/Sources/PostgresNIO/New/Messages/RowDescription.swift
@@ -1,77 +1,82 @@
 import NIOCore
 
-extension PSQLBackendMessage {
+/// A backend row description message.
+///
+/// - NOTE: This struct is not part of the ``PSQLBackendMessage`` namespace even
+///         though this is where it actually belongs. The reason for this is, that we want
+///         this type to be @usableFromInline. If a type is made @usableFromInline in an
+///         enclosing type, the enclosing type must be @usableFromInline as well.
+///         Not putting `DataRow` in ``PSQLBackendMessage`` is our way to trick
+///         the Swift compiler.
+struct RowDescription: PSQLBackendMessage.PayloadDecodable, Equatable {
+    /// Specifies the object ID of the parameter data type.
+    var columns: [Column]
     
-    struct RowDescription: PayloadDecodable, Equatable {
-        /// Specifies the object ID of the parameter data type.
-        var columns: [Column]
+    struct Column: Equatable {
+        /// The field name.
+        var name: String
         
-        struct Column: Equatable {
-            /// The field name.
-            var name: String
-            
-            /// If the field can be identified as a column of a specific table, the object ID of the table; otherwise zero.
-            var tableOID: Int32
-            
-            /// If the field can be identified as a column of a specific table, the attribute number of the column; otherwise zero.
-            var columnAttributeNumber: Int16
-            
-            /// The object ID of the field's data type.
-            var dataType: PSQLDataType
-            
-            /// The data type size (see pg_type.typlen). Note that negative values denote variable-width types.
-            var dataTypeSize: Int16
-            
-            /// The type modifier (see pg_attribute.atttypmod). The meaning of the modifier is type-specific.
-            var dataTypeModifier: Int32
-            
-            /// The format being used for the field. Currently will be text or binary. In a RowDescription returned
-            /// from the statement variant of Describe, the format code is not yet known and will always be text.
-            var format: PSQLFormat
+        /// If the field can be identified as a column of a specific table, the object ID of the table; otherwise zero.
+        var tableOID: Int32
+        
+        /// If the field can be identified as a column of a specific table, the attribute number of the column; otherwise zero.
+        var columnAttributeNumber: Int16
+        
+        /// The object ID of the field's data type.
+        var dataType: PSQLDataType
+        
+        /// The data type size (see pg_type.typlen). Note that negative values denote variable-width types.
+        var dataTypeSize: Int16
+        
+        /// The type modifier (see pg_attribute.atttypmod). The meaning of the modifier is type-specific.
+        var dataTypeModifier: Int32
+        
+        /// The format being used for the field. Currently will be text or binary. In a RowDescription returned
+        /// from the statement variant of Describe, the format code is not yet known and will always be text.
+        var format: PSQLFormat
+    }
+    
+    static func decode(from buffer: inout ByteBuffer) throws -> Self {
+        try buffer.ensureAtLeastNBytesRemaining(2)
+        let columnCount = buffer.readInteger(as: Int16.self)!
+        
+        guard columnCount >= 0 else {
+            throw PSQLPartialDecodingError.integerMustBePositiveOrNull(columnCount)
         }
         
-        static func decode(from buffer: inout ByteBuffer) throws -> Self {
-            try buffer.ensureAtLeastNBytesRemaining(2)
-            let columnCount = buffer.readInteger(as: Int16.self)!
-            
-            guard columnCount >= 0 else {
-                throw PSQLPartialDecodingError.integerMustBePositiveOrNull(columnCount)
+        var result = [Column]()
+        result.reserveCapacity(Int(columnCount))
+        
+        for _ in 0..<columnCount {
+            guard let name = buffer.readNullTerminatedString() else {
+                throw PSQLPartialDecodingError.fieldNotDecodable(type: String.self)
             }
             
-            var result = [Column]()
-            result.reserveCapacity(Int(columnCount))
+            try buffer.ensureAtLeastNBytesRemaining(18)
             
-            for _ in 0..<columnCount {
-                guard let name = buffer.readNullTerminatedString() else {
-                    throw PSQLPartialDecodingError.fieldNotDecodable(type: String.self)
-                }
-                
-                try buffer.ensureAtLeastNBytesRemaining(18)
-                
-                let tableOID = buffer.readInteger(as: Int32.self)!
-                let columnAttributeNumber = buffer.readInteger(as: Int16.self)!
-                let dataType = PSQLDataType(rawValue: buffer.readInteger(as: Int32.self)!)
-                let dataTypeSize = buffer.readInteger(as: Int16.self)!
-                let dataTypeModifier = buffer.readInteger(as: Int32.self)!
-                let formatCodeInt16 = buffer.readInteger(as: Int16.self)!
-                
-                guard let format = PSQLFormat(rawValue: formatCodeInt16) else {
-                    throw PSQLPartialDecodingError.valueNotRawRepresentable(value: formatCodeInt16, asType: PSQLFormat.self)
-                }
-                
-                let field = Column(
-                    name: name,
-                    tableOID: tableOID,
-                    columnAttributeNumber: columnAttributeNumber,
-                    dataType: dataType,
-                    dataTypeSize: dataTypeSize,
-                    dataTypeModifier: dataTypeModifier,
-                    format: format)
-                
-                result.append(field)
+            let tableOID = buffer.readInteger(as: Int32.self)!
+            let columnAttributeNumber = buffer.readInteger(as: Int16.self)!
+            let dataType = PSQLDataType(rawValue: buffer.readInteger(as: Int32.self)!)
+            let dataTypeSize = buffer.readInteger(as: Int16.self)!
+            let dataTypeModifier = buffer.readInteger(as: Int32.self)!
+            let formatCodeInt16 = buffer.readInteger(as: Int16.self)!
+            
+            guard let format = PSQLFormat(rawValue: formatCodeInt16) else {
+                throw PSQLPartialDecodingError.valueNotRawRepresentable(value: formatCodeInt16, asType: PSQLFormat.self)
             }
             
-            return RowDescription(columns: result)
+            let field = Column(
+                name: name,
+                tableOID: tableOID,
+                columnAttributeNumber: columnAttributeNumber,
+                dataType: dataType,
+                dataTypeSize: dataTypeSize,
+                dataTypeModifier: dataTypeModifier,
+                format: format)
+            
+            result.append(field)
         }
+        
+        return RowDescription(columns: result)
     }
 }

--- a/Sources/PostgresNIO/New/PSQLChannelHandler.swift
+++ b/Sources/PostgresNIO/New/PSQLChannelHandler.swift
@@ -465,7 +465,7 @@ final class PSQLChannelHandler: ChannelDuplexHandler {
     
     private func succeedQueryWithRowStream(
         _ queryContext: ExtendedQueryContext,
-        columns: [PSQLBackendMessage.RowDescription.Column],
+        columns: [RowDescription.Column],
         context: ChannelHandlerContext)
     {
         let rows = PSQLRowStream(

--- a/Sources/PostgresNIO/New/PSQLConnection.swift
+++ b/Sources/PostgresNIO/New/PSQLConnection.swift
@@ -147,7 +147,7 @@ final class PSQLConnection {
     // MARK: Prepared statements
     
     func prepareStatement(_ query: String, with name: String, logger: Logger) -> EventLoopFuture<PSQLPreparedStatement> {
-        let promise = self.channel.eventLoop.makePromise(of: PSQLBackendMessage.RowDescription?.self)
+        let promise = self.channel.eventLoop.makePromise(of: RowDescription?.self)
         let context = PrepareStatementContext(
             name: name,
             query: query,

--- a/Sources/PostgresNIO/New/PSQLPreparedStatement.swift
+++ b/Sources/PostgresNIO/New/PSQLPreparedStatement.swift
@@ -10,5 +10,5 @@ struct PSQLPreparedStatement {
     let connection: PSQLConnection
     
     /// The `RowDescription` to apply to all `DataRow`s when executing this `PSQLPreparedStatement`
-    let rowDescription: PSQLBackendMessage.RowDescription?
+    let rowDescription: RowDescription?
 }

--- a/Sources/PostgresNIO/New/PSQLRowStream.swift
+++ b/Sources/PostgresNIO/New/PSQLRowStream.swift
@@ -12,8 +12,8 @@ final class PSQLRowStream {
     let logger: Logger
     
     private enum UpstreamState {
-        case streaming(buffer: CircularBuffer<PSQLBackendMessage.DataRow>, dataSource: PSQLRowsDataSource)
-        case finished(buffer: CircularBuffer<PSQLBackendMessage.DataRow>, commandTag: String)
+        case streaming(buffer: CircularBuffer<DataRow>, dataSource: PSQLRowsDataSource)
+        case finished(buffer: CircularBuffer<DataRow>, commandTag: String)
         case failure(Error)
         case consumed(Result<String, Error>)
         case modifying
@@ -25,18 +25,18 @@ final class PSQLRowStream {
         case consuming
     }
     
-    internal let rowDescription: [PSQLBackendMessage.RowDescription.Column]
+    internal let rowDescription: [RowDescription.Column]
     private let lookupTable: [String: Int]
     private var upstreamState: UpstreamState
     private var downstreamState: DownstreamState
     private let jsonDecoder: PSQLJSONDecoder
     
-    init(rowDescription: [PSQLBackendMessage.RowDescription.Column],
+    init(rowDescription: [RowDescription.Column],
          queryContext: ExtendedQueryContext,
          eventLoop: EventLoop,
          rowSource: RowSource)
     {
-        let buffer = CircularBuffer<PSQLBackendMessage.DataRow>()
+        let buffer = CircularBuffer<DataRow>()
         
         self.downstreamState = .consuming
         switch rowSource {
@@ -186,7 +186,7 @@ final class PSQLRowStream {
         ])
     }
     
-    internal func receive(_ newRows: CircularBuffer<PSQLBackendMessage.DataRow>) {
+    internal func receive(_ newRows: [DataRow]) {
         precondition(!newRows.isEmpty, "Expected to get rows!")
         self.eventLoop.preconditionInEventLoop()
         self.logger.trace("Row stream received rows", metadata: [

--- a/Sources/PostgresNIO/New/PSQLTask.swift
+++ b/Sources/PostgresNIO/New/PSQLTask.swift
@@ -21,7 +21,7 @@ enum PSQLTask {
 final class ExtendedQueryContext {
     enum Query {
         case unnamed(String)
-        case preparedStatement(name: String, rowDescription: PSQLBackendMessage.RowDescription?)
+        case preparedStatement(name: String, rowDescription: RowDescription?)
     }
     
     let query: Query
@@ -65,12 +65,12 @@ final class PrepareStatementContext {
     let name: String
     let query: String
     let logger: Logger
-    let promise: EventLoopPromise<PSQLBackendMessage.RowDescription?>
+    let promise: EventLoopPromise<RowDescription?>
     
     init(name: String,
          query: String,
          logger: Logger,
-         promise: EventLoopPromise<PSQLBackendMessage.RowDescription?>)
+         promise: EventLoopPromise<RowDescription?>)
     {
         self.name = name
         self.query = query

--- a/Tests/PostgresNIOTests/New/Connection State Machine/ExtendedQueryStateMachineTests.swift
+++ b/Tests/PostgresNIOTests/New/Connection State Machine/ExtendedQueryStateMachineTests.swift
@@ -40,25 +40,25 @@ class ExtendedQueryStateMachineTests: XCTestCase {
         // We need to ensure that even though the row description from the wire says that we
         // will receive data in `.text` format, we will actually receive it in binary format,
         // since we requested it in binary with our bind message.
-        let input: [PSQLBackendMessage.RowDescription.Column] = [
+        let input: [RowDescription.Column] = [
             .init(name: "version", tableOID: 0, columnAttributeNumber: 0, dataType: .text, dataTypeSize: -1, dataTypeModifier: -1, format: .text)
         ]
-        let expected: [PSQLBackendMessage.RowDescription.Column] = input.map {
+        let expected: [RowDescription.Column] = input.map {
             .init(name: $0.name, tableOID: $0.tableOID, columnAttributeNumber: $0.columnAttributeNumber, dataType: $0.dataType,
                   dataTypeSize: $0.dataTypeSize, dataTypeModifier: $0.dataTypeModifier, format: .binary)
         }
         
         XCTAssertEqual(state.rowDescriptionReceived(.init(columns: input)), .wait)
         XCTAssertEqual(state.bindCompleteReceived(), .succeedQuery(queryContext, columns: expected))
-        let row1: PSQLBackendMessage.DataRow = [ByteBuffer(string: "test1")]
+        let row1: DataRow = [ByteBuffer(string: "test1")]
         XCTAssertEqual(state.dataRowReceived(row1), .wait)
         XCTAssertEqual(state.channelReadComplete(), .forwardRows([row1]))
         XCTAssertEqual(state.readEventCaught(), .wait)
         XCTAssertEqual(state.requestQueryRows(), .read)
         
-        let row2: PSQLBackendMessage.DataRow = [ByteBuffer(string: "test2")]
-        let row3: PSQLBackendMessage.DataRow = [ByteBuffer(string: "test3")]
-        let row4: PSQLBackendMessage.DataRow = [ByteBuffer(string: "test4")]
+        let row2: DataRow = [ByteBuffer(string: "test2")]
+        let row3: DataRow = [ByteBuffer(string: "test3")]
+        let row4: DataRow = [ByteBuffer(string: "test4")]
         XCTAssertEqual(state.dataRowReceived(row2), .wait)
         XCTAssertEqual(state.dataRowReceived(row3), .wait)
         XCTAssertEqual(state.dataRowReceived(row4), .wait)
@@ -69,8 +69,8 @@ class ExtendedQueryStateMachineTests: XCTestCase {
         XCTAssertEqual(state.channelReadComplete(), .wait)
         XCTAssertEqual(state.readEventCaught(), .read)
         
-        let row5: PSQLBackendMessage.DataRow = [ByteBuffer(string: "test5")]
-        let row6: PSQLBackendMessage.DataRow = [ByteBuffer(string: "test6")]
+        let row5: DataRow = [ByteBuffer(string: "test5")]
+        let row6: DataRow = [ByteBuffer(string: "test6")]
         XCTAssertEqual(state.dataRowReceived(row5), .wait)
         XCTAssertEqual(state.dataRowReceived(row6), .wait)
         

--- a/Tests/PostgresNIOTests/New/Connection State Machine/PrepareStatementStateMachineTests.swift
+++ b/Tests/PostgresNIOTests/New/Connection State Machine/PrepareStatementStateMachineTests.swift
@@ -7,7 +7,7 @@ class PrepareStatementStateMachineTests: XCTestCase {
     func testCreatePreparedStatementReturningRowDescription() {
         var state = ConnectionStateMachine.readyForQuery()
         
-        let promise = EmbeddedEventLoop().makePromise(of: PSQLBackendMessage.RowDescription?.self)
+        let promise = EmbeddedEventLoop().makePromise(of: RowDescription?.self)
         promise.fail(PSQLError.uncleanShutdown) // we don't care about the error at all.
         
         let name = "haha"
@@ -20,7 +20,7 @@ class PrepareStatementStateMachineTests: XCTestCase {
         XCTAssertEqual(state.parseCompleteReceived(), .wait)
         XCTAssertEqual(state.parameterDescriptionReceived(.init(dataTypes: [.int8])), .wait)
         
-        let columns: [PSQLBackendMessage.RowDescription.Column] = [
+        let columns: [RowDescription.Column] = [
             .init(name: "id", tableOID: 0, columnAttributeNumber: 0, dataType: .int8, dataTypeSize: 8, dataTypeModifier: -1, format: .binary)
         ]
         
@@ -32,7 +32,7 @@ class PrepareStatementStateMachineTests: XCTestCase {
     func testCreatePreparedStatementReturningNoData() {
         var state = ConnectionStateMachine.readyForQuery()
         
-        let promise = EmbeddedEventLoop().makePromise(of: PSQLBackendMessage.RowDescription?.self)
+        let promise = EmbeddedEventLoop().makePromise(of: RowDescription?.self)
         promise.fail(PSQLError.uncleanShutdown) // we don't care about the error at all.
         
         let name = "haha"

--- a/Tests/PostgresNIOTests/New/Extensions/PSQLBackendMessage+Equatable.swift
+++ b/Tests/PostgresNIOTests/New/Extensions/PSQLBackendMessage+Equatable.swift
@@ -1,4 +1,5 @@
 @testable import PostgresNIO
+import class Foundation.JSONEncoder
 
 extension PSQLBackendMessage: Equatable {
     
@@ -45,13 +46,5 @@ extension PSQLBackendMessage: Equatable {
         default:
             return false
         }
-    }
-}
-
-extension PSQLBackendMessage.DataRow: ExpressibleByArrayLiteral {
-    public typealias ArrayLiteralElement = ByteBuffer
-
-    public init(arrayLiteral elements: ByteBuffer...) {
-        self.init(columns: elements)
     }
 }

--- a/Tests/PostgresNIOTests/New/Extensions/PSQLBackendMessage+Equatable.swift
+++ b/Tests/PostgresNIOTests/New/Extensions/PSQLBackendMessage+Equatable.swift
@@ -1,5 +1,4 @@
 @testable import PostgresNIO
-import class Foundation.JSONEncoder
 
 extension PSQLBackendMessage: Equatable {
     

--- a/Tests/PostgresNIOTests/New/Extensions/PSQLBackendMessageEncoder.swift
+++ b/Tests/PostgresNIOTests/New/Extensions/PSQLBackendMessageEncoder.swift
@@ -188,19 +188,10 @@ extension PSQLBackendMessage.BackendKeyData: PSQLMessagePayloadEncodable {
     }
 }
 
-extension PSQLBackendMessage.DataRow: PSQLMessagePayloadEncodable {
+extension DataRow: PSQLMessagePayloadEncodable {
     public func encode(into buffer: inout ByteBuffer) {
-        buffer.writeInteger(Int16(self.columns.count))
-        
-        for column in self.columns {
-            switch column {
-            case .none:
-                buffer.writeInteger(-1, as: Int32.self)
-            case .some(var writable):
-                buffer.writeInteger(Int32(writable.readableBytes))
-                buffer.writeBuffer(&writable)
-            }
-        }
+        buffer.writeInteger(Int16(self.columnCount))
+        buffer.writeBytes(self.bytes.readableBytesView)
     }
 }
 
@@ -255,7 +246,7 @@ extension PSQLBackendMessage.TransactionState: PSQLMessagePayloadEncodable {
     }
 }
 
-extension PSQLBackendMessage.RowDescription: PSQLMessagePayloadEncodable {
+extension RowDescription: PSQLMessagePayloadEncodable {
     public func encode(into buffer: inout ByteBuffer) {
         buffer.writeInteger(Int16(self.columns.count))
         

--- a/Tests/PostgresNIOTests/New/Extensions/PSQLBackendMessageEncoder.swift
+++ b/Tests/PostgresNIOTests/New/Extensions/PSQLBackendMessageEncoder.swift
@@ -190,7 +190,7 @@ extension PSQLBackendMessage.BackendKeyData: PSQLMessagePayloadEncodable {
 
 extension DataRow: PSQLMessagePayloadEncodable {
     public func encode(into buffer: inout ByteBuffer) {
-        buffer.writeInteger(Int16(self.columnCount))
+        buffer.writeInteger(self.columnCount, as: Int16.self)
         buffer.writeBytes(self.bytes.readableBytesView)
     }
 }

--- a/Tests/PostgresNIOTests/New/Messages/DataRowTests.swift
+++ b/Tests/PostgresNIOTests/New/Messages/DataRowTests.swift
@@ -20,18 +20,127 @@ class DataRowTests: XCTestCase {
             buffer.writeBytes([UInt8](repeating: 5, count: 10))
         }
 
-        let expectedColumns: [ByteBuffer?] = [
-            nil,
-            ByteBuffer(),
-            ByteBuffer(bytes: [UInt8](repeating: 5, count: 10))
-        ]
-        
+        let rowSlice = buffer.getSlice(at: 7, length: buffer.readableBytes - 7)!
+
         let expectedInOuts = [
-            (buffer, [PSQLBackendMessage.dataRow(.init(columns: expectedColumns))]),
+            (buffer, [PSQLBackendMessage.dataRow(.init(columnCount: 3, bytes: rowSlice))]),
         ]
-        
+
         XCTAssertNoThrow(try ByteToMessageDecoderVerifier.verifyDecoder(
             inputOutputPairs: expectedInOuts,
             decoderFactory: { PSQLBackendMessageDecoder(hasAlreadyReceivedBytes: false) }))
     }
+    
+    func testIteratingElements() {
+        let dataRow = DataRow.makeTestDataRow(nil, ByteBuffer(), ByteBuffer(repeating: 5, count: 10))
+        var iterator = dataRow.makeIterator()
+        
+        XCTAssertEqual(dataRow.count, 3)
+        XCTAssertEqual(iterator.next(), .some(.none))
+        XCTAssertEqual(iterator.next(), ByteBuffer())
+        XCTAssertEqual(iterator.next(), ByteBuffer(repeating: 5, count: 10))
+        XCTAssertEqual(iterator.next(), .none)
+    }
+    
+    func testIndexAfterAndSubscript() {
+        let dataRow = DataRow.makeTestDataRow(
+            nil,
+            ByteBuffer(),
+            ByteBuffer(repeating: 5, count: 10),
+            nil
+        )
+        
+        var index = dataRow.startIndex
+        XCTAssertEqual(dataRow[index], .none)
+        index = dataRow.index(after: index)
+        XCTAssertEqual(dataRow[index], ByteBuffer())
+        index = dataRow.index(after: index)
+        XCTAssertEqual(dataRow[index], ByteBuffer(repeating: 5, count: 10))
+        index = dataRow.index(after: index)
+        XCTAssertEqual(dataRow[index], .none)
+        index = dataRow.index(after: index)
+        XCTAssertEqual(index, dataRow.endIndex)
+    }
+    
+    func testIndexComparison() {
+        let dataRow = DataRow.makeTestDataRow(
+            nil,
+            ByteBuffer(),
+            ByteBuffer(repeating: 5, count: 10),
+            nil
+        )
+        
+        let startIndex = dataRow.startIndex
+        let secondIndex = dataRow.index(after: startIndex)
+        
+        XCTAssertLessThanOrEqual(startIndex, secondIndex)
+        XCTAssertLessThan(startIndex, secondIndex)
+        
+        XCTAssertGreaterThanOrEqual(secondIndex, startIndex)
+        XCTAssertGreaterThan(secondIndex, startIndex)
+        
+        XCTAssertFalse(secondIndex == startIndex)
+        XCTAssertEqual(secondIndex, secondIndex)
+        XCTAssertEqual(startIndex, startIndex)
+    }
+    
+    func testColumnSubscript() {
+        let dataRow = DataRow.makeTestDataRow(
+            nil,
+            ByteBuffer(),
+            ByteBuffer(repeating: 5, count: 10),
+            nil
+        )
+    
+        XCTAssertEqual(dataRow.count, 4)
+        XCTAssertEqual(dataRow[column: 0], .none)
+        XCTAssertEqual(dataRow[column: 1], ByteBuffer())
+        XCTAssertEqual(dataRow[column: 2], ByteBuffer(repeating: 5, count: 10))
+        XCTAssertEqual(dataRow[column: 3], .none)
+    }
+    
+    func testWithContiguousStorageIfAvailable() {
+        let dataRow = DataRow.makeTestDataRow(
+            nil,
+            ByteBuffer(),
+            ByteBuffer(repeating: 5, count: 10),
+            nil
+        )
+        
+        XCTAssertNil(dataRow.withContiguousStorageIfAvailable { _ -> Int in
+            XCTFail("DataRow does not have a contiguous storage")
+            return 123
+        })
+    }
 }
+
+extension DataRow: ExpressibleByArrayLiteral {
+    public typealias ArrayLiteralElement = PSQLEncodable
+
+    public init(arrayLiteral elements: PSQLEncodable...) {
+        
+        var buffer = ByteBuffer()
+        let encodingContext = PSQLEncodingContext(jsonEncoder: JSONEncoder())
+        elements.forEach { element in
+            try! element.encodeRaw(into: &buffer, context: encodingContext)
+        }
+        
+        self.init(columnCount: Int16(elements.count), bytes: buffer)
+    }
+    
+    static func makeTestDataRow(_ buffers: ByteBuffer?...) -> DataRow {
+        var bytes = ByteBuffer()
+        buffers.forEach { column in
+            switch column {
+            case .none:
+                bytes.writeInteger(Int32(-1))
+            case .some(var input):
+                bytes.writeInteger(Int32(input.readableBytes))
+                bytes.writeBuffer(&input)
+            }
+        }
+        
+        return DataRow(columnCount: Int16(buffers.count), bytes: bytes)
+    }
+}
+

--- a/Tests/PostgresNIOTests/New/Messages/DataRowTests.swift
+++ b/Tests/PostgresNIOTests/New/Messages/DataRowTests.swift
@@ -107,9 +107,8 @@ class DataRowTests: XCTestCase {
             nil
         )
         
-        XCTAssertNil(dataRow.withContiguousStorageIfAvailable { _ -> Int in
-            XCTFail("DataRow does not have a contiguous storage")
-            return 123
+        XCTAssertNil(dataRow.withContiguousStorageIfAvailable { _ in
+            return XCTFail("DataRow does not have a contiguous storage")
         })
     }
 }

--- a/Tests/PostgresNIOTests/New/Messages/RowDescriptionTests.swift
+++ b/Tests/PostgresNIOTests/New/Messages/RowDescriptionTests.swift
@@ -6,7 +6,7 @@ import NIOTestUtils
 class RowDescriptionTests: XCTestCase {
     
     func testDecode() {
-        let columns: [PSQLBackendMessage.RowDescription.Column] = [
+        let columns: [RowDescription.Column] = [
             .init(name: "First", tableOID: 123, columnAttributeNumber: 123, dataType: .bool, dataTypeSize: 2, dataTypeModifier: 8, format: .binary),
             .init(name: "Second", tableOID: 123, columnAttributeNumber: 456, dataType: .uuidArray, dataTypeSize: 567, dataTypeModifier: 123, format: .text),
         ]
@@ -42,7 +42,7 @@ class RowDescriptionTests: XCTestCase {
     }
     
     func testDecodeFailureBecauseOfMissingNullTerminationInColumnName() {
-        let column = PSQLBackendMessage.RowDescription.Column(
+        let column = RowDescription.Column(
             name: "First", tableOID: 123, columnAttributeNumber: 123, dataType: .bool, dataTypeSize: 2, dataTypeModifier: 8, format: .binary)
         
         var buffer = ByteBuffer()
@@ -65,7 +65,7 @@ class RowDescriptionTests: XCTestCase {
     }
     
     func testDecodeFailureBecauseOfMissingColumnCount() {
-        let column = PSQLBackendMessage.RowDescription.Column(
+        let column = RowDescription.Column(
             name: "First", tableOID: 123, columnAttributeNumber: 123, dataType: .bool, dataTypeSize: 2, dataTypeModifier: 8, format: .binary)
         
         var buffer = ByteBuffer()
@@ -87,7 +87,7 @@ class RowDescriptionTests: XCTestCase {
     }
     
     func testDecodeFailureBecauseInvalidFormatCode() {
-        let column = PSQLBackendMessage.RowDescription.Column(
+        let column = RowDescription.Column(
             name: "First", tableOID: 123, columnAttributeNumber: 123, dataType: .bool, dataTypeSize: 2, dataTypeModifier: 8, format: .binary)
         
         var buffer = ByteBuffer()
@@ -110,7 +110,7 @@ class RowDescriptionTests: XCTestCase {
     }
     
     func testDecodeFailureBecauseNegativeColumnCount() {
-        let column = PSQLBackendMessage.RowDescription.Column(
+        let column = RowDescription.Column(
             name: "First", tableOID: 123, columnAttributeNumber: 123, dataType: .bool, dataTypeSize: 2, dataTypeModifier: 8, format: .binary)
         
         var buffer = ByteBuffer()


### PR DESCRIPTION
This is a cherry pick of #188.

### Modifications

- `DataRow` and `RowDescription` have been moved out of the `PSQLBackendMessage` namespace. This allows us to mark them as `@inlinable` or `@usableFromInline` at a later point, without marking everything in `PSQLBackendMessage` as `@inlinable`
- `DataRow` does not use an internal array for its columns anymore. Instead all read operations are directly done on its ByteBuffer slice.
- `DataRow` implements the `Collection` protocol now.

### Result

One allocation fewer per queried row.