### PR TITLE
Rename PSQLCodable to PostgresCodable

### DIFF
--- a/Sources/PostgresNIO/New/Data/Array+PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/Data/Array+PostgresCodable.swift
@@ -2,7 +2,7 @@ import NIOCore
 import struct Foundation.UUID
 
 /// A type, of which arrays can be encoded into and decoded from a postgres binary format
-protocol PSQLArrayElement: PSQLCodable {
+protocol PSQLArrayElement: PostgresCodable {
     static var psqlArrayType: PostgresDataType { get }
     static var psqlArrayElementType: PostgresDataType { get }
 }
@@ -67,7 +67,7 @@ extension UUID: PSQLArrayElement {
     static var psqlArrayElementType: PostgresDataType { .uuid }
 }
 
-extension Array: PSQLEncodable where Element: PSQLArrayElement {
+extension Array: PostgresEncodable where Element: PSQLArrayElement {
     var psqlType: PostgresDataType {
         Element.psqlArrayType
     }
@@ -155,6 +155,6 @@ extension Array: PostgresDecodable where Element: PSQLArrayElement {
     }
 }
 
-extension Array: PSQLCodable where Element: PSQLArrayElement {
+extension Array: PostgresCodable where Element: PSQLArrayElement {
 
 }

--- a/Sources/PostgresNIO/New/Data/Bool+PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/Data/Bool+PostgresCodable.swift
@@ -1,6 +1,6 @@
 import NIOCore
 
-extension Bool: PSQLCodable {
+extension Bool: PostgresCodable {
     var psqlType: PostgresDataType {
         .bool
     }

--- a/Sources/PostgresNIO/New/Data/Bytes+PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/Data/Bytes+PostgresCodable.swift
@@ -2,7 +2,7 @@ import struct Foundation.Data
 import NIOCore
 import NIOFoundationCompat
 
-extension PSQLEncodable where Self: Sequence, Self.Element == UInt8 {
+extension PostgresEncodable where Self: Sequence, Self.Element == UInt8 {
     var psqlType: PostgresDataType {
         .bytea
     }
@@ -19,7 +19,7 @@ extension PSQLEncodable where Self: Sequence, Self.Element == UInt8 {
     }
 }
 
-extension ByteBuffer: PSQLCodable {
+extension ByteBuffer: PostgresCodable {
     var psqlType: PostgresDataType {
         .bytea
     }
@@ -46,7 +46,7 @@ extension ByteBuffer: PSQLCodable {
     }
 }
 
-extension Data: PSQLCodable {
+extension Data: PostgresCodable {
     var psqlType: PostgresDataType {
         .bytea
     }

--- a/Sources/PostgresNIO/New/Data/Date+PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/Data/Date+PostgresCodable.swift
@@ -1,7 +1,7 @@
 import NIOCore
 import struct Foundation.Date
 
-extension Date: PSQLCodable {
+extension Date: PostgresCodable {
     var psqlType: PostgresDataType {
         .timestamptz
     }

--- a/Sources/PostgresNIO/New/Data/Decimal+PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/Data/Decimal+PostgresCodable.swift
@@ -1,7 +1,7 @@
 import NIOCore
 import struct Foundation.Decimal
 
-extension Decimal: PSQLCodable {
+extension Decimal: PostgresCodable {
     var psqlType: PostgresDataType {
         .numeric
     }

--- a/Sources/PostgresNIO/New/Data/Float+PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/Data/Float+PostgresCodable.swift
@@ -1,6 +1,6 @@
 import NIOCore
 
-extension Float: PSQLCodable {
+extension Float: PostgresCodable {
     var psqlType: PostgresDataType {
         .float4
     }
@@ -44,7 +44,7 @@ extension Float: PSQLCodable {
     }
 }
 
-extension Double: PSQLCodable {
+extension Double: PostgresCodable {
     var psqlType: PostgresDataType {
         .float8
     }

--- a/Sources/PostgresNIO/New/Data/Int+PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/Data/Int+PostgresCodable.swift
@@ -1,6 +1,6 @@
 import NIOCore
 
-extension UInt8: PSQLCodable {
+extension UInt8: PostgresCodable {
     var psqlType: PostgresDataType {
         .char
     }
@@ -35,7 +35,7 @@ extension UInt8: PSQLCodable {
     }
 }
 
-extension Int16: PSQLCodable {
+extension Int16: PostgresCodable {
     
     var psqlType: PostgresDataType {
         .int2
@@ -75,7 +75,7 @@ extension Int16: PSQLCodable {
     }
 }
 
-extension Int32: PSQLCodable {
+extension Int32: PostgresCodable {
     var psqlType: PostgresDataType {
         .int4
     }
@@ -119,7 +119,7 @@ extension Int32: PSQLCodable {
     }
 }
 
-extension Int64: PSQLCodable {
+extension Int64: PostgresCodable {
     var psqlType: PostgresDataType {
         .int8
     }
@@ -168,7 +168,7 @@ extension Int64: PSQLCodable {
     }
 }
 
-extension Int: PSQLCodable {
+extension Int: PostgresCodable {
     var psqlType: PostgresDataType {
         switch self.bitWidth {
         case Int32.bitWidth:

--- a/Sources/PostgresNIO/New/Data/JSON+PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/Data/JSON+PostgresCodable.swift
@@ -5,7 +5,7 @@ import class Foundation.JSONDecoder
 
 private let JSONBVersionByte: UInt8 = 0x01
 
-extension PSQLCodable where Self: Codable {
+extension PostgresCodable where Self: Codable {
     var psqlType: PostgresDataType {
         .jsonb
     }

--- a/Sources/PostgresNIO/New/Data/Optional+PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/Data/Optional+PostgresCodable.swift
@@ -25,7 +25,7 @@ extension Optional: PostgresDecodable where Wrapped: PostgresDecodable, Wrapped.
     }
 }
 
-extension Optional: PSQLEncodable where Wrapped: PSQLEncodable {
+extension Optional: PostgresEncodable where Wrapped: PostgresEncodable {
     var psqlType: PostgresDataType {
         switch self {
         case .some(let value):
@@ -64,6 +64,6 @@ extension Optional: PSQLEncodable where Wrapped: PSQLEncodable {
     }
 }
 
-extension Optional: PSQLCodable where Wrapped: PSQLCodable, Wrapped.DecodableType == Wrapped {
+extension Optional: PostgresCodable where Wrapped: PostgresCodable, Wrapped.DecodableType == Wrapped {
     
 }

--- a/Sources/PostgresNIO/New/Data/RawRepresentable+PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/Data/RawRepresentable+PostgresCodable.swift
@@ -1,6 +1,6 @@
 import NIOCore
 
-extension PSQLCodable where Self: RawRepresentable, RawValue: PSQLCodable {
+extension PostgresCodable where Self: RawRepresentable, RawValue: PostgresCodable {
     var psqlType: PostgresDataType {
         self.rawValue.psqlType
     }

--- a/Sources/PostgresNIO/New/Data/String+PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/Data/String+PostgresCodable.swift
@@ -1,7 +1,7 @@
 import NIOCore
 import struct Foundation.UUID
 
-extension String: PSQLCodable {
+extension String: PostgresCodable {
     var psqlType: PostgresDataType {
         .text
     }

--- a/Sources/PostgresNIO/New/Data/UUID+PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/Data/UUID+PostgresCodable.swift
@@ -2,7 +2,7 @@ import NIOCore
 import struct Foundation.UUID
 import typealias Foundation.uuid_t
 
-extension UUID: PSQLCodable {
+extension UUID: PostgresCodable {
     
     var psqlType: PostgresDataType {
         .uuid

--- a/Sources/PostgresNIO/New/PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/PostgresCodable.swift
@@ -2,7 +2,7 @@ import NIOCore
 import Foundation
 
 /// A type that can encode itself to a postgres wire binary representation.
-protocol PSQLEncodable {
+protocol PostgresEncodable {
     /// identifies the data type that we will encode into `byteBuffer` in `encode`
     var psqlType: PostgresDataType { get }
     
@@ -68,9 +68,9 @@ extension PostgresDecodable {
 }
 
 /// A type that can be encoded into and decoded from a postgres binary format
-protocol PSQLCodable: PSQLEncodable, PostgresDecodable {}
+protocol PostgresCodable: PostgresEncodable, PostgresDecodable {}
 
-extension PSQLEncodable {
+extension PostgresEncodable {
     func encodeRaw<JSONEncoder: PostgresJSONEncoder>(
         into buffer: inout ByteBuffer,
         context: PSQLEncodingContext<JSONEncoder>

--- a/Sources/PostgresNIO/New/PostgresQuery.swift
+++ b/Sources/PostgresNIO/New/PostgresQuery.swift
@@ -23,7 +23,7 @@ extension PostgresQuery: ExpressibleByStringInterpolation {
         self.binds = PostgresBindings()
     }
 
-    mutating func appendBinding<Value: PSQLEncodable, JSONEncoder: PostgresJSONEncoder>(
+    mutating func appendBinding<Value: PostgresEncodable, JSONEncoder: PostgresJSONEncoder>(
         _ value: Value,
         context: PSQLEncodingContext<JSONEncoder>
     ) throws {
@@ -47,17 +47,17 @@ extension PostgresQuery {
             self.sql.append(contentsOf: literal)
         }
 
-        mutating func appendInterpolation<Value: PSQLEncodable>(_ value: Value) throws {
+        mutating func appendInterpolation<Value: PostgresEncodable>(_ value: Value) throws {
             try self.binds.append(value, context: .default)
             self.sql.append(contentsOf: "$\(self.binds.count)")
         }
 
-        mutating func appendInterpolation<Value: PSQLEncodable>(_ value: Optional<Value>) throws {
+        mutating func appendInterpolation<Value: PostgresEncodable>(_ value: Optional<Value>) throws {
             try self.binds.append(value, context: .default)
             self.sql.append(contentsOf: "$\(self.binds.count)")
         }
 
-        mutating func appendInterpolation<Value: PSQLEncodable, JSONEncoder: PostgresJSONEncoder>(
+        mutating func appendInterpolation<Value: PostgresEncodable, JSONEncoder: PostgresJSONEncoder>(
             _ value: Value,
             context: PSQLEncodingContext<JSONEncoder>
         ) throws {
@@ -86,7 +86,7 @@ struct PostgresBindings: Hashable {
             self.format = format
         }
 
-        init<Value: PSQLEncodable>(value: Value) {
+        init<Value: PostgresEncodable>(value: Value) {
             self.init(dataType: value.psqlType, format: value.psqlFormat)
         }
     }
@@ -110,7 +110,7 @@ struct PostgresBindings: Hashable {
         self.bytes.reserveCapacity(128 * capacity)
     }
 
-    mutating func append<Value: PSQLEncodable, JSONEncoder: PostgresJSONEncoder>(
+    mutating func append<Value: PostgresEncodable, JSONEncoder: PostgresJSONEncoder>(
         _ value: Value,
         context: PSQLEncodingContext<JSONEncoder>
     ) throws {

--- a/Sources/PostgresNIO/Postgres+PSQLCompat.swift
+++ b/Sources/PostgresNIO/Postgres+PSQLCompat.swift
@@ -1,6 +1,6 @@
 import NIOCore
 
-extension PostgresData: PSQLEncodable {
+extension PostgresData: PostgresEncodable {
     var psqlType: PostgresDataType {
         self.type
     }
@@ -44,7 +44,7 @@ extension PostgresData: PostgresDecodable {
     }
 }
 
-extension PostgresData: PSQLCodable {}
+extension PostgresData: PostgresCodable {}
 
 extension PSQLError {
     func toPostgresError() -> Error {

--- a/Tests/IntegrationTests/PSQLIntegrationTests.swift
+++ b/Tests/IntegrationTests/PSQLIntegrationTests.swift
@@ -298,7 +298,7 @@ final class IntegrationTests: XCTestCase {
     }
     
     func testRoundTripJSONB() {
-        struct Object: Codable, PSQLCodable {
+        struct Object: Codable, PostgresCodable {
             let foo: Int
             let bar: Int
         }

--- a/Tests/PostgresNIOTests/New/Data/Bytes+PSQLCodableTests.swift
+++ b/Tests/PostgresNIOTests/New/Data/Bytes+PSQLCodableTests.swift
@@ -29,7 +29,7 @@ class Bytes_PSQLCodableTests: XCTestCase {
     }
     
     func testEncodeSequenceWhereElementUInt8() {
-        struct ByteSequence: Sequence, PSQLEncodable {
+        struct ByteSequence: Sequence, PostgresEncodable {
             typealias Element = UInt8
             typealias Iterator = Array<UInt8>.Iterator
             

--- a/Tests/PostgresNIOTests/New/Data/JSON+PSQLCodableTests.swift
+++ b/Tests/PostgresNIOTests/New/Data/JSON+PSQLCodableTests.swift
@@ -4,7 +4,7 @@ import NIOCore
 
 class JSON_PSQLCodableTests: XCTestCase {
     
-    struct Hello: Equatable, Codable, PSQLCodable {
+    struct Hello: Equatable, Codable, PostgresCodable {
         let hello: String
         
         init(name: String) {

--- a/Tests/PostgresNIOTests/New/Data/Optional+PSQLCodableTests.swift
+++ b/Tests/PostgresNIOTests/New/Data/Optional+PSQLCodableTests.swift
@@ -35,7 +35,7 @@ class Optional_PSQLCodableTests: XCTestCase {
     
     func testRoundTripSomeUUIDAsPSQLEncodable() {
         let value: Optional<UUID> = UUID()
-        let encodable: PSQLEncodable = value
+        let encodable: PostgresEncodable = value
         
         var buffer = ByteBuffer()
         XCTAssertEqual(encodable.psqlType, .uuid)
@@ -51,7 +51,7 @@ class Optional_PSQLCodableTests: XCTestCase {
     
     func testRoundTripNoneUUIDAsPSQLEncodable() {
         let value: Optional<UUID> = .none
-        let encodable: PSQLEncodable = value
+        let encodable: PostgresEncodable = value
         
         var buffer = ByteBuffer()
         XCTAssertEqual(encodable.psqlType, .null)

--- a/Tests/PostgresNIOTests/New/Data/RawRepresentable+PSQLCodableTests.swift
+++ b/Tests/PostgresNIOTests/New/Data/RawRepresentable+PSQLCodableTests.swift
@@ -4,7 +4,7 @@ import NIOCore
 
 class RawRepresentable_PSQLCodableTests: XCTestCase {
     
-    enum MyRawRepresentable: Int16, PSQLCodable {
+    enum MyRawRepresentable: Int16, PostgresCodable {
         case testing = 1
         case staging = 2
         case production = 3

--- a/Tests/PostgresNIOTests/New/Messages/DataRowTests.swift
+++ b/Tests/PostgresNIOTests/New/Messages/DataRowTests.swift
@@ -114,9 +114,9 @@ class DataRowTests: XCTestCase {
 }
 
 extension DataRow: ExpressibleByArrayLiteral {
-    public typealias ArrayLiteralElement = PSQLEncodable
+    public typealias ArrayLiteralElement = PostgresEncodable
 
-    public init(arrayLiteral elements: PSQLEncodable...) {
+    public init(arrayLiteral elements: PostgresEncodable...) {
         
         var buffer = ByteBuffer()
         let encodingContext = PSQLEncodingContext(jsonEncoder: JSONEncoder())

--- a/Tests/PostgresNIOTests/New/PostgresQueryTests.swift
+++ b/Tests/PostgresNIOTests/New/PostgresQueryTests.swift
@@ -31,7 +31,7 @@ final class PostgresQueryTests: XCTestCase {
     }
 
     func testStringInterpolationWithCustomJSONEncoder() throws {
-        struct Foo: Codable, PSQLCodable {
+        struct Foo: Codable, PostgresCodable {
             var helloWorld: String
         }
 
@@ -55,7 +55,7 @@ final class PostgresQueryTests: XCTestCase {
     }
 
     func testAllowUsersToGenerateLotsOfRows() throws {
-        struct Foo: Codable, PSQLCodable {
+        struct Foo: Codable, PostgresCodable {
             var helloWorld: String
         }
 


### PR DESCRIPTION
### Motivation

Same as #224.

### Modifications

- Rename `PSQLCodable` to `PostgresCodable`
- Rename `PSQLEncodable` to `PostgresEncodable`

### Result

More consistent future API