### PR TITLE
Explicit TLS config

### DIFF
--- a/Tests/IntegrationTests/PSQLIntegrationTests.swift
+++ b/Tests/IntegrationTests/PSQLIntegrationTests.swift
@@ -28,7 +28,7 @@ final class IntegrationTests: XCTestCase {
             username: env("POSTGRES_USER") ?? "test_username",
             database: env("POSTGRES_DB") ?? "test_database",
             password: "wrong_password",
-            tlsConfiguration: nil)
+            tls: .disable)
 
         let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully()) }
@@ -358,7 +358,8 @@ extension PSQLConnection {
             username: env("POSTGRES_USER") ?? "test_username",
             database: env("POSTGRES_DB") ?? "test_database",
             password: env("POSTGRES_PASSWORD") ?? "test_password",
-            tlsConfiguration: nil)
+            tls: .disable
+        )
 
         return PSQLConnection.connect(configuration: config, logger: logger, on: eventLoop)
     }

--- a/Tests/PostgresNIOTests/New/Connection State Machine/AuthenticationStateMachineTests.swift
+++ b/Tests/PostgresNIOTests/New/Connection State Machine/AuthenticationStateMachineTests.swift
@@ -6,7 +6,9 @@ class AuthenticationStateMachineTests: XCTestCase {
     
     func testAuthenticatePlaintext() {
         let authContext = AuthContext(username: "test", password: "abc123", database: "test")
-        var state = ConnectionStateMachine(.waitingToStartAuthentication)
+
+        var state = ConnectionStateMachine()
+        XCTAssertEqual(state.connected(tls: .disable), .provideAuthenticationContext)
         
         XCTAssertEqual(state.provideAuthenticationContext(authContext), .sendStartupMessage(authContext))
         XCTAssertEqual(state.authenticationMessageReceived(.plaintext), .sendPasswordMessage(.cleartext, authContext))
@@ -15,7 +17,8 @@ class AuthenticationStateMachineTests: XCTestCase {
     
     func testAuthenticateMD5() {
         let authContext = AuthContext(username: "test", password: "abc123", database: "test")
-        var state = ConnectionStateMachine(.waitingToStartAuthentication)
+        var state = ConnectionStateMachine()
+        XCTAssertEqual(state.connected(tls: .disable), .provideAuthenticationContext)
         let salt: (UInt8, UInt8, UInt8, UInt8) = (0, 1, 2, 3)
         
         XCTAssertEqual(state.provideAuthenticationContext(authContext), .sendStartupMessage(authContext))
@@ -25,7 +28,8 @@ class AuthenticationStateMachineTests: XCTestCase {
     
     func testAuthenticateMD5WithoutPassword() {
         let authContext = AuthContext(username: "test", password: nil, database: "test")
-        var state = ConnectionStateMachine(.waitingToStartAuthentication)
+        var state = ConnectionStateMachine()
+        XCTAssertEqual(state.connected(tls: .disable), .provideAuthenticationContext)
         let salt: (UInt8, UInt8, UInt8, UInt8) = (0, 1, 2, 3)
         
         XCTAssertEqual(state.provideAuthenticationContext(authContext), .sendStartupMessage(authContext))
@@ -35,15 +39,16 @@ class AuthenticationStateMachineTests: XCTestCase {
     
     func testAuthenticateOkAfterStartUpWithoutAuthChallenge() {
         let authContext = AuthContext(username: "test", password: "abc123", database: "test")
-        var state = ConnectionStateMachine(.waitingToStartAuthentication)
-        
+        var state = ConnectionStateMachine()
+        XCTAssertEqual(state.connected(tls: .disable), .provideAuthenticationContext)
         XCTAssertEqual(state.provideAuthenticationContext(authContext), .sendStartupMessage(authContext))
         XCTAssertEqual(state.authenticationMessageReceived(.ok), .wait)
     }
     
     func testAuthenticationFailure() {
         let authContext = AuthContext(username: "test", password: "abc123", database: "test")
-        var state = ConnectionStateMachine(.waitingToStartAuthentication)
+        var state = ConnectionStateMachine()
+        XCTAssertEqual(state.connected(tls: .disable), .provideAuthenticationContext)
         let salt: (UInt8, UInt8, UInt8, UInt8) = (0, 1, 2, 3)
         
         XCTAssertEqual(state.provideAuthenticationContext(authContext), .sendStartupMessage(authContext))
@@ -74,7 +79,8 @@ class AuthenticationStateMachineTests: XCTestCase {
         
         for (message, mechanism) in unsupported {
             let authContext = AuthContext(username: "test", password: "abc123", database: "test")
-            var state = ConnectionStateMachine(.waitingToStartAuthentication)
+            var state = ConnectionStateMachine()
+            XCTAssertEqual(state.connected(tls: .disable), .provideAuthenticationContext)
             XCTAssertEqual(state.provideAuthenticationContext(authContext), .sendStartupMessage(authContext))
             XCTAssertEqual(state.authenticationMessageReceived(message),
                            .closeConnectionAndCleanup(.init(action: .close, tasks: [], error: .unsupportedAuthMechanism(mechanism), closePromise: nil)))
@@ -92,7 +98,8 @@ class AuthenticationStateMachineTests: XCTestCase {
         
         for message in unexpected {
             let authContext = AuthContext(username: "test", password: "abc123", database: "test")
-            var state = ConnectionStateMachine(.waitingToStartAuthentication)
+            var state = ConnectionStateMachine()
+            XCTAssertEqual(state.connected(tls: .disable), .provideAuthenticationContext)
             XCTAssertEqual(state.provideAuthenticationContext(authContext), .sendStartupMessage(authContext))
             XCTAssertEqual(state.authenticationMessageReceived(message),
                            .closeConnectionAndCleanup(.init(action: .close, tasks: [], error: .unexpectedBackendMessage(.authentication(message)), closePromise: nil)))
@@ -118,7 +125,8 @@ class AuthenticationStateMachineTests: XCTestCase {
         
         for message in unexpected {
             let authContext = AuthContext(username: "test", password: "abc123", database: "test")
-            var state = ConnectionStateMachine(.waitingToStartAuthentication)
+            var state = ConnectionStateMachine()
+            XCTAssertEqual(state.connected(tls: .disable), .provideAuthenticationContext)
             XCTAssertEqual(state.provideAuthenticationContext(authContext), .sendStartupMessage(authContext))
             XCTAssertEqual(state.authenticationMessageReceived(.md5(salt: salt)), .sendPasswordMessage(.md5(salt: salt), authContext))
             XCTAssertEqual(state.authenticationMessageReceived(message),

--- a/Tests/PostgresNIOTests/New/Connection State Machine/ConnectionStateMachineTests.swift
+++ b/Tests/PostgresNIOTests/New/Connection State Machine/ConnectionStateMachineTests.swift
@@ -9,7 +9,7 @@ class ConnectionStateMachineTests: XCTestCase {
     func testStartup() {
         let authContext = AuthContext(username: "test", password: "abc123", database: "test")
         var state = ConnectionStateMachine()
-        XCTAssertEqual(state.connected(requireTLS: false), .provideAuthenticationContext)
+        XCTAssertEqual(state.connected(tls: .disable), .provideAuthenticationContext)
         XCTAssertEqual(state.provideAuthenticationContext(authContext), .sendStartupMessage(authContext))
         XCTAssertEqual(state.authenticationMessageReceived(.plaintext), .sendPasswordMessage(.cleartext, authContext))
         XCTAssertEqual(state.authenticationMessageReceived(.ok), .wait)
@@ -18,7 +18,7 @@ class ConnectionStateMachineTests: XCTestCase {
     func testSSLStartupSuccess() {
         let authContext = AuthContext(username: "test", password: "abc123", database: "test")
         var state = ConnectionStateMachine()
-        XCTAssertEqual(state.connected(requireTLS: true), .sendSSLRequest)
+        XCTAssertEqual(state.connected(tls: .require), .sendSSLRequest)
         XCTAssertEqual(state.sslSupportedReceived(), .establishSSLConnection)
         XCTAssertEqual(state.sslHandlerAdded(), .wait)
         XCTAssertEqual(state.sslEstablished(), .provideAuthenticationContext)
@@ -31,18 +31,25 @@ class ConnectionStateMachineTests: XCTestCase {
         struct SSLHandlerAddError: Error, Equatable {}
         
         var state = ConnectionStateMachine()
-        XCTAssertEqual(state.connected(requireTLS: true), .sendSSLRequest)
+        XCTAssertEqual(state.connected(tls: .require), .sendSSLRequest)
         XCTAssertEqual(state.sslSupportedReceived(), .establishSSLConnection)
         let failError = PSQLError.failedToAddSSLHandler(underlying: SSLHandlerAddError())
         XCTAssertEqual(state.errorHappened(failError), .closeConnectionAndCleanup(.init(action: .close, tasks: [], error: failError, closePromise: nil)))
     }
     
-    func testSSLStartupSSLUnsupported() {
+    func testTLSRequiredStartupSSLUnsupported() {
         var state = ConnectionStateMachine()
         
-        XCTAssertEqual(state.connected(requireTLS: true), .sendSSLRequest)
+        XCTAssertEqual(state.connected(tls: .require), .sendSSLRequest)
         XCTAssertEqual(state.sslUnsupportedReceived(),
                        .closeConnectionAndCleanup(.init(action: .close, tasks: [], error: PSQLError.sslUnsupported, closePromise: nil)))
+    }
+
+    func testTLSPreferredStartupSSLUnsupported() {
+        var state = ConnectionStateMachine()
+
+        XCTAssertEqual(state.connected(tls: .prefer), .sendSSLRequest)
+        XCTAssertEqual(state.sslUnsupportedReceived(), .provideAuthenticationContext)
     }
         
     func testParameterStatusReceivedAndBackendKeyAfterAuthenticated() {
@@ -133,7 +140,7 @@ class ConnectionStateMachineTests: XCTestCase {
             promise: queryPromise)
 
         XCTAssertEqual(state.enqueue(task: .extendedQuery(extendedQueryContext)), .wait)
-        XCTAssertEqual(state.connected(requireTLS: false), .provideAuthenticationContext)
+        XCTAssertEqual(state.connected(tls: .disable), .provideAuthenticationContext)
         XCTAssertEqual(state.provideAuthenticationContext(authContext), .sendStartupMessage(authContext))
         XCTAssertEqual(state.authenticationMessageReceived(.md5(salt: salt)), .sendPasswordMessage(.md5(salt: salt), authContext))
         let fields: [PSQLBackendMessage.Field: String] = [

--- a/Tests/PostgresNIOTests/New/Extensions/ConnectionAction+TestUtils.swift
+++ b/Tests/PostgresNIOTests/New/Extensions/ConnectionAction+TestUtils.swift
@@ -91,7 +91,8 @@ extension ConnectionStateMachine {
             processID: 2730,
             secretKey: 882037977,
             parameters: paramaters,
-            transactionState: transactionState)
+            transactionState: transactionState
+        )
     }
 }
 

--- a/Tests/PostgresNIOTests/New/PSQLChannelHandlerTests.swift
+++ b/Tests/PostgresNIOTests/New/PSQLChannelHandlerTests.swift
@@ -38,7 +38,7 @@ class PSQLChannelHandlerTests: XCTestCase {
     
     func testEstablishSSLCallbackIsCalledIfSSLIsSupported() {
         var config = self.testConnectionConfiguration()
-        config.tlsConfiguration = .makeClientConfiguration()
+        XCTAssertNoThrow(config.tls = .require(try NIOSSLContext(configuration: .makeClientConfiguration())))
         var addSSLCallbackIsHit = false
         let handler = PSQLChannelHandler(configuration: config) { channel in
             addSSLCallbackIsHit = true
@@ -80,7 +80,7 @@ class PSQLChannelHandlerTests: XCTestCase {
     
     func testSSLUnsupportedClosesConnection() {
         var config = self.testConnectionConfiguration()
-        config.tlsConfiguration = .makeClientConfiguration()
+        XCTAssertNoThrow(config.tls = .require(try NIOSSLContext(configuration: .makeClientConfiguration())))
         
         let handler = PSQLChannelHandler(configuration: config) { channel in
             XCTFail("This callback should never be exectuded")
@@ -173,7 +173,7 @@ class PSQLChannelHandlerTests: XCTestCase {
         username: String = "test",
         database: String = "postgres",
         password: String = "password",
-        tlsConfiguration: TLSConfiguration? = nil
+        tls: PSQLConnection.Configuration.TLS = .disable
     ) -> PSQLConnection.Configuration {
         PSQLConnection.Configuration(
             host: host,
@@ -181,7 +181,7 @@ class PSQLChannelHandlerTests: XCTestCase {
             username: username,
             database: database,
             password: password,
-            tlsConfiguration: tlsConfiguration
+            tls: tls
         )
     }
 }

--- a/Tests/PostgresNIOTests/New/PSQLConnectionTests.swift
+++ b/Tests/PostgresNIOTests/New/PSQLConnectionTests.swift
@@ -27,7 +27,8 @@ class PSQLConnectionTests: XCTestCase {
             username: "postgres",
             database: "postgres",
             password: "abc123",
-            tlsConfiguration: nil)
+            tls: .disable
+        )
         
         var logger = Logger.psqlTest
         logger.logLevel = .trace


### PR DESCRIPTION
### Motivation

Currently users provide a TLSConfiguration to the PSQLConnection.Configuration to signal they want to require TLS. This is very implicit and it will create a new `NIOSSLContext` for every new connection (VERY, VERY expensive operation).

### Changes

- Make TLS config explicit in `PSQLConnection.Configuration`. The initial provided values are `.disable`, `.prefer`, `.require`
- If users use `.prefer` or `.require` they must provide a NIOSSLContext

### Result

- Faster more explicit code