### PR TITLE
Add missing debug logging of raw queries

### DIFF
--- a/Sources/PostgresNIO/PostgresDatabase+Query.swift
+++ b/Sources/PostgresNIO/PostgresDatabase+Query.swift
@@ -23,6 +23,8 @@ extension PostgresDatabase {
         onMetadata: @escaping (PostgresQueryMetadata) -> () = { _ in },
         onRow: @escaping (PostgresRow) throws -> ()
     ) -> EventLoopFuture<Void> {
+        self.logger.debug("\(string) \(binds)")
+
         let request = PostgresCommands.query(query: string, binds: binds, onMetadata: onMetadata, onRow: onRow)
         
         return self.send(request, logger: logger)


### PR DESCRIPTION
Raw queries and their bindings are now logged at the `.debug` log level, as with MySQLNIO.