### PR TITLE
Make PSQLDecodingContext generic

### DIFF
--- a/Sources/PostgresNIO/New/Data/Array+PSQLCodable.swift
+++ b/Sources/PostgresNIO/New/Data/Array+PSQLCodable.swift
@@ -105,7 +105,7 @@ extension Array: PSQLDecodable where Element: PSQLArrayElement {
         from buffer: inout ByteBuffer,
         type: PostgresDataType,
         format: PostgresFormat,
-        context: PSQLDecodingContext<JSONDecoder>
+        context: PostgresDecodingContext<JSONDecoder>
     ) throws -> Array<Element> {
         guard case .binary = format else {
             // currently we only support decoding arrays in binary format.

--- a/Sources/PostgresNIO/New/Data/Array+PSQLCodable.swift
+++ b/Sources/PostgresNIO/New/Data/Array+PSQLCodable.swift
@@ -101,7 +101,12 @@ extension Array: PSQLEncodable where Element: PSQLArrayElement {
 }
 
 extension Array: PSQLDecodable where Element: PSQLArrayElement {
-    static func decode(from buffer: inout ByteBuffer, type: PostgresDataType, format: PostgresFormat, context: PSQLDecodingContext) throws -> Array<Element> {
+    static func decode<JSONDecoder: PostgresJSONDecoder>(
+        from buffer: inout ByteBuffer,
+        type: PostgresDataType,
+        format: PostgresFormat,
+        context: PSQLDecodingContext<JSONDecoder>
+    ) throws -> Array<Element> {
         guard case .binary = format else {
             // currently we only support decoding arrays in binary format.
             throw PostgresCastingError.Code.failure

--- a/Sources/PostgresNIO/New/Data/Bool+PSQLCodable.swift
+++ b/Sources/PostgresNIO/New/Data/Bool+PSQLCodable.swift
@@ -13,7 +13,7 @@ extension Bool: PSQLCodable {
         from buffer: inout ByteBuffer,
         type: PostgresDataType,
         format: PostgresFormat,
-        context: PSQLDecodingContext<JSONDecoder>
+        context: PostgresDecodingContext<JSONDecoder>
     ) throws -> Self {
         guard type == .bool else {
             throw PostgresCastingError.Code.typeMismatch

--- a/Sources/PostgresNIO/New/Data/Bool+PSQLCodable.swift
+++ b/Sources/PostgresNIO/New/Data/Bool+PSQLCodable.swift
@@ -9,7 +9,12 @@ extension Bool: PSQLCodable {
         .binary
     }
 
-    static func decode(from buffer: inout ByteBuffer, type: PostgresDataType, format: PostgresFormat, context: PSQLDecodingContext) throws -> Bool {
+    static func decode<JSONDecoder: PostgresJSONDecoder>(
+        from buffer: inout ByteBuffer,
+        type: PostgresDataType,
+        format: PostgresFormat,
+        context: PSQLDecodingContext<JSONDecoder>
+    ) throws -> Self {
         guard type == .bool else {
             throw PostgresCastingError.Code.typeMismatch
         }

--- a/Sources/PostgresNIO/New/Data/Bytes+PSQLCodable.swift
+++ b/Sources/PostgresNIO/New/Data/Bytes+PSQLCodable.swift
@@ -34,7 +34,7 @@ extension ByteBuffer: PSQLCodable {
         from buffer: inout ByteBuffer,
         type: PostgresDataType,
         format: PostgresFormat,
-        context: PSQLDecodingContext<JSONDecoder>
+        context: PostgresDecodingContext<JSONDecoder>
     ) throws -> Self {
         return buffer
     }
@@ -57,7 +57,7 @@ extension Data: PSQLCodable {
         from buffer: inout ByteBuffer,
         type: PostgresDataType,
         format: PostgresFormat,
-        context: PSQLDecodingContext<JSONDecoder>
+        context: PostgresDecodingContext<JSONDecoder>
     ) throws -> Self {
         return buffer.readData(length: buffer.readableBytes, byteTransferStrategy: .automatic)!
     }

--- a/Sources/PostgresNIO/New/Data/Bytes+PSQLCodable.swift
+++ b/Sources/PostgresNIO/New/Data/Bytes+PSQLCodable.swift
@@ -30,7 +30,12 @@ extension ByteBuffer: PSQLCodable {
         byteBuffer.writeBuffer(&copyOfSelf)
     }
 
-    static func decode(from buffer: inout ByteBuffer, type: PostgresDataType, format: PostgresFormat, context: PSQLDecodingContext) throws -> Self {
+    static func decode<JSONDecoder: PostgresJSONDecoder>(
+        from buffer: inout ByteBuffer,
+        type: PostgresDataType,
+        format: PostgresFormat,
+        context: PSQLDecodingContext<JSONDecoder>
+    ) throws -> Self {
         return buffer
     }
 }
@@ -48,7 +53,12 @@ extension Data: PSQLCodable {
         byteBuffer.writeBytes(self)
     }
 
-    static func decode(from buffer: inout ByteBuffer, type: PostgresDataType, format: PostgresFormat, context: PSQLDecodingContext) throws -> Self {
+    static func decode<JSONDecoder: PostgresJSONDecoder>(
+        from buffer: inout ByteBuffer,
+        type: PostgresDataType,
+        format: PostgresFormat,
+        context: PSQLDecodingContext<JSONDecoder>
+    ) throws -> Self {
         return buffer.readData(length: buffer.readableBytes, byteTransferStrategy: .automatic)!
     }
 }

--- a/Sources/PostgresNIO/New/Data/Date+PSQLCodable.swift
+++ b/Sources/PostgresNIO/New/Data/Date+PSQLCodable.swift
@@ -14,7 +14,7 @@ extension Date: PSQLCodable {
         from buffer: inout ByteBuffer,
         type: PostgresDataType,
         format: PostgresFormat,
-        context: PSQLDecodingContext<JSONDecoder>
+        context: PostgresDecodingContext<JSONDecoder>
     ) throws -> Self {
         switch type {
         case .timestamp, .timestamptz:

--- a/Sources/PostgresNIO/New/Data/Date+PSQLCodable.swift
+++ b/Sources/PostgresNIO/New/Data/Date+PSQLCodable.swift
@@ -10,7 +10,12 @@ extension Date: PSQLCodable {
         .binary
     }
     
-    static func decode(from buffer: inout ByteBuffer, type: PostgresDataType, format: PostgresFormat, context: PSQLDecodingContext) throws -> Self {
+    static func decode<JSONDecoder: PostgresJSONDecoder>(
+        from buffer: inout ByteBuffer,
+        type: PostgresDataType,
+        format: PostgresFormat,
+        context: PSQLDecodingContext<JSONDecoder>
+    ) throws -> Self {
         switch type {
         case .timestamp, .timestamptz:
             guard buffer.readableBytes == 8, let microseconds = buffer.readInteger(as: Int64.self) else {

--- a/Sources/PostgresNIO/New/Data/Decimal+PSQLCodable.swift
+++ b/Sources/PostgresNIO/New/Data/Decimal+PSQLCodable.swift
@@ -10,7 +10,12 @@ extension Decimal: PSQLCodable {
         .binary
     }
     
-    static func decode(from buffer: inout ByteBuffer, type: PostgresDataType, format: PostgresFormat, context: PSQLDecodingContext) throws -> Self {
+    static func decode<JSONDecoder: PostgresJSONDecoder>(
+        from buffer: inout ByteBuffer,
+        type: PostgresDataType,
+        format: PostgresFormat,
+        context: PSQLDecodingContext<JSONDecoder>
+    ) throws -> Self {
         switch (format, type) {
         case (.binary, .numeric):
             guard let numeric = PostgresNumeric(buffer: &buffer) else {

--- a/Sources/PostgresNIO/New/Data/Decimal+PSQLCodable.swift
+++ b/Sources/PostgresNIO/New/Data/Decimal+PSQLCodable.swift
@@ -14,7 +14,7 @@ extension Decimal: PSQLCodable {
         from buffer: inout ByteBuffer,
         type: PostgresDataType,
         format: PostgresFormat,
-        context: PSQLDecodingContext<JSONDecoder>
+        context: PostgresDecodingContext<JSONDecoder>
     ) throws -> Self {
         switch (format, type) {
         case (.binary, .numeric):

--- a/Sources/PostgresNIO/New/Data/Float+PSQLCodable.swift
+++ b/Sources/PostgresNIO/New/Data/Float+PSQLCodable.swift
@@ -9,7 +9,12 @@ extension Float: PSQLCodable {
         .binary
     }
     
-    static func decode(from buffer: inout ByteBuffer, type: PostgresDataType, format: PostgresFormat, context: PSQLDecodingContext) throws -> Self {
+    static func decode<JSONDecoder: PostgresJSONDecoder>(
+        from buffer: inout ByteBuffer,
+        type: PostgresDataType,
+        format: PostgresFormat,
+        context: PSQLDecodingContext<JSONDecoder>
+    ) throws -> Self {
         switch (format, type) {
         case (.binary, .float4):
             guard buffer.readableBytes == 4, let float = buffer.psqlReadFloat() else {
@@ -45,7 +50,12 @@ extension Double: PSQLCodable {
         .binary
     }
     
-    static func decode(from buffer: inout ByteBuffer, type: PostgresDataType, format: PostgresFormat, context: PSQLDecodingContext) throws -> Self {
+    static func decode<JSONDecoder: PostgresJSONDecoder>(
+        from buffer: inout ByteBuffer,
+        type: PostgresDataType,
+        format: PostgresFormat,
+        context: PSQLDecodingContext<JSONDecoder>
+    ) throws -> Self {
         switch (format, type) {
         case (.binary, .float4):
             guard buffer.readableBytes == 4, let float = buffer.psqlReadFloat() else {

--- a/Sources/PostgresNIO/New/Data/Float+PSQLCodable.swift
+++ b/Sources/PostgresNIO/New/Data/Float+PSQLCodable.swift
@@ -13,7 +13,7 @@ extension Float: PSQLCodable {
         from buffer: inout ByteBuffer,
         type: PostgresDataType,
         format: PostgresFormat,
-        context: PSQLDecodingContext<JSONDecoder>
+        context: PostgresDecodingContext<JSONDecoder>
     ) throws -> Self {
         switch (format, type) {
         case (.binary, .float4):
@@ -54,7 +54,7 @@ extension Double: PSQLCodable {
         from buffer: inout ByteBuffer,
         type: PostgresDataType,
         format: PostgresFormat,
-        context: PSQLDecodingContext<JSONDecoder>
+        context: PostgresDecodingContext<JSONDecoder>
     ) throws -> Self {
         switch (format, type) {
         case (.binary, .float4):

--- a/Sources/PostgresNIO/New/Data/Int+PSQLCodable.swift
+++ b/Sources/PostgresNIO/New/Data/Int+PSQLCodable.swift
@@ -13,7 +13,7 @@ extension UInt8: PSQLCodable {
         from buffer: inout ByteBuffer,
         type: PostgresDataType,
         format: PostgresFormat,
-        context: PSQLDecodingContext<JSONDecoder>
+        context: PostgresDecodingContext<JSONDecoder>
     ) throws -> Self {
         switch type {
         case .bpchar, .char:
@@ -46,7 +46,7 @@ extension Int16: PSQLCodable {
         from buffer: inout ByteBuffer,
         type: PostgresDataType,
         format: PostgresFormat,
-        context: PSQLDecodingContext<JSONDecoder>
+        context: PostgresDecodingContext<JSONDecoder>
     ) throws -> Self {
         switch (format, type) {
         case (.binary, .int2):
@@ -82,7 +82,7 @@ extension Int32: PSQLCodable {
         from buffer: inout ByteBuffer,
         type: PostgresDataType,
         format: PostgresFormat,
-        context: PSQLDecodingContext<JSONDecoder>
+        context: PostgresDecodingContext<JSONDecoder>
     ) throws -> Self {
         switch (format, type) {
         case (.binary, .int2):
@@ -123,7 +123,7 @@ extension Int64: PSQLCodable {
         from buffer: inout ByteBuffer,
         type: PostgresDataType,
         format: PostgresFormat,
-        context: PSQLDecodingContext<JSONDecoder>
+        context: PostgresDecodingContext<JSONDecoder>
     ) throws -> Self {
         switch (format, type) {
         case (.binary, .int2):
@@ -176,7 +176,7 @@ extension Int: PSQLCodable {
         from buffer: inout ByteBuffer,
         type: PostgresDataType,
         format: PostgresFormat,
-        context: PSQLDecodingContext<JSONDecoder>
+        context: PostgresDecodingContext<JSONDecoder>
     ) throws -> Self {
         switch (format, type) {
         case (.binary, .int2):

--- a/Sources/PostgresNIO/New/Data/Int+PSQLCodable.swift
+++ b/Sources/PostgresNIO/New/Data/Int+PSQLCodable.swift
@@ -9,7 +9,12 @@ extension UInt8: PSQLCodable {
         .binary
     }
 
-    static func decode(from buffer: inout ByteBuffer, type: PostgresDataType, format: PostgresFormat, context: PSQLDecodingContext) throws -> Self {
+    static func decode<JSONDecoder: PostgresJSONDecoder>(
+        from buffer: inout ByteBuffer,
+        type: PostgresDataType,
+        format: PostgresFormat,
+        context: PSQLDecodingContext<JSONDecoder>
+    ) throws -> Self {
         switch type {
         case .bpchar, .char:
             guard buffer.readableBytes == 1, let value = buffer.readInteger(as: UInt8.self) else {
@@ -37,7 +42,12 @@ extension Int16: PSQLCodable {
         .binary
     }
 
-    static func decode(from buffer: inout ByteBuffer, type: PostgresDataType, format: PostgresFormat, context: PSQLDecodingContext) throws -> Self {
+    static func decode<JSONDecoder: PostgresJSONDecoder>(
+        from buffer: inout ByteBuffer,
+        type: PostgresDataType,
+        format: PostgresFormat,
+        context: PSQLDecodingContext<JSONDecoder>
+    ) throws -> Self {
         switch (format, type) {
         case (.binary, .int2):
             guard buffer.readableBytes == 2, let value = buffer.readInteger(as: Int16.self) else {
@@ -68,7 +78,12 @@ extension Int32: PSQLCodable {
         .binary
     }
 
-    static func decode(from buffer: inout ByteBuffer, type: PostgresDataType, format: PostgresFormat, context: PSQLDecodingContext) throws -> Self {
+    static func decode<JSONDecoder: PostgresJSONDecoder>(
+        from buffer: inout ByteBuffer,
+        type: PostgresDataType,
+        format: PostgresFormat,
+        context: PSQLDecodingContext<JSONDecoder>
+    ) throws -> Self {
         switch (format, type) {
         case (.binary, .int2):
             guard buffer.readableBytes == 2, let value = buffer.readInteger(as: Int16.self) else {
@@ -104,7 +119,12 @@ extension Int64: PSQLCodable {
         .binary
     }
 
-    static func decode(from buffer: inout ByteBuffer, type: PostgresDataType, format: PostgresFormat, context: PSQLDecodingContext) throws -> Self {
+    static func decode<JSONDecoder: PostgresJSONDecoder>(
+        from buffer: inout ByteBuffer,
+        type: PostgresDataType,
+        format: PostgresFormat,
+        context: PSQLDecodingContext<JSONDecoder>
+    ) throws -> Self {
         switch (format, type) {
         case (.binary, .int2):
             guard buffer.readableBytes == 2, let value = buffer.readInteger(as: Int16.self) else {
@@ -152,7 +172,12 @@ extension Int: PSQLCodable {
         .binary
     }
 
-    static func decode(from buffer: inout ByteBuffer, type: PostgresDataType, format: PostgresFormat, context: PSQLDecodingContext) throws -> Self {
+    static func decode<JSONDecoder: PostgresJSONDecoder>(
+        from buffer: inout ByteBuffer,
+        type: PostgresDataType,
+        format: PostgresFormat,
+        context: PSQLDecodingContext<JSONDecoder>
+    ) throws -> Self {
         switch (format, type) {
         case (.binary, .int2):
             guard buffer.readableBytes == 2, let value = buffer.readInteger(as: Int16.self) else {

--- a/Sources/PostgresNIO/New/Data/JSON+PSQLCodable.swift
+++ b/Sources/PostgresNIO/New/Data/JSON+PSQLCodable.swift
@@ -18,7 +18,7 @@ extension PSQLCodable where Self: Codable {
         from buffer: inout ByteBuffer,
         type: PostgresDataType,
         format: PostgresFormat,
-        context: PSQLDecodingContext<JSONDecoder>
+        context: PostgresDecodingContext<JSONDecoder>
     ) throws -> Self {
         switch (format, type) {
         case (.binary, .jsonb):

--- a/Sources/PostgresNIO/New/Data/JSON+PSQLCodable.swift
+++ b/Sources/PostgresNIO/New/Data/JSON+PSQLCodable.swift
@@ -14,7 +14,12 @@ extension PSQLCodable where Self: Codable {
         .binary
     }
     
-    static func decode(from buffer: inout ByteBuffer, type: PostgresDataType, format: PostgresFormat, context: PSQLDecodingContext) throws -> Self {
+    static func decode<JSONDecoder: PostgresJSONDecoder>(
+        from buffer: inout ByteBuffer,
+        type: PostgresDataType,
+        format: PostgresFormat,
+        context: PSQLDecodingContext<JSONDecoder>
+    ) throws -> Self {
         switch (format, type) {
         case (.binary, .jsonb):
             guard JSONBVersionByte == buffer.readInteger(as: UInt8.self) else {

--- a/Sources/PostgresNIO/New/Data/Optional+PSQLCodable.swift
+++ b/Sources/PostgresNIO/New/Data/Optional+PSQLCodable.swift
@@ -3,27 +3,25 @@ import NIOCore
 extension Optional: PSQLDecodable where Wrapped: PSQLDecodable, Wrapped.DecodableType == Wrapped {
     typealias DecodableType = Wrapped
 
-    static func decode(
+    static func decode<JSONDecoder: PostgresJSONDecoder>(
         from byteBuffer: inout ByteBuffer,
         type: PostgresDataType,
         format: PostgresFormat,
-        context: PSQLDecodingContext
+        context: PSQLDecodingContext<JSONDecoder>
     ) throws -> Optional<Wrapped> {
         preconditionFailure("This should not be called")
     }
 
-    static func decodeRaw(
+    static func decodeRaw<JSONDecoder: PostgresJSONDecoder>(
         from byteBuffer: inout ByteBuffer?,
         type: PostgresDataType,
         format: PostgresFormat,
-        context: PSQLDecodingContext
+        context: PSQLDecodingContext<JSONDecoder>
     ) throws -> Self {
-        switch byteBuffer {
-        case .some(var buffer):
-            return try DecodableType.decode(from: &buffer, type: type, format: format, context: context)
-        case .none:
+        guard var buffer = byteBuffer else {
             return nil
         }
+        return try DecodableType.decode(from: &buffer, type: type, format: format, context: context)
     }
 }
 

--- a/Sources/PostgresNIO/New/Data/Optional+PSQLCodable.swift
+++ b/Sources/PostgresNIO/New/Data/Optional+PSQLCodable.swift
@@ -7,7 +7,7 @@ extension Optional: PSQLDecodable where Wrapped: PSQLDecodable, Wrapped.Decodabl
         from byteBuffer: inout ByteBuffer,
         type: PostgresDataType,
         format: PostgresFormat,
-        context: PSQLDecodingContext<JSONDecoder>
+        context: PostgresDecodingContext<JSONDecoder>
     ) throws -> Optional<Wrapped> {
         preconditionFailure("This should not be called")
     }
@@ -16,7 +16,7 @@ extension Optional: PSQLDecodable where Wrapped: PSQLDecodable, Wrapped.Decodabl
         from byteBuffer: inout ByteBuffer?,
         type: PostgresDataType,
         format: PostgresFormat,
-        context: PSQLDecodingContext<JSONDecoder>
+        context: PostgresDecodingContext<JSONDecoder>
     ) throws -> Self {
         guard var buffer = byteBuffer else {
             return nil

--- a/Sources/PostgresNIO/New/Data/RawRepresentable+PSQLCodable.swift
+++ b/Sources/PostgresNIO/New/Data/RawRepresentable+PSQLCodable.swift
@@ -13,7 +13,7 @@ extension PSQLCodable where Self: RawRepresentable, RawValue: PSQLCodable {
         from buffer: inout ByteBuffer,
         type: PostgresDataType,
         format: PostgresFormat,
-        context: PSQLDecodingContext<JSONDecoder>
+        context: PostgresDecodingContext<JSONDecoder>
     ) throws -> Self {
         guard let rawValue = try? RawValue.decode(from: &buffer, type: type, format: format, context: context),
               let selfValue = Self.init(rawValue: rawValue) else {

--- a/Sources/PostgresNIO/New/Data/RawRepresentable+PSQLCodable.swift
+++ b/Sources/PostgresNIO/New/Data/RawRepresentable+PSQLCodable.swift
@@ -9,7 +9,12 @@ extension PSQLCodable where Self: RawRepresentable, RawValue: PSQLCodable {
         self.rawValue.psqlFormat
     }
     
-    static func decode(from buffer: inout ByteBuffer, type: PostgresDataType, format: PostgresFormat, context: PSQLDecodingContext) throws -> Self {
+    static func decode<JSONDecoder: PostgresJSONDecoder>(
+        from buffer: inout ByteBuffer,
+        type: PostgresDataType,
+        format: PostgresFormat,
+        context: PSQLDecodingContext<JSONDecoder>
+    ) throws -> Self {
         guard let rawValue = try? RawValue.decode(from: &buffer, type: type, format: format, context: context),
               let selfValue = Self.init(rawValue: rawValue) else {
             throw PostgresCastingError.Code.failure

--- a/Sources/PostgresNIO/New/Data/String+PSQLCodable.swift
+++ b/Sources/PostgresNIO/New/Data/String+PSQLCodable.swift
@@ -18,7 +18,7 @@ extension String: PSQLCodable {
         from buffer: inout ByteBuffer,
         type: PostgresDataType,
         format: PostgresFormat,
-        context: PSQLDecodingContext<JSONDecoder>
+        context: PostgresDecodingContext<JSONDecoder>
     ) throws -> Self {
         switch (format, type) {
         case (_, .varchar),

--- a/Sources/PostgresNIO/New/Data/String+PSQLCodable.swift
+++ b/Sources/PostgresNIO/New/Data/String+PSQLCodable.swift
@@ -14,7 +14,12 @@ extension String: PSQLCodable {
         byteBuffer.writeString(self)
     }
     
-    static func decode(from buffer: inout ByteBuffer, type: PostgresDataType, format: PostgresFormat, context: PSQLDecodingContext) throws -> Self {
+    static func decode<JSONDecoder: PostgresJSONDecoder>(
+        from buffer: inout ByteBuffer,
+        type: PostgresDataType,
+        format: PostgresFormat,
+        context: PSQLDecodingContext<JSONDecoder>
+    ) throws -> Self {
         switch (format, type) {
         case (_, .varchar),
              (_, .text),

--- a/Sources/PostgresNIO/New/Data/UUID+PSQLCodable.swift
+++ b/Sources/PostgresNIO/New/Data/UUID+PSQLCodable.swift
@@ -22,7 +22,12 @@ extension UUID: PSQLCodable {
         ])
     }
     
-    static func decode(from buffer: inout ByteBuffer, type: PostgresDataType, format: PostgresFormat, context: PSQLDecodingContext) throws -> Self {
+    static func decode<JSONDecoder: PostgresJSONDecoder>(
+        from buffer: inout ByteBuffer,
+        type: PostgresDataType,
+        format: PostgresFormat,
+        context: PSQLDecodingContext<JSONDecoder>
+    ) throws -> Self {
         switch (format, type) {
         case (.binary, .uuid):
             guard let uuid = buffer.readUUID() else {

--- a/Sources/PostgresNIO/New/Data/UUID+PSQLCodable.swift
+++ b/Sources/PostgresNIO/New/Data/UUID+PSQLCodable.swift
@@ -26,7 +26,7 @@ extension UUID: PSQLCodable {
         from buffer: inout ByteBuffer,
         type: PostgresDataType,
         format: PostgresFormat,
-        context: PSQLDecodingContext<JSONDecoder>
+        context: PostgresDecodingContext<JSONDecoder>
     ) throws -> Self {
         switch (format, type) {
         case (.binary, .uuid):

--- a/Sources/PostgresNIO/New/PSQLCodable.swift
+++ b/Sources/PostgresNIO/New/PSQLCodable.swift
@@ -37,7 +37,7 @@ protocol PSQLDecodable {
         from byteBuffer: inout ByteBuffer,
         type: PostgresDataType,
         format: PostgresFormat,
-        context: PSQLDecodingContext<JSONDecoder>
+        context: PostgresDecodingContext<JSONDecoder>
     ) throws -> Self
 
     /// Decode an entity from the `byteBuffer` in postgres wire format.
@@ -47,7 +47,7 @@ protocol PSQLDecodable {
         from byteBuffer: inout ByteBuffer?,
         type: PostgresDataType,
         format: PostgresFormat,
-        context: PSQLDecodingContext<JSONDecoder>
+        context: PostgresDecodingContext<JSONDecoder>
     ) throws -> Self
 }
 
@@ -57,7 +57,7 @@ extension PSQLDecodable {
         from byteBuffer: inout ByteBuffer?,
         type: PostgresDataType,
         format: PostgresFormat,
-        context: PSQLDecodingContext<JSONDecoder>
+        context: PostgresDecodingContext<JSONDecoder>
     ) throws -> Self {
         guard var buffer = byteBuffer else {
             throw PostgresCastingError.Code.missingData
@@ -89,7 +89,7 @@ struct PSQLEncodingContext {
     let jsonEncoder: PostgresJSONEncoder
 }
 
-struct PSQLDecodingContext<JSONDecoder: PostgresJSONDecoder> {
+struct PostgresDecodingContext<JSONDecoder: PostgresJSONDecoder> {
     let jsonDecoder: JSONDecoder
     
     init(jsonDecoder: JSONDecoder) {

--- a/Sources/PostgresNIO/New/PSQLCodable.swift
+++ b/Sources/PostgresNIO/New/PSQLCodable.swift
@@ -33,21 +33,31 @@ protocol PSQLDecodable {
     ///   - context: A `PSQLDecodingContext` providing context for decoding. This includes a `JSONDecoder`
     ///              to use when decoding json and metadata to create better errors.
     /// - Returns: A decoded object
-    static func decode(from byteBuffer: inout ByteBuffer, type: PostgresDataType, format: PostgresFormat, context: PSQLDecodingContext) throws -> Self
+    static func decode<JSONDecoder: PostgresJSONDecoder>(
+        from byteBuffer: inout ByteBuffer,
+        type: PostgresDataType,
+        format: PostgresFormat,
+        context: PSQLDecodingContext<JSONDecoder>
+    ) throws -> Self
 
     /// Decode an entity from the `byteBuffer` in postgres wire format.
     /// This method has a default implementation and may be overriden
     /// only for special cases, like `Optional`s.
-    static func decodeRaw(from byteBuffer: inout ByteBuffer?, type: PostgresDataType, format: PostgresFormat, context: PSQLDecodingContext) throws -> Self
+    static func decodeRaw<JSONDecoder: PostgresJSONDecoder>(
+        from byteBuffer: inout ByteBuffer?,
+        type: PostgresDataType,
+        format: PostgresFormat,
+        context: PSQLDecodingContext<JSONDecoder>
+    ) throws -> Self
 }
 
 extension PSQLDecodable {
     @inlinable
-    public static func decodeRaw(
+    static func decodeRaw<JSONDecoder: PostgresJSONDecoder>(
         from byteBuffer: inout ByteBuffer?,
         type: PostgresDataType,
         format: PostgresFormat,
-        context: PSQLDecodingContext
+        context: PSQLDecodingContext<JSONDecoder>
     ) throws -> Self {
         guard var buffer = byteBuffer else {
             throw PostgresCastingError.Code.missingData
@@ -79,22 +89,10 @@ struct PSQLEncodingContext {
     let jsonEncoder: PostgresJSONEncoder
 }
 
-struct PSQLDecodingContext {
+struct PSQLDecodingContext<JSONDecoder: PostgresJSONDecoder> {
+    let jsonDecoder: JSONDecoder
     
-    let jsonDecoder: PostgresJSONDecoder
-    
-    let columnIndex: Int
-    let columnName: String
-    
-    let file: String
-    let line: Int
-    
-    init(jsonDecoder: PostgresJSONDecoder, columnName: String, columnIndex: Int, file: String, line: Int) {
+    init(jsonDecoder: JSONDecoder) {
         self.jsonDecoder = jsonDecoder
-        self.columnName = columnName
-        self.columnIndex = columnIndex
-        
-        self.file = file
-        self.line = line
     }
 }

--- a/Sources/PostgresNIO/New/PSQLRow.swift
+++ b/Sources/PostgresNIO/New/PSQLRow.swift
@@ -48,7 +48,7 @@ extension PSQLRow {
         precondition(index < self.data.columnCount)
         
         let column = self.columns[index]
-        let context = PSQLDecodingContext(jsonDecoder: jsonDecoder)
+        let context = PostgresDecodingContext(jsonDecoder: jsonDecoder)
 
         // Safe to force unwrap here, as we have ensured above that the row has enough columns 
         var cellSlice = self.data[column: index]!

--- a/Sources/PostgresNIO/New/PSQLRow.swift
+++ b/Sources/PostgresNIO/New/PSQLRow.swift
@@ -48,12 +48,7 @@ extension PSQLRow {
         precondition(index < self.data.columnCount)
         
         let column = self.columns[index]
-        let context = PSQLDecodingContext(
-            jsonDecoder: jsonDecoder,
-            columnName: column.name,
-            columnIndex: index,
-            file: file,
-            line: line)
+        let context = PSQLDecodingContext(jsonDecoder: jsonDecoder)
 
         // Safe to force unwrap here, as we have ensured above that the row has enough columns 
         var cellSlice = self.data[column: index]!

--- a/Sources/PostgresNIO/Postgres+PSQLCompat.swift
+++ b/Sources/PostgresNIO/Postgres+PSQLCompat.swift
@@ -30,7 +30,7 @@ extension PostgresData: PSQLDecodable {
         from buffer: inout ByteBuffer,
         type: PostgresDataType,
         format: PostgresFormat,
-        context: PSQLDecodingContext<JSONDecoder>
+        context: PostgresDecodingContext<JSONDecoder>
     ) throws -> Self {
         let myBuffer = buffer.readSlice(length: buffer.readableBytes)!
         

--- a/Sources/PostgresNIO/Postgres+PSQLCompat.swift
+++ b/Sources/PostgresNIO/Postgres+PSQLCompat.swift
@@ -26,7 +26,12 @@ extension PostgresData: PSQLEncodable {
 }
 
 extension PostgresData: PSQLDecodable {
-    static func decode(from buffer: inout ByteBuffer, type: PostgresDataType, format: PostgresFormat, context: PSQLDecodingContext) throws -> Self {
+    static func decode<JSONDecoder: PostgresJSONDecoder>(
+        from buffer: inout ByteBuffer,
+        type: PostgresDataType,
+        format: PostgresFormat,
+        context: PSQLDecodingContext<JSONDecoder>
+    ) throws -> Self {
         let myBuffer = buffer.readSlice(length: buffer.readableBytes)!
         
         return PostgresData(type: PostgresDataType(UInt32(type.rawValue)), typeModifier: nil, formatCode: .binary, value: myBuffer)

--- a/Tests/PostgresNIOTests/New/Extensions/PSQLCoding+TestUtils.swift
+++ b/Tests/PostgresNIOTests/New/Extensions/PSQLCoding+TestUtils.swift
@@ -7,7 +7,7 @@ extension PSQLFrontendMessageEncoder {
     }
 }
 
-extension PSQLDecodingContext where JSONDecoder == Foundation.JSONDecoder {
+extension PostgresDecodingContext where JSONDecoder == Foundation.JSONDecoder {
     static func forTests() -> Self {
         Self(jsonDecoder: JSONDecoder())
     }

--- a/Tests/PostgresNIOTests/New/Extensions/PSQLCoding+TestUtils.swift
+++ b/Tests/PostgresNIOTests/New/Extensions/PSQLCoding+TestUtils.swift
@@ -7,9 +7,9 @@ extension PSQLFrontendMessageEncoder {
     }
 }
 
-extension PSQLDecodingContext {
-    static func forTests(columnName: String = "unknown", columnIndex: Int = 0, jsonDecoder: PostgresJSONDecoder = JSONDecoder(), file: String = #file, line: Int = #line) -> Self {
-        Self(jsonDecoder: JSONDecoder(), columnName: columnName, columnIndex: columnIndex, file: file, line: line)
+extension PSQLDecodingContext where JSONDecoder == Foundation.JSONDecoder {
+    static func forTests() -> Self {
+        Self(jsonDecoder: JSONDecoder())
     }
 }
 


### PR DESCRIPTION
### Motivation

Since we don't attach the JSONDecoder to the connection anymore and supply during decoding, we can now make the decoding generic over the supplied JSONDecoder.

### Changes

- Make `PSQLDecodingContext` generic over the JSONDecoder
- Rename `PSQLDecodingContext` to `PostgresDecodingContext`

### Result

- We don't use an existential in the very hot code paths.