### PR TITLE
Remove PSQLJSONDecoder

### DIFF
--- a/Sources/PostgresNIO/New/PSQL+JSON.swift
+++ b/Sources/PostgresNIO/New/PSQL+JSON.swift
@@ -7,10 +7,4 @@ protocol PSQLJSONEncoder {
     func encode<T: Encodable>(_ value: T, into buffer: inout ByteBuffer) throws
 }
 
-protocol PSQLJSONDecoder {
-    func decode<T: Decodable>(_ type: T.Type, from buffer: ByteBuffer) throws -> T
-}
-
 extension JSONEncoder: PSQLJSONEncoder {}
-extension JSONDecoder: PSQLJSONDecoder {}
-

--- a/Sources/PostgresNIO/New/PSQLCodable.swift
+++ b/Sources/PostgresNIO/New/PSQLCodable.swift
@@ -60,7 +60,7 @@ struct PSQLEncodingContext {
 
 struct PSQLDecodingContext {
     
-    let jsonDecoder: PSQLJSONDecoder
+    let jsonDecoder: PostgresJSONDecoder
     
     let columnIndex: Int
     let columnName: String
@@ -68,7 +68,7 @@ struct PSQLDecodingContext {
     let file: String
     let line: Int
     
-    init(jsonDecoder: PSQLJSONDecoder, columnName: String, columnIndex: Int, file: String, line: Int) {
+    init(jsonDecoder: PostgresJSONDecoder, columnName: String, columnIndex: Int, file: String, line: Int) {
         self.jsonDecoder = jsonDecoder
         self.columnName = columnName
         self.columnIndex = columnIndex

--- a/Sources/PostgresNIO/New/PSQLRow.swift
+++ b/Sources/PostgresNIO/New/PSQLRow.swift
@@ -29,7 +29,7 @@ extension PSQLRow {
     ///   - type: The type to decode the data into
     /// - Throws: The error of the decoding implementation. See also `PSQLDecodable` protocol for this.
     /// - Returns: The decoded value of Type T.
-    func decode<T: PSQLDecodable, JSONDecoder: PSQLJSONDecoder>(column: String, as type: T.Type, jsonDecoder: JSONDecoder, file: String = #file, line: Int = #line) throws -> T {
+    func decode<T: PSQLDecodable, JSONDecoder: PostgresJSONDecoder>(column: String, as type: T.Type, jsonDecoder: JSONDecoder, file: String = #file, line: Int = #line) throws -> T {
         guard let index = self.lookupTable[column] else {
             preconditionFailure("A column '\(column)' does not exist.")
         }
@@ -44,7 +44,7 @@ extension PSQLRow {
     ///   - type: The type to decode the data into
     /// - Throws: The error of the decoding implementation. See also `PSQLDecodable` protocol for this.
     /// - Returns: The decoded value of Type T.
-    func decode<T: PSQLDecodable, JSONDecoder: PSQLJSONDecoder>(column index: Int, as type: T.Type, jsonDecoder: JSONDecoder, file: String = #file, line: Int = #line) throws -> T {
+    func decode<T: PSQLDecodable, JSONDecoder: PostgresJSONDecoder>(column index: Int, as type: T.Type, jsonDecoder: JSONDecoder, file: String = #file, line: Int = #line) throws -> T {
         precondition(index < self.data.columnCount)
         
         let column = self.columns[index]

--- a/Sources/PostgresNIO/Postgres+PSQLCompat.swift
+++ b/Sources/PostgresNIO/Postgres+PSQLCompat.swift
@@ -1,19 +1,5 @@
 import NIOCore
 
-struct PostgresJSONDecoderWrapper: PSQLJSONDecoder {
-    let downstream: PostgresJSONDecoder
-    
-    init(_ downstream: PostgresJSONDecoder) {
-        self.downstream = downstream
-    }
-    
-    func decode<T>(_ type: T.Type, from buffer: ByteBuffer) throws -> T where T : Decodable {
-        var buffer = buffer
-        let data = buffer.readData(length: buffer.readableBytes)!
-        return try self.downstream.decode(T.self, from: data)
-    }
-}
-
 struct PostgresJSONEncoderWrapper: PSQLJSONEncoder {
     let downstream: PostgresJSONEncoder
     

--- a/Sources/PostgresNIO/Utilities/PostgresJSONDecoder.swift
+++ b/Sources/PostgresNIO/Utilities/PostgresJSONDecoder.swift
@@ -1,10 +1,22 @@
-import Foundation
+import class Foundation.JSONDecoder
+import struct Foundation.Data
+import NIOFoundationCompat
 
 /// A protocol that mimicks the Foundation `JSONDecoder.decode(_:from:)` function.
 /// Conform a non-Foundation JSON decoder to this protocol if you want PostgresNIO to be
 /// able to use it when decoding JSON & JSONB values (see `PostgresNIO._defaultJSONDecoder`)
 public protocol PostgresJSONDecoder {
     func decode<T>(_ type: T.Type, from data: Data) throws -> T where T : Decodable
+
+    func decode<T: Decodable>(_ type: T.Type, from buffer: ByteBuffer) throws -> T
+}
+
+extension PostgresJSONDecoder {
+    public func decode<T: Decodable>(_ type: T.Type, from buffer: ByteBuffer) throws -> T {
+        var copy = buffer
+        let data = copy.readData(length: buffer.readableBytes)!
+        return try self.decode(type, from: data)
+    }
 }
 
 extension JSONDecoder: PostgresJSONDecoder {}

--- a/Tests/PostgresNIOTests/New/Extensions/PSQLCoding+TestUtils.swift
+++ b/Tests/PostgresNIOTests/New/Extensions/PSQLCoding+TestUtils.swift
@@ -8,7 +8,7 @@ extension PSQLFrontendMessageEncoder {
 }
 
 extension PSQLDecodingContext {
-    static func forTests(columnName: String = "unknown", columnIndex: Int = 0, jsonDecoder: PSQLJSONDecoder = JSONDecoder(), file: String = #file, line: Int = #line) -> Self {
+    static func forTests(columnName: String = "unknown", columnIndex: Int = 0, jsonDecoder: PostgresJSONDecoder = JSONDecoder(), file: String = #file, line: Int = #line) -> Self {
         Self(jsonDecoder: JSONDecoder(), columnName: columnName, columnIndex: columnIndex, file: file, line: line)
     }
 }


### PR DESCRIPTION
### Motivation

While rewriting lot's of PostgresNIO internals in the last year, I created new types that very closely match existing types. This was a mistake. I should have tried everything to reuse existing types, and change them as needed.

### Changes

⚠️ This PR extends API... minor version bump required.

- Remove `PSQLJSONDecoder`
- Extend `PostgresJSONDecoder` with a decode method based on `ByteBuffer`
- Provide a default implementation for the new decode method based on `ByteBuffer` to not break API
- Replace all uses of `PSQLJSONDecoder ` with `PostgresJSONDecoder`

### Result

Fewer types, easier API for adopters.
