### PR TITLE
Remove PSQLJSONDecoder from PSQLConnection

### DIFF
--- a/Sources/PostgresNIO/Connection/PostgresConnection+Connect.swift
+++ b/Sources/PostgresNIO/Connection/PostgresConnection+Connect.swift
@@ -12,8 +12,7 @@ extension PostgresConnection {
     ) -> EventLoopFuture<PostgresConnection> {
         
         let coders = PSQLConnection.Configuration.Coders(
-            jsonEncoder: PostgresJSONEncoderWrapper(_defaultJSONEncoder),
-            jsonDecoder: PostgresJSONDecoderWrapper(_defaultJSONDecoder)
+            jsonEncoder: PostgresJSONEncoderWrapper(_defaultJSONEncoder)
         )
         
         let configuration = PSQLConnection.Configuration(

--- a/Sources/PostgresNIO/New/PSQLConnection.swift
+++ b/Sources/PostgresNIO/New/PSQLConnection.swift
@@ -14,15 +14,13 @@ final class PSQLConnection {
         
         struct Coders {
             var jsonEncoder: PSQLJSONEncoder
-            var jsonDecoder: PSQLJSONDecoder
             
-            init(jsonEncoder: PSQLJSONEncoder, jsonDecoder: PSQLJSONDecoder) {
+            init(jsonEncoder: PSQLJSONEncoder) {
                 self.jsonEncoder = jsonEncoder
-                self.jsonDecoder = jsonDecoder
             }
             
             static var foundation: Coders {
-                Coders(jsonEncoder: JSONEncoder(), jsonDecoder: JSONDecoder())
+                Coders(jsonEncoder: JSONEncoder())
             }
         }
         
@@ -98,13 +96,11 @@ final class PSQLConnection {
     /// A logger to use in case
     private var logger: Logger
     let connectionID: String
-    let jsonDecoder: PSQLJSONDecoder
 
-    init(channel: Channel, connectionID: String, logger: Logger, jsonDecoder: PSQLJSONDecoder) {
+    init(channel: Channel, connectionID: String, logger: Logger) {
         self.channel = channel
         self.connectionID = connectionID
         self.logger = logger
-        self.jsonDecoder = jsonDecoder
     }
     deinit {
         assert(self.isClosed, "PostgresConnection deinitialized before being closed.")
@@ -136,7 +132,6 @@ final class PSQLConnection {
             query: query,
             bind: bind,
             logger: logger,
-            jsonDecoder: self.jsonDecoder,
             promise: promise)
         
         self.channel.write(PSQLTask.extendedQuery(context), promise: nil)
@@ -171,7 +166,6 @@ final class PSQLConnection {
             preparedStatement: preparedStatement,
             bind: bind,
             logger: logger,
-            jsonDecoder: self.jsonDecoder,
             promise: promise)
         
         self.channel.write(PSQLTask.extendedQuery(context), promise: nil)
@@ -258,7 +252,7 @@ final class PSQLConnection {
                     }
                 }.map { _ in channel }
             }.map { channel in
-                PSQLConnection(channel: channel, connectionID: connectionID, logger: logger, jsonDecoder: configuration.coders.jsonDecoder)
+                PSQLConnection(channel: channel, connectionID: connectionID, logger: logger)
             }.flatMapErrorThrowing { error -> PSQLConnection in
                 switch error {
                 case is PSQLError:

--- a/Sources/PostgresNIO/New/PSQLRow.swift
+++ b/Sources/PostgresNIO/New/PSQLRow.swift
@@ -64,10 +64,12 @@ extension PSQLRow {
 }
 
 extension PSQLRow {
+    // TODO: Remove this function. Only here to keep the tests running as of today.
     func decode<T: PSQLDecodable>(column: String, as type: T.Type, file: String = #file, line: Int = #line) throws -> T {
         try self.decode(column: column, as: type, jsonDecoder: JSONDecoder(), file: file, line: line)
     }
 
+    // TODO: Remove this function. Only here to keep the tests running as of today.
     func decode<T: PSQLDecodable>(column index: Int, as type: T.Type, file: String = #file, line: Int = #line) throws -> T {
         try self.decode(column: index, as: type, jsonDecoder: JSONDecoder(), file: file, line: line)
     }

--- a/Sources/PostgresNIO/New/PSQLTask.swift
+++ b/Sources/PostgresNIO/New/PSQLTask.swift
@@ -28,26 +28,22 @@ final class ExtendedQueryContext {
     let bind: [PSQLEncodable]
     let logger: Logger
     
-    let jsonDecoder: PSQLJSONDecoder
     let promise: EventLoopPromise<PSQLRowStream>
     
     init(query: String,
          bind: [PSQLEncodable],
          logger: Logger,
-         jsonDecoder: PSQLJSONDecoder,
          promise: EventLoopPromise<PSQLRowStream>)
     {
         self.query = .unnamed(query)
         self.bind = bind
         self.logger = logger
-        self.jsonDecoder = jsonDecoder
         self.promise = promise
     }
     
     init(preparedStatement: PSQLPreparedStatement,
          bind: [PSQLEncodable],
          logger: Logger,
-         jsonDecoder: PSQLJSONDecoder,
          promise: EventLoopPromise<PSQLRowStream>)
     {
         self.query = .preparedStatement(
@@ -55,7 +51,6 @@ final class ExtendedQueryContext {
             rowDescription: preparedStatement.rowDescription)
         self.bind = bind
         self.logger = logger
-        self.jsonDecoder = jsonDecoder
         self.promise = promise
     }
 

--- a/Tests/PostgresNIOTests/New/Connection State Machine/ConnectionStateMachineTests.swift
+++ b/Tests/PostgresNIOTests/New/Connection State Machine/ConnectionStateMachineTests.swift
@@ -124,7 +124,6 @@ class ConnectionStateMachineTests: XCTestCase {
         let authContext = AuthContext(username: "test", password: "abc123", database: "test")
         let salt: (UInt8, UInt8, UInt8, UInt8) = (0, 1, 2, 3)
 
-        let jsonDecoder = JSONDecoder()
         let queryPromise = eventLoopGroup.next().makePromise(of: PSQLRowStream.self)
 
         var state = ConnectionStateMachine()
@@ -132,7 +131,6 @@ class ConnectionStateMachineTests: XCTestCase {
             query: "Select version()",
             bind: [],
             logger: .psqlTest,
-            jsonDecoder: jsonDecoder,
             promise: queryPromise)
 
         XCTAssertEqual(state.enqueue(task: .extendedQuery(extendedQueryContext)), .wait)

--- a/Tests/PostgresNIOTests/New/Connection State Machine/ExtendedQueryStateMachineTests.swift
+++ b/Tests/PostgresNIOTests/New/Connection State Machine/ExtendedQueryStateMachineTests.swift
@@ -13,7 +13,7 @@ class ExtendedQueryStateMachineTests: XCTestCase {
         let promise = EmbeddedEventLoop().makePromise(of: PSQLRowStream.self)
         promise.fail(PSQLError.uncleanShutdown) // we don't care about the error at all.
         let query = "DELETE FROM table WHERE id=$0"
-        let queryContext = ExtendedQueryContext(query: query, bind: [1], logger: logger, jsonDecoder: JSONDecoder(), promise: promise)
+        let queryContext = ExtendedQueryContext(query: query, bind: [1], logger: logger, promise: promise)
         
         XCTAssertEqual(state.enqueue(task: .extendedQuery(queryContext)), .sendParseDescribeBindExecuteSync(query: query, binds: [1]))
         XCTAssertEqual(state.parseCompleteReceived(), .wait)
@@ -31,7 +31,7 @@ class ExtendedQueryStateMachineTests: XCTestCase {
         let queryPromise = EmbeddedEventLoop().makePromise(of: PSQLRowStream.self)
         queryPromise.fail(PSQLError.uncleanShutdown) // we don't care about the error at all.
         let query = "SELECT version()"
-        let queryContext = ExtendedQueryContext(query: query, bind: [], logger: logger, jsonDecoder: JSONDecoder(), promise: queryPromise)
+        let queryContext = ExtendedQueryContext(query: query, bind: [], logger: logger, promise: queryPromise)
         
         XCTAssertEqual(state.enqueue(task: .extendedQuery(queryContext)), .sendParseDescribeBindExecuteSync(query: query, binds: []))
         XCTAssertEqual(state.parseCompleteReceived(), .wait)
@@ -85,7 +85,7 @@ class ExtendedQueryStateMachineTests: XCTestCase {
         let promise = EmbeddedEventLoop().makePromise(of: PSQLRowStream.self)
         promise.fail(PSQLError.uncleanShutdown) // we don't care about the error at all.
         let query = "DELETE FROM table WHERE id=$0"
-        let queryContext = ExtendedQueryContext(query: query, bind: [1], logger: logger, jsonDecoder: JSONDecoder(), promise: promise)
+        let queryContext = ExtendedQueryContext(query: query, bind: [1], logger: logger, promise: promise)
         
         XCTAssertEqual(state.enqueue(task: .extendedQuery(queryContext)), .sendParseDescribeBindExecuteSync(query: query, binds: [1]))
         XCTAssertEqual(state.parseCompleteReceived(), .wait)

--- a/Tests/PostgresNIOTests/New/PSQLRowStreamTests.swift
+++ b/Tests/PostgresNIOTests/New/PSQLRowStreamTests.swift
@@ -10,7 +10,7 @@ class PSQLRowStreamTests: XCTestCase {
         let promise = eventLoop.makePromise(of: PSQLRowStream.self)
         
         let queryContext = ExtendedQueryContext(
-            query: "INSERT INTO foo bar;", bind: [], logger: logger, jsonDecoder: JSONDecoder(), promise: promise
+            query: "INSERT INTO foo bar;", bind: [], logger: logger, promise: promise
         )
         
         let stream = PSQLRowStream(
@@ -31,7 +31,7 @@ class PSQLRowStreamTests: XCTestCase {
         let promise = eventLoop.makePromise(of: PSQLRowStream.self)
         
         let queryContext = ExtendedQueryContext(
-            query: "SELECT * FROM test;", bind: [], logger: logger, jsonDecoder: JSONDecoder(), promise: promise
+            query: "SELECT * FROM test;", bind: [], logger: logger, promise: promise
         )
         
         let stream = PSQLRowStream(
@@ -53,7 +53,7 @@ class PSQLRowStreamTests: XCTestCase {
         let promise = eventLoop.makePromise(of: PSQLRowStream.self)
         
         let queryContext = ExtendedQueryContext(
-            query: "SELECT * FROM test;", bind: [], logger: logger, jsonDecoder: JSONDecoder(), promise: promise
+            query: "SELECT * FROM test;", bind: [], logger: logger, promise: promise
         )
         
         let dataSource = CountingDataSource()
@@ -92,9 +92,7 @@ class PSQLRowStreamTests: XCTestCase {
         let promise = eventLoop.makePromise(of: PSQLRowStream.self)
         
         let queryContext = ExtendedQueryContext(
-            query: "SELECT * FROM test;", bind: [], logger: logger, jsonDecoder: JSONDecoder(), promise: promise
-        )
-        
+            query: "SELECT * FROM test;", bind: [], logger: logger, promise: promise)
         let dataSource = CountingDataSource()
         let stream = PSQLRowStream(
             rowDescription: [
@@ -144,7 +142,7 @@ class PSQLRowStreamTests: XCTestCase {
         let promise = eventLoop.makePromise(of: PSQLRowStream.self)
         
         let queryContext = ExtendedQueryContext(
-            query: "SELECT * FROM test;", bind: [], logger: logger, jsonDecoder: JSONDecoder(), promise: promise
+            query: "SELECT * FROM test;", bind: [], logger: logger, promise: promise
         )
         
         let dataSource = CountingDataSource()
@@ -188,7 +186,7 @@ class PSQLRowStreamTests: XCTestCase {
         let promise = eventLoop.makePromise(of: PSQLRowStream.self)
         
         let queryContext = ExtendedQueryContext(
-            query: "SELECT * FROM test;", bind: [], logger: logger, jsonDecoder: JSONDecoder(), promise: promise
+            query: "SELECT * FROM test;", bind: [], logger: logger, promise: promise
         )
         
         let dataSource = CountingDataSource()
@@ -237,7 +235,7 @@ class PSQLRowStreamTests: XCTestCase {
         let promise = eventLoop.makePromise(of: PSQLRowStream.self)
         
         let queryContext = ExtendedQueryContext(
-            query: "SELECT * FROM test;", bind: [], logger: logger, jsonDecoder: JSONDecoder(), promise: promise
+            query: "SELECT * FROM test;", bind: [], logger: logger, promise: promise
         )
         
         let dataSource = CountingDataSource()


### PR DESCRIPTION
### Motivation

Currently we attach a PSQLJSONDecoder and PSQLJSONEncoder to a PostgresConnection. This is not ideal. Instead users should be able to supply an encoder and decoder on a per query basis.

### Changes

- Remove PSQLJSONDecoder from the Connection and supply it on decoding instead.

### Result

- Code that is less intertwined and easier to reason about. 
- Fewer existentials hanging around.