### PR TITLE
Rename PSQLRowSequence to PostgresRowSequence

### DIFF
--- a/Sources/PostgresNIO/New/PSQLRowStream.swift
+++ b/Sources/PostgresNIO/New/PSQLRowStream.swift
@@ -64,7 +64,7 @@ final class PSQLRowStream {
     // MARK: Async Sequence
     
     #if swift(>=5.5) && canImport(_Concurrency)
-    func asyncSequence() -> PSQLRowSequence {
+    func asyncSequence() -> PostgresRowSequence {
         self.eventLoop.preconditionInEventLoop()
 
         guard case .waitingForConsumer(let bufferState) = self.downstreamState else {
@@ -90,7 +90,7 @@ final class PSQLRowStream {
             self.downstreamState = .consumed(.failure(error))
         }
         
-        return PSQLRowSequence(consumer)
+        return PostgresRowSequence(consumer)
     }
     
     func demand() {

--- a/Sources/PostgresNIO/New/PostgresRowSequence.swift
+++ b/Sources/PostgresNIO/New/PostgresRowSequence.swift
@@ -5,7 +5,7 @@ import NIOConcurrencyHelpers
 /// An async sequence of ``PSQLRow``s.
 ///
 /// - Note: This is a struct to allow us to move to a move only type easily once they become available.
-struct PSQLRowSequence: AsyncSequence {
+struct PostgresRowSequence: AsyncSequence {
     typealias Element = PSQLRow
     typealias AsyncIterator = Iterator
     
@@ -38,7 +38,7 @@ struct PSQLRowSequence: AsyncSequence {
     }
 }
 
-extension PSQLRowSequence {
+extension PostgresRowSequence {
     struct Iterator: AsyncIteratorProtocol {
         typealias Element = PSQLRow
         
@@ -155,11 +155,11 @@ final class AsyncStreamConsumer {
         }
     }
     
-    func makeAsyncIterator() -> PSQLRowSequence.Iterator {
+    func makeAsyncIterator() -> PostgresRowSequence.Iterator {
         self.lock.withLock {
             self.state.createAsyncIterator()
         }
-        let iterator = PSQLRowSequence.Iterator(consumer: self)
+        let iterator = PostgresRowSequence.Iterator(consumer: self)
         return iterator
     }
 
@@ -532,7 +532,7 @@ extension AsyncStreamConsumer {
     }
 }
 
-extension PSQLRowSequence {
+extension PostgresRowSequence {
     func collect() async throws -> [PSQLRow] {
         var result = [PSQLRow]()
         for try await row in self {

--- a/Tests/PostgresNIOTests/New/PostgresRowSequenceTests.swift
+++ b/Tests/PostgresNIOTests/New/PostgresRowSequenceTests.swift
@@ -5,7 +5,7 @@ import XCTest
 @testable import PostgresNIO
 
 #if swift(>=5.5.2)
-final class PSQLRowSequenceTests: XCTestCase {
+final class PostgresRowSequenceTests: XCTestCase {
 
     func testBackpressureWorks() async throws {
         let eventLoop = EmbeddedEventLoop()
@@ -90,7 +90,7 @@ final class PSQLRowSequenceTests: XCTestCase {
         let dataRows: [DataRow] = (0..<128).map { [ByteBuffer(integer: Int64($0))] }
         stream.receive(dataRows)
 
-        var iterator: PSQLRowSequence.Iterator? = rowSequence.makeAsyncIterator()
+        var iterator: PostgresRowSequence.Iterator? = rowSequence.makeAsyncIterator()
         iterator = nil
 
         XCTAssertEqual(dataSource.cancelCount, 1)
@@ -112,7 +112,7 @@ final class PSQLRowSequenceTests: XCTestCase {
         )
         promise.succeed(stream)
 
-        var rowSequence: PSQLRowSequence? = stream.asyncSequence()
+        var rowSequence: PostgresRowSequence? = stream.asyncSequence()
         rowSequence = nil
 
         XCTAssertEqual(dataSource.cancelCount, 1)


### PR DESCRIPTION
### Motivation

Same as #224 and #225.

### Changes

- Rename `PSQLRowSequence` to `PostgresRowSequence`