### PR TITLE
Merge type PSQLFormat into PostgresFormat

### DIFF
--- a/Sources/PostgresNIO/Data/PostgresData.swift
+++ b/Sources/PostgresNIO/Data/PostgresData.swift
@@ -16,11 +16,11 @@ public struct PostgresData: CustomStringConvertible, CustomDebugStringConvertibl
     /// Currently will be zero (text) or one (binary).
     /// In a RowDescription returned from the statement variant of Describe,
     /// the format code is not yet known and will always be zero.
-    public var formatCode: PostgresFormatCode
+    public var formatCode: PostgresFormat
     
     public var value: ByteBuffer?
     
-    public init(type: PostgresDataType, typeModifier: Int32? = nil, formatCode: PostgresFormatCode = .binary, value: ByteBuffer? = nil) {
+    public init(type: PostgresDataType, typeModifier: Int32? = nil, formatCode: PostgresFormat = .binary, value: ByteBuffer? = nil) {
         self.type = type
         self.typeModifier = typeModifier
         self.formatCode = formatCode

--- a/Sources/PostgresNIO/Data/PostgresDataType.swift
+++ b/Sources/PostgresNIO/Data/PostgresDataType.swift
@@ -17,8 +17,10 @@ extension PostgresFormat: CustomStringConvertible {
     }
 }
 
+// TODO: The Codable conformance does not make any sense. Let's remove this with next major break.
 extension PostgresFormat: Codable {}
 
+// TODO: Renamed during 1.x. Remove this with next major break.
 @available(*, deprecated, renamed: "PostgresFormat")
 public typealias PostgresFormatCode = PostgresFormat
 

--- a/Sources/PostgresNIO/Data/PostgresDataType.swift
+++ b/Sources/PostgresNIO/Data/PostgresDataType.swift
@@ -1,11 +1,14 @@
-/// The format code being used for the field.
-/// Currently will be zero (text) or one (binary).
-/// In a RowDescription returned from the statement variant of Describe,
-/// the format code is not yet known and will always be zero.
-public enum PostgresFormatCode: Int16, Codable, CustomStringConvertible {
+/// The format the postgres types are encoded in on the wire.
+///
+/// Currently there a two wire formats supported:
+///  - text
+///  - binary
+public enum PostgresFormat: Int16 {
     case text = 0
     case binary = 1
-    
+}
+
+extension PostgresFormat: CustomStringConvertible {
     public var description: String {
         switch self {
         case .text: return "text"
@@ -13,6 +16,11 @@ public enum PostgresFormatCode: Int16, Codable, CustomStringConvertible {
         }
     }
 }
+
+extension PostgresFormat: Codable {}
+
+@available(*, deprecated, renamed: "PostgresFormat")
+public typealias PostgresFormatCode = PostgresFormat
 
 /// The data type's raw object ID.
 /// Use `select * from pg_type where oid = <idhere>;` to lookup more information.

--- a/Sources/PostgresNIO/Data/PostgresRow.swift
+++ b/Sources/PostgresNIO/Data/PostgresRow.swift
@@ -1,7 +1,7 @@
 public struct PostgresRow: CustomStringConvertible {
     final class LookupTable {
         let rowDescription: PostgresMessage.RowDescription
-        let resultFormat: [PostgresFormatCode]
+        let resultFormat: [PostgresFormat]
 
         struct Value {
             let index: Int
@@ -27,7 +27,7 @@ public struct PostgresRow: CustomStringConvertible {
 
         init(
             rowDescription: PostgresMessage.RowDescription,
-            resultFormat: [PostgresFormatCode]
+            resultFormat: [PostgresFormat]
         ) {
             self.rowDescription = rowDescription
             self.resultFormat = resultFormat
@@ -54,7 +54,7 @@ public struct PostgresRow: CustomStringConvertible {
         guard let entry = self.lookupTable.lookup(column: column) else {
             return nil
         }
-        let formatCode: PostgresFormatCode
+        let formatCode: PostgresFormat
         switch self.lookupTable.resultFormat.count {
         case 1: formatCode = self.lookupTable.resultFormat[0]
         default: formatCode = entry.field.formatCode

--- a/Sources/PostgresNIO/Message/PostgresMessage+Bind.swift
+++ b/Sources/PostgresNIO/Message/PostgresMessage+Bind.swift
@@ -26,7 +26,7 @@ extension PostgresMessage {
         /// This can be zero to indicate that there are no parameters or that the parameters all use the default format (text);
         /// or one, in which case the specified format code is applied to all parameters; or it can equal the actual number of parameters.
         /// The parameter format codes. Each must presently be zero (text) or one (binary).
-        public var parameterFormatCodes: [PostgresFormatCode]
+        public var parameterFormatCodes: [PostgresFormat]
         
         /// The number of parameter values that follow (possibly zero). This must match the number of parameters needed by the query.
         public var parameters: [Parameter]
@@ -35,7 +35,7 @@ extension PostgresMessage {
         /// This can be zero to indicate that there are no result columns or that the result columns should all use the default format (text);
         /// or one, in which case the specified format code is applied to all result columns (if any);
         /// or it can equal the actual number of result columns of the query.
-        public var resultFormatCodes: [PostgresFormatCode]
+        public var resultFormatCodes: [PostgresFormat]
         
         /// Serializes this message into a byte buffer.
         public func serialize(into buffer: inout ByteBuffer) {

--- a/Sources/PostgresNIO/Message/PostgresMessage+RowDescription.swift
+++ b/Sources/PostgresNIO/Message/PostgresMessage+RowDescription.swift
@@ -29,7 +29,7 @@ extension PostgresMessage {
                 guard let dataTypeModifier = buffer.readInteger(as: Int32.self) else {
                     throw PostgresError.protocol("Could not read row description field data type modifier")
                 }
-                guard let formatCode = buffer.readInteger(as: PostgresFormatCode.self) else {
+                guard let formatCode = buffer.readInteger(as: PostgresFormat.self) else {
                     throw PostgresError.protocol("Could not read row description field format code")
                 }
                 return .init(
@@ -65,7 +65,7 @@ extension PostgresMessage {
             /// Currently will be zero (text) or one (binary).
             /// In a RowDescription returned from the statement variant of Describe,
             /// the format code is not yet known and will always be zero.
-            public var formatCode: PostgresFormatCode
+            public var formatCode: PostgresFormat
             
             /// See `CustomStringConvertible`.
             public var description: String {

--- a/Sources/PostgresNIO/New/Data/Array+PSQLCodable.swift
+++ b/Sources/PostgresNIO/New/Data/Array+PSQLCodable.swift
@@ -72,7 +72,7 @@ extension Array: PSQLEncodable where Element: PSQLArrayElement {
         Element.psqlArrayType
     }
     
-    var psqlFormat: PSQLFormat {
+    var psqlFormat: PostgresFormat {
         .binary
     }
     
@@ -102,7 +102,7 @@ extension Array: PSQLEncodable where Element: PSQLArrayElement {
 
 extension Array: PSQLDecodable where Element: PSQLArrayElement {
     
-    static func decode(from buffer: inout ByteBuffer, type: PSQLDataType, format: PSQLFormat, context: PSQLDecodingContext) throws -> Array<Element> {
+    static func decode(from buffer: inout ByteBuffer, type: PSQLDataType, format: PostgresFormat, context: PSQLDecodingContext) throws -> Array<Element> {
         guard case .binary = format else {
             // currently we only support decoding arrays in binary format.
             throw PSQLCastingError.failure(targetType: Self.self, type: type, postgresData: buffer, context: context)

--- a/Sources/PostgresNIO/New/Data/Bool+PSQLCodable.swift
+++ b/Sources/PostgresNIO/New/Data/Bool+PSQLCodable.swift
@@ -5,11 +5,11 @@ extension Bool: PSQLCodable {
         .bool
     }
     
-    var psqlFormat: PSQLFormat {
+    var psqlFormat: PostgresFormat {
         .binary
     }
     
-    static func decode(from buffer: inout ByteBuffer, type: PSQLDataType, format: PSQLFormat, context: PSQLDecodingContext) throws -> Bool {
+    static func decode(from buffer: inout ByteBuffer, type: PSQLDataType, format: PostgresFormat, context: PSQLDecodingContext) throws -> Bool {
         guard type == .bool else {
             throw PSQLCastingError.failure(targetType: Self.self, type: type, postgresData: buffer, context: context)
         }

--- a/Sources/PostgresNIO/New/Data/Bytes+PSQLCodable.swift
+++ b/Sources/PostgresNIO/New/Data/Bytes+PSQLCodable.swift
@@ -7,7 +7,7 @@ extension PSQLEncodable where Self: Sequence, Self.Element == UInt8 {
         .bytea
     }
     
-    var psqlFormat: PSQLFormat {
+    var psqlFormat: PostgresFormat {
         .binary
     }
     
@@ -21,7 +21,7 @@ extension ByteBuffer: PSQLCodable {
         .bytea
     }
     
-    var psqlFormat: PSQLFormat {
+    var psqlFormat: PostgresFormat {
         .binary
     }
     
@@ -30,7 +30,7 @@ extension ByteBuffer: PSQLCodable {
         byteBuffer.writeBuffer(&copyOfSelf)
     }
     
-    static func decode(from buffer: inout ByteBuffer, type: PSQLDataType, format: PSQLFormat, context: PSQLDecodingContext) throws -> Self {
+    static func decode(from buffer: inout ByteBuffer, type: PSQLDataType, format: PostgresFormat, context: PSQLDecodingContext) throws -> Self {
         return buffer
     }
 }
@@ -40,7 +40,7 @@ extension Data: PSQLCodable {
         .bytea
     }
 
-    var psqlFormat: PSQLFormat {
+    var psqlFormat: PostgresFormat {
         .binary
     }
 
@@ -48,7 +48,7 @@ extension Data: PSQLCodable {
         byteBuffer.writeBytes(self)
     }
 
-    static func decode(from buffer: inout ByteBuffer, type: PSQLDataType, format: PSQLFormat, context: PSQLDecodingContext) throws -> Self {
+    static func decode(from buffer: inout ByteBuffer, type: PSQLDataType, format: PostgresFormat, context: PSQLDecodingContext) throws -> Self {
         return buffer.readData(length: buffer.readableBytes, byteTransferStrategy: .automatic)!
     }
 }

--- a/Sources/PostgresNIO/New/Data/Date+PSQLCodable.swift
+++ b/Sources/PostgresNIO/New/Data/Date+PSQLCodable.swift
@@ -6,11 +6,11 @@ extension Date: PSQLCodable {
         .timestamptz
     }
     
-    var psqlFormat: PSQLFormat {
+    var psqlFormat: PostgresFormat {
         .binary
     }
     
-    static func decode(from buffer: inout ByteBuffer, type: PSQLDataType, format: PSQLFormat, context: PSQLDecodingContext) throws -> Self {
+    static func decode(from buffer: inout ByteBuffer, type: PSQLDataType, format: PostgresFormat, context: PSQLDecodingContext) throws -> Self {
         switch type {
         case .timestamp, .timestamptz:
             guard buffer.readableBytes == 8, let microseconds = buffer.readInteger(as: Int64.self) else {

--- a/Sources/PostgresNIO/New/Data/Decimal+PSQLCodable.swift
+++ b/Sources/PostgresNIO/New/Data/Decimal+PSQLCodable.swift
@@ -6,11 +6,11 @@ extension Decimal: PSQLCodable {
         .numeric
     }
     
-    var psqlFormat: PSQLFormat {
+    var psqlFormat: PostgresFormat {
         .binary
     }
     
-    static func decode(from byteBuffer: inout ByteBuffer, type: PSQLDataType, format: PSQLFormat, context: PSQLDecodingContext) throws -> Decimal {
+    static func decode(from byteBuffer: inout ByteBuffer, type: PSQLDataType, format: PostgresFormat, context: PSQLDecodingContext) throws -> Decimal {
         switch (format, type) {
         case (.binary, .numeric):
             guard let numeric = PostgresNumeric(buffer: &byteBuffer) else {

--- a/Sources/PostgresNIO/New/Data/Float+PSQLCodable.swift
+++ b/Sources/PostgresNIO/New/Data/Float+PSQLCodable.swift
@@ -5,11 +5,11 @@ extension Float: PSQLCodable {
         .float4
     }
     
-    var psqlFormat: PSQLFormat {
+    var psqlFormat: PostgresFormat {
         .binary
     }
     
-    static func decode(from buffer: inout ByteBuffer, type: PSQLDataType, format: PSQLFormat, context: PSQLDecodingContext) throws -> Float {
+    static func decode(from buffer: inout ByteBuffer, type: PSQLDataType, format: PostgresFormat, context: PSQLDecodingContext) throws -> Float {
         switch (format, type) {
         case (.binary, .float4):
             guard buffer.readableBytes == 4, let float = buffer.psqlReadFloat() else {
@@ -41,11 +41,11 @@ extension Double: PSQLCodable {
         .float8
     }
     
-    var psqlFormat: PSQLFormat {
+    var psqlFormat: PostgresFormat {
         .binary
     }
     
-    static func decode(from buffer: inout ByteBuffer, type: PSQLDataType, format: PSQLFormat, context: PSQLDecodingContext) throws -> Double {
+    static func decode(from buffer: inout ByteBuffer, type: PSQLDataType, format: PostgresFormat, context: PSQLDecodingContext) throws -> Double {
         switch (format, type) {
         case (.binary, .float4):
             guard buffer.readableBytes == 4, let float = buffer.psqlReadFloat() else {

--- a/Sources/PostgresNIO/New/Data/Int+PSQLCodable.swift
+++ b/Sources/PostgresNIO/New/Data/Int+PSQLCodable.swift
@@ -5,12 +5,12 @@ extension UInt8: PSQLCodable {
         .char
     }
     
-    var psqlFormat: PSQLFormat {
+    var psqlFormat: PostgresFormat {
         .binary
     }
     
     // decoding
-    static func decode(from buffer: inout ByteBuffer, type: PSQLDataType, format: PSQLFormat, context: PSQLDecodingContext) throws -> Self {
+    static func decode(from buffer: inout ByteBuffer, type: PSQLDataType, format: PostgresFormat, context: PSQLDecodingContext) throws -> Self {
         switch type {
         case .bpchar, .char:
             guard buffer.readableBytes == 1, let value = buffer.readInteger(as: UInt8.self) else {
@@ -35,12 +35,12 @@ extension Int16: PSQLCodable {
         .int2
     }
     
-    var psqlFormat: PSQLFormat {
+    var psqlFormat: PostgresFormat {
         .binary
     }
     
     // decoding
-    static func decode(from buffer: inout ByteBuffer, type: PSQLDataType, format: PSQLFormat, context: PSQLDecodingContext) throws -> Self {
+    static func decode(from buffer: inout ByteBuffer, type: PSQLDataType, format: PostgresFormat, context: PSQLDecodingContext) throws -> Self {
         switch (format, type) {
         case (.binary, .int2):
             guard buffer.readableBytes == 2, let value = buffer.readInteger(as: Int16.self) else {
@@ -68,12 +68,12 @@ extension Int32: PSQLCodable {
         .int4
     }
     
-    var psqlFormat: PSQLFormat {
+    var psqlFormat: PostgresFormat {
         .binary
     }
     
     // decoding
-    static func decode(from buffer: inout ByteBuffer, type: PSQLDataType, format: PSQLFormat, context: PSQLDecodingContext) throws -> Self {
+    static func decode(from buffer: inout ByteBuffer, type: PSQLDataType, format: PostgresFormat, context: PSQLDecodingContext) throws -> Self {
         switch (format, type) {
         case (.binary, .int2):
             guard buffer.readableBytes == 2, let value = buffer.readInteger(as: Int16.self) else {
@@ -106,12 +106,12 @@ extension Int64: PSQLCodable {
         .int8
     }
     
-    var psqlFormat: PSQLFormat {
+    var psqlFormat: PostgresFormat {
         .binary
     }
     
     // decoding
-    static func decode(from buffer: inout ByteBuffer, type: PSQLDataType, format: PSQLFormat, context: PSQLDecodingContext) throws -> Self {
+    static func decode(from buffer: inout ByteBuffer, type: PSQLDataType, format: PostgresFormat, context: PSQLDecodingContext) throws -> Self {
         switch (format, type) {
         case (.binary, .int2):
             guard buffer.readableBytes == 2, let value = buffer.readInteger(as: Int16.self) else {
@@ -156,12 +156,12 @@ extension Int: PSQLCodable {
         }
     }
     
-    var psqlFormat: PSQLFormat {
+    var psqlFormat: PostgresFormat {
         .binary
     }
     
     // decoding
-    static func decode(from buffer: inout ByteBuffer, type: PSQLDataType, format: PSQLFormat, context: PSQLDecodingContext) throws -> Self {
+    static func decode(from buffer: inout ByteBuffer, type: PSQLDataType, format: PostgresFormat, context: PSQLDecodingContext) throws -> Self {
         switch (format, type) {
         case (.binary, .int2):
             guard buffer.readableBytes == 2, let value = buffer.readInteger(as: Int16.self) else {

--- a/Sources/PostgresNIO/New/Data/JSON+PSQLCodable.swift
+++ b/Sources/PostgresNIO/New/Data/JSON+PSQLCodable.swift
@@ -10,11 +10,11 @@ extension PSQLCodable where Self: Codable {
         .jsonb
     }
     
-    var psqlFormat: PSQLFormat {
+    var psqlFormat: PostgresFormat {
         .binary
     }
     
-    static func decode(from buffer: inout ByteBuffer, type: PSQLDataType, format: PSQLFormat, context: PSQLDecodingContext) throws -> Self {
+    static func decode(from buffer: inout ByteBuffer, type: PSQLDataType, format: PostgresFormat, context: PSQLDecodingContext) throws -> Self {
         switch (format, type) {
         case (.binary, .jsonb):
             guard JSONBVersionByte == buffer.readInteger(as: UInt8.self) else {

--- a/Sources/PostgresNIO/New/Data/Optional+PSQLCodable.swift
+++ b/Sources/PostgresNIO/New/Data/Optional+PSQLCodable.swift
@@ -1,7 +1,7 @@
 import NIOCore
 
 extension Optional: PSQLDecodable where Wrapped: PSQLDecodable {
-    static func decode(from byteBuffer: inout ByteBuffer, type: PSQLDataType, format: PSQLFormat, context: PSQLDecodingContext) throws -> Optional<Wrapped> {
+    static func decode(from byteBuffer: inout ByteBuffer, type: PSQLDataType, format: PostgresFormat, context: PSQLDecodingContext) throws -> Optional<Wrapped> {
         preconditionFailure("This code path should never be hit.")
         // The code path for decoding an optional should be:
         //  -> PSQLData.decode(as: String?.self)
@@ -20,7 +20,7 @@ extension Optional: PSQLEncodable where Wrapped: PSQLEncodable {
         }
     }
     
-    var psqlFormat: PSQLFormat {
+    var psqlFormat: PostgresFormat {
         switch self {
         case .some(let value):
             return value.psqlFormat

--- a/Sources/PostgresNIO/New/Data/RawRepresentable+PSQLCodable.swift
+++ b/Sources/PostgresNIO/New/Data/RawRepresentable+PSQLCodable.swift
@@ -5,11 +5,11 @@ extension PSQLCodable where Self: RawRepresentable, RawValue: PSQLCodable {
         self.rawValue.psqlType
     }
     
-    var psqlFormat: PSQLFormat {
+    var psqlFormat: PostgresFormat {
         self.rawValue.psqlFormat
     }
     
-    static func decode(from buffer: inout ByteBuffer, type: PSQLDataType, format: PSQLFormat, context: PSQLDecodingContext) throws -> Self {
+    static func decode(from buffer: inout ByteBuffer, type: PSQLDataType, format: PostgresFormat, context: PSQLDecodingContext) throws -> Self {
         guard let rawValue = try? RawValue.decode(from: &buffer, type: type, format: format, context: context),
               let selfValue = Self.init(rawValue: rawValue) else {
             throw PSQLCastingError.failure(targetType: Self.self, type: type, postgresData: buffer, context: context)

--- a/Sources/PostgresNIO/New/Data/String+PSQLCodable.swift
+++ b/Sources/PostgresNIO/New/Data/String+PSQLCodable.swift
@@ -6,7 +6,7 @@ extension String: PSQLCodable {
         .text
     }
     
-    var psqlFormat: PSQLFormat {
+    var psqlFormat: PostgresFormat {
         .binary
     }
     
@@ -14,7 +14,7 @@ extension String: PSQLCodable {
         byteBuffer.writeString(self)
     }
     
-    static func decode(from buffer: inout ByteBuffer, type: PSQLDataType, format: PSQLFormat, context: PSQLDecodingContext) throws -> String {
+    static func decode(from buffer: inout ByteBuffer, type: PSQLDataType, format: PostgresFormat, context: PSQLDecodingContext) throws -> String {
         switch (format, type) {
         case (_, .varchar),
              (_, .text),

--- a/Sources/PostgresNIO/New/Data/UUID+PSQLCodable.swift
+++ b/Sources/PostgresNIO/New/Data/UUID+PSQLCodable.swift
@@ -8,7 +8,7 @@ extension UUID: PSQLCodable {
         .uuid
     }
     
-    var psqlFormat: PSQLFormat {
+    var psqlFormat: PostgresFormat {
         .binary
     }
     
@@ -22,7 +22,7 @@ extension UUID: PSQLCodable {
         ])
     }
     
-    static func decode(from buffer: inout ByteBuffer, type: PSQLDataType, format: PSQLFormat, context: PSQLDecodingContext) throws -> UUID {
+    static func decode(from buffer: inout ByteBuffer, type: PSQLDataType, format: PostgresFormat, context: PSQLDecodingContext) throws -> UUID {
         switch (format, type) {
         case (.binary, .uuid):
             guard let uuid = buffer.readUUID() else {

--- a/Sources/PostgresNIO/New/Messages/Bind.swift
+++ b/Sources/PostgresNIO/New/Messages/Bind.swift
@@ -42,7 +42,7 @@ extension PSQLFrontendMessage {
             // result columns of the query.
             buffer.writeInteger(1, as: Int16.self)
             // The result-column format codes. Each must presently be zero (text) or one (binary).
-            buffer.writeInteger(PSQLFormat.binary.rawValue, as: Int16.self)
+            buffer.writeInteger(PostgresFormat.binary.rawValue, as: Int16.self)
         }
     }
 }

--- a/Sources/PostgresNIO/New/Messages/RowDescription.swift
+++ b/Sources/PostgresNIO/New/Messages/RowDescription.swift
@@ -33,7 +33,7 @@ struct RowDescription: PSQLBackendMessage.PayloadDecodable, Equatable {
         
         /// The format being used for the field. Currently will be text or binary. In a RowDescription returned
         /// from the statement variant of Describe, the format code is not yet known and will always be text.
-        var format: PSQLFormat
+        var format: PostgresFormat
     }
     
     static func decode(from buffer: inout ByteBuffer) throws -> Self {
@@ -57,8 +57,8 @@ struct RowDescription: PSQLBackendMessage.PayloadDecodable, Equatable {
                 throw PSQLPartialDecodingError.expectedAtLeastNRemainingBytes(18, actual: buffer.readableBytes)
             }
             
-            guard let format = PSQLFormat(rawValue: formatCodeInt16) else {
-                throw PSQLPartialDecodingError.valueNotRawRepresentable(value: formatCodeInt16, asType: PSQLFormat.self)
+            guard let format = PostgresFormat(rawValue: formatCodeInt16) else {
+                throw PSQLPartialDecodingError.valueNotRawRepresentable(value: formatCodeInt16, asType: PostgresFormat.self)
             }
             
             let field = Column(

--- a/Sources/PostgresNIO/New/PSQLCodable.swift
+++ b/Sources/PostgresNIO/New/PSQLCodable.swift
@@ -6,7 +6,7 @@ protocol PSQLEncodable {
     var psqlType: PSQLDataType { get }
     
     /// identifies the postgres format that is used to encode the value into `byteBuffer` in `encode`
-    var psqlFormat: PSQLFormat { get }
+    var psqlFormat: PostgresFormat { get }
     
     /// Encode the entity into the `byteBuffer` in Postgres binary format, without setting
     /// the byte count. This method is called from the default `encodeRaw` implementation.
@@ -32,7 +32,7 @@ protocol PSQLDecodable {
     ///   - context: A `PSQLDecodingContext` providing context for decoding. This includes a `JSONDecoder`
     ///              to use when decoding json and metadata to create better errors.
     /// - Returns: A decoded object
-    static func decode(from byteBuffer: inout ByteBuffer, type: PSQLDataType, format: PSQLFormat, context: PSQLDecodingContext) throws -> Self
+    static func decode(from byteBuffer: inout ByteBuffer, type: PSQLDataType, format: PostgresFormat, context: PSQLDecodingContext) throws -> Self
 }
 
 /// A type that can be encoded into and decoded from a postgres binary format

--- a/Sources/PostgresNIO/New/PSQLData.swift
+++ b/Sources/PostgresNIO/New/PSQLData.swift
@@ -1,23 +1,13 @@
 import NIOCore
 
-/// The format the postgres types are encoded in on the wire.
-///
-/// Currently there a two wire formats supported:
-///  - text
-///  - binary
-enum PSQLFormat: Int16 {
-    case text = 0
-    case binary = 1
-}
-
 struct PSQLData: Equatable {
     
     @usableFromInline var bytes: ByteBuffer?
     @usableFromInline var dataType: PSQLDataType
-    @usableFromInline var format: PSQLFormat
+    @usableFromInline var format: PostgresFormat
     
     /// use this only for testing
-    init(bytes: ByteBuffer?, dataType: PSQLDataType, format: PSQLFormat) {
+    init(bytes: ByteBuffer?, dataType: PSQLDataType, format: PostgresFormat) {
         self.bytes = bytes
         self.dataType = dataType
         self.format = format

--- a/Sources/PostgresNIO/Postgres+PSQLCompat.swift
+++ b/Sources/PostgresNIO/Postgres+PSQLCompat.swift
@@ -32,7 +32,7 @@ extension PostgresData: PSQLEncodable {
         PSQLDataType(Int32(self.type.rawValue))
     }
     
-    var psqlFormat: PSQLFormat {
+    var psqlFormat: PostgresFormat {
         .binary
     }
     
@@ -53,7 +53,7 @@ extension PostgresData: PSQLEncodable {
 }
 
 extension PostgresData: PSQLDecodable {
-    static func decode(from byteBuffer: inout ByteBuffer, type: PSQLDataType, format: PSQLFormat, context: PSQLDecodingContext) throws -> PostgresData {
+    static func decode(from byteBuffer: inout ByteBuffer, type: PSQLDataType, format: PostgresFormat, context: PSQLDecodingContext) throws -> PostgresData {
         let myBuffer = byteBuffer.readSlice(length: byteBuffer.readableBytes)!
         
         return PostgresData(type: PostgresDataType(UInt32(type.rawValue)), typeModifier: nil, formatCode: .binary, value: myBuffer)
@@ -102,8 +102,8 @@ extension PSQLError {
     }
 }
 
-extension PostgresFormatCode {
-    init(psqlFormatCode: PSQLFormat) {
+extension PostgresFormat {
+    init(psqlFormatCode: PostgresFormat) {
         switch psqlFormatCode {
         case .binary:
             self = .binary

--- a/Tests/PostgresNIOTests/New/Data/JSON+PSQLCodableTests.swift
+++ b/Tests/PostgresNIOTests/New/Data/JSON+PSQLCodableTests.swift
@@ -38,7 +38,7 @@ class JSON_PSQLCodableTests: XCTestCase {
     }
     
     func testDecodeFromJSONAsText() {
-        let combinations : [(PSQLFormat, PSQLDataType)] = [
+        let combinations : [(PostgresFormat, PSQLDataType)] = [
             (.text, .json), (.text, .jsonb),
         ]
         var buffer = ByteBuffer()

--- a/Tests/PostgresNIOTests/New/Data/UUID+PSQLCodableTests.swift
+++ b/Tests/PostgresNIOTests/New/Data/UUID+PSQLCodableTests.swift
@@ -40,7 +40,7 @@ class UUID_PSQLCodableTests: XCTestCase {
     }
     
     func testDecodeFromString() {
-        let options: [(PSQLFormat, PSQLDataType)] = [
+        let options: [(PostgresFormat, PSQLDataType)] = [
             (.binary, .text),
             (.binary, .varchar),
             (.text, .uuid),

--- a/Tests/PostgresNIOTests/New/PSQLRowStreamTests.swift
+++ b/Tests/PostgresNIOTests/New/PSQLRowStreamTests.swift
@@ -289,7 +289,7 @@ class PSQLRowStreamTests: XCTestCase {
         XCTAssertEqual(stream.commandTag, "SELECT 6")
     }
 
-    func makeColumnDescription(name: String, dataType: PSQLDataType, format: PSQLFormat) -> RowDescription.Column {
+    func makeColumnDescription(name: String, dataType: PSQLDataType, format: PostgresFormat) -> RowDescription.Column {
         RowDescription.Column(
             name: "test",
             tableOID: 123,


### PR DESCRIPTION
### Motivation

While rewriting lot's of PostgresNIO internals in the last year, I created new types that very closely match existing types. This was a mistake. I should have tried everything to reuse existing types, and change them as needed.

### Changes

- Remove `PSQLFormat`
- Rename `PostgresFormatCode` to `PostgresFormat` ⚠️ This increases public API... minor version bump required.
- Add `typealias PostgresFormatCode = PostgresFormat` with deprecation to not break public API

### Result

- Fewer types, easier API for adopters.
