### PR TITLE
Cleanup PostgresDecodable

### DIFF
--- a/Sources/PostgresNIO/New/Data/Array+PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/Data/Array+PostgresCodable.swift
@@ -104,12 +104,12 @@ extension Array: PostgresEncodable where Element: PSQLArrayElement {
 }
 
 extension Array: PostgresDecodable where Element: PSQLArrayElement {
-    static func decode<JSONDecoder: PostgresJSONDecoder>(
+    init<JSONDecoder: PostgresJSONDecoder>(
         from buffer: inout ByteBuffer,
         type: PostgresDataType,
         format: PostgresFormat,
         context: PostgresDecodingContext<JSONDecoder>
-    ) throws -> Array<Element> {
+    ) throws {
         guard case .binary = format else {
             // currently we only support decoding arrays in binary format.
             throw PostgresCastingError.Code.failure
@@ -124,7 +124,8 @@ extension Array: PostgresDecodable where Element: PSQLArrayElement {
         let elementType = PostgresDataType(element)
         
         guard isNotEmpty == 1 else {
-            return []
+            self = []
+            return
         }
         
         guard let (expectedArrayCount, dimensions) = buffer.readMultipleIntegers(endianness: .big, as: (Int32, Int32).self),
@@ -146,12 +147,12 @@ extension Array: PostgresDecodable where Element: PSQLArrayElement {
                 throw PostgresCastingError.Code.failure
             }
             
-            let element = try Element.decode(from: &elementBuffer, type: elementType, format: format, context: context)
+            let element = try Element.init(from: &elementBuffer, type: elementType, format: format, context: context)
             
             result.append(element)
         }
         
-        return result
+        self = result
     }
 }
 

--- a/Sources/PostgresNIO/New/Data/Bytes+PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/Data/Bytes+PostgresCodable.swift
@@ -19,7 +19,7 @@ extension PostgresEncodable where Self: Sequence, Self.Element == UInt8 {
     }
 }
 
-extension ByteBuffer: PostgresCodable {
+extension ByteBuffer: PostgresEncodable {
     var psqlType: PostgresDataType {
         .bytea
     }
@@ -35,18 +35,22 @@ extension ByteBuffer: PostgresCodable {
         var copyOfSelf = self // dirty hack
         byteBuffer.writeBuffer(&copyOfSelf)
     }
+}
 
-    static func decode<JSONDecoder: PostgresJSONDecoder>(
+extension ByteBuffer: PostgresDecodable {
+    init<JSONDecoder: PostgresJSONDecoder>(
         from buffer: inout ByteBuffer,
         type: PostgresDataType,
         format: PostgresFormat,
         context: PostgresDecodingContext<JSONDecoder>
-    ) throws -> Self {
-        return buffer
+    ) {
+        self = buffer
     }
 }
 
-extension Data: PostgresCodable {
+extension ByteBuffer: PostgresCodable {}
+
+extension Data: PostgresEncodable {
     var psqlType: PostgresDataType {
         .bytea
     }
@@ -61,13 +65,17 @@ extension Data: PostgresCodable {
     ) {
         byteBuffer.writeBytes(self)
     }
+}
 
-    static func decode<JSONDecoder: PostgresJSONDecoder>(
+extension Data: PostgresDecodable {
+    init<JSONDecoder: PostgresJSONDecoder>(
         from buffer: inout ByteBuffer,
         type: PostgresDataType,
         format: PostgresFormat,
         context: PostgresDecodingContext<JSONDecoder>
-    ) throws -> Self {
-        return buffer.readData(length: buffer.readableBytes, byteTransferStrategy: .automatic)!
+    ) {
+        self = buffer.readData(length: buffer.readableBytes, byteTransferStrategy: .automatic)!
     }
 }
+
+extension Data: PostgresCodable {}

--- a/Sources/PostgresNIO/New/Data/Float+PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/Data/Float+PostgresCodable.swift
@@ -1,39 +1,12 @@
 import NIOCore
 
-extension Float: PostgresCodable {
+extension Float: PostgresEncodable {
     var psqlType: PostgresDataType {
         .float4
     }
     
     var psqlFormat: PostgresFormat {
         .binary
-    }
-    
-    static func decode<JSONDecoder: PostgresJSONDecoder>(
-        from buffer: inout ByteBuffer,
-        type: PostgresDataType,
-        format: PostgresFormat,
-        context: PostgresDecodingContext<JSONDecoder>
-    ) throws -> Self {
-        switch (format, type) {
-        case (.binary, .float4):
-            guard buffer.readableBytes == 4, let float = buffer.psqlReadFloat() else {
-                throw PostgresCastingError.Code.failure
-            }
-            return float
-        case (.binary, .float8):
-            guard buffer.readableBytes == 8, let double = buffer.psqlReadDouble() else {
-                throw PostgresCastingError.Code.failure
-            }
-            return Float(double)
-        case (.text, .float4), (.text, .float8):
-            guard let string = buffer.readString(length: buffer.readableBytes), let value = Float(string) else {
-                throw PostgresCastingError.Code.failure
-            }
-            return value
-        default:
-            throw PostgresCastingError.Code.typeMismatch
-        }
     }
     
     func encode<JSONEncoder: PostgresJSONEncoder>(
@@ -44,40 +17,44 @@ extension Float: PostgresCodable {
     }
 }
 
-extension Double: PostgresCodable {
+extension Float: PostgresDecodable {
+    init<JSONDecoder: PostgresJSONDecoder>(
+        from buffer: inout ByteBuffer,
+        type: PostgresDataType,
+        format: PostgresFormat,
+        context: PostgresDecodingContext<JSONDecoder>
+    ) throws {
+        switch (format, type) {
+        case (.binary, .float4):
+            guard buffer.readableBytes == 4, let float = buffer.psqlReadFloat() else {
+                throw PostgresCastingError.Code.failure
+            }
+            self = float
+        case (.binary, .float8):
+            guard buffer.readableBytes == 8, let double = buffer.psqlReadDouble() else {
+                throw PostgresCastingError.Code.failure
+            }
+            self = Float(double)
+        case (.text, .float4), (.text, .float8):
+            guard let string = buffer.readString(length: buffer.readableBytes), let value = Float(string) else {
+                throw PostgresCastingError.Code.failure
+            }
+            self = value
+        default:
+            throw PostgresCastingError.Code.typeMismatch
+        }
+    }
+}
+
+extension Float: PostgresCodable {}
+
+extension Double: PostgresEncodable {
     var psqlType: PostgresDataType {
         .float8
     }
     
     var psqlFormat: PostgresFormat {
         .binary
-    }
-    
-    static func decode<JSONDecoder: PostgresJSONDecoder>(
-        from buffer: inout ByteBuffer,
-        type: PostgresDataType,
-        format: PostgresFormat,
-        context: PostgresDecodingContext<JSONDecoder>
-    ) throws -> Self {
-        switch (format, type) {
-        case (.binary, .float4):
-            guard buffer.readableBytes == 4, let float = buffer.psqlReadFloat() else {
-                throw PostgresCastingError.Code.failure
-            }
-            return Double(float)
-        case (.binary, .float8):
-            guard buffer.readableBytes == 8, let double = buffer.psqlReadDouble() else {
-                throw PostgresCastingError.Code.failure
-            }
-            return double
-        case (.text, .float4), (.text, .float8):
-            guard let string = buffer.readString(length: buffer.readableBytes), let value = Double(string) else {
-                throw PostgresCastingError.Code.failure
-            }
-            return value
-        default:
-            throw PostgresCastingError.Code.typeMismatch
-        }
     }
     
     func encode<JSONEncoder: PostgresJSONEncoder>(
@@ -88,3 +65,33 @@ extension Double: PostgresCodable {
     }
 }
 
+extension Double: PostgresDecodable {
+    init<JSONDecoder: PostgresJSONDecoder>(
+        from buffer: inout ByteBuffer,
+        type: PostgresDataType,
+        format: PostgresFormat,
+        context: PostgresDecodingContext<JSONDecoder>
+    ) throws {
+        switch (format, type) {
+        case (.binary, .float4):
+            guard buffer.readableBytes == 4, let float = buffer.psqlReadFloat() else {
+                throw PostgresCastingError.Code.failure
+            }
+            self = Double(float)
+        case (.binary, .float8):
+            guard buffer.readableBytes == 8, let double = buffer.psqlReadDouble() else {
+                throw PostgresCastingError.Code.failure
+            }
+            self = double
+        case (.text, .float4), (.text, .float8):
+            guard let string = buffer.readString(length: buffer.readableBytes), let value = Double(string) else {
+                throw PostgresCastingError.Code.failure
+            }
+            self = value
+        default:
+            throw PostgresCastingError.Code.typeMismatch
+        }
+    }
+}
+
+extension Double: PostgresCodable {}

--- a/Sources/PostgresNIO/New/Data/Int+PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/Data/Int+PostgresCodable.swift
@@ -1,30 +1,14 @@
 import NIOCore
 
-extension UInt8: PostgresCodable {
+// MARK: UInt8
+
+extension UInt8: PostgresEncodable {
     var psqlType: PostgresDataType {
         .char
     }
 
     var psqlFormat: PostgresFormat {
         .binary
-    }
-
-    static func decode<JSONDecoder: PostgresJSONDecoder>(
-        from buffer: inout ByteBuffer,
-        type: PostgresDataType,
-        format: PostgresFormat,
-        context: PostgresDecodingContext<JSONDecoder>
-    ) throws -> Self {
-        switch type {
-        case .bpchar, .char:
-            guard buffer.readableBytes == 1, let value = buffer.readInteger(as: UInt8.self) else {
-                throw PostgresCastingError.Code.failure
-            }
-            
-            return value
-        default:
-            throw PostgresCastingError.Code.typeMismatch
-        }
     }
 
     func encode<JSONEncoder: PostgresJSONEncoder>(
@@ -35,7 +19,31 @@ extension UInt8: PostgresCodable {
     }
 }
 
-extension Int16: PostgresCodable {
+extension UInt8: PostgresDecodable {
+    init<JSONDecoder: PostgresJSONDecoder>(
+        from buffer: inout ByteBuffer,
+        type: PostgresDataType,
+        format: PostgresFormat,
+        context: PostgresDecodingContext<JSONDecoder>
+    ) throws {
+        switch type {
+        case .bpchar, .char:
+            guard buffer.readableBytes == 1, let value = buffer.readInteger(as: UInt8.self) else {
+                throw PostgresCastingError.Code.failure
+            }
+
+            self = value
+        default:
+            throw PostgresCastingError.Code.typeMismatch
+        }
+    }
+}
+
+extension UInt8: PostgresCodable {}
+
+// MARK: Int16
+
+extension Int16: PostgresEncodable {
     
     var psqlType: PostgresDataType {
         .int2
@@ -43,28 +51,6 @@ extension Int16: PostgresCodable {
 
     var psqlFormat: PostgresFormat {
         .binary
-    }
-
-    static func decode<JSONDecoder: PostgresJSONDecoder>(
-        from buffer: inout ByteBuffer,
-        type: PostgresDataType,
-        format: PostgresFormat,
-        context: PostgresDecodingContext<JSONDecoder>
-    ) throws -> Self {
-        switch (format, type) {
-        case (.binary, .int2):
-            guard buffer.readableBytes == 2, let value = buffer.readInteger(as: Int16.self) else {
-                throw PostgresCastingError.Code.failure
-            }
-            return value
-        case (.text, .int2):
-            guard let string = buffer.readString(length: buffer.readableBytes), let value = Int16(string) else {
-                throw PostgresCastingError.Code.failure
-            }
-            return value
-        default:
-            throw PostgresCastingError.Code.typeMismatch
-        }
     }
 
     func encode<JSONEncoder: PostgresJSONEncoder>(
@@ -75,40 +61,41 @@ extension Int16: PostgresCodable {
     }
 }
 
-extension Int32: PostgresCodable {
+extension Int16: PostgresDecodable {
+    init<JSONDecoder: PostgresJSONDecoder>(
+        from buffer: inout ByteBuffer,
+        type: PostgresDataType,
+        format: PostgresFormat,
+        context: PostgresDecodingContext<JSONDecoder>
+    ) throws {
+        switch (format, type) {
+        case (.binary, .int2):
+            guard buffer.readableBytes == 2, let value = buffer.readInteger(as: Int16.self) else {
+                throw PostgresCastingError.Code.failure
+            }
+            self = value
+        case (.text, .int2):
+            guard let string = buffer.readString(length: buffer.readableBytes), let value = Int16(string) else {
+                throw PostgresCastingError.Code.failure
+            }
+            self = value
+        default:
+            throw PostgresCastingError.Code.typeMismatch
+        }
+    }
+}
+
+extension Int16: PostgresCodable {}
+
+// MARK: Int32
+
+extension Int32: PostgresEncodable {
     var psqlType: PostgresDataType {
         .int4
     }
     
     var psqlFormat: PostgresFormat {
         .binary
-    }
-
-    static func decode<JSONDecoder: PostgresJSONDecoder>(
-        from buffer: inout ByteBuffer,
-        type: PostgresDataType,
-        format: PostgresFormat,
-        context: PostgresDecodingContext<JSONDecoder>
-    ) throws -> Self {
-        switch (format, type) {
-        case (.binary, .int2):
-            guard buffer.readableBytes == 2, let value = buffer.readInteger(as: Int16.self) else {
-                throw PostgresCastingError.Code.failure
-            }
-            return Int32(value)
-        case (.binary, .int4):
-            guard buffer.readableBytes == 4, let value = buffer.readInteger(as: Int32.self) else {
-                throw PostgresCastingError.Code.failure
-            }
-            return Int32(value)
-        case (.text, .int2), (.text, .int4):
-            guard let string = buffer.readString(length: buffer.readableBytes), let value = Int32(string) else {
-                throw PostgresCastingError.Code.failure
-            }
-            return value
-        default:
-            throw PostgresCastingError.Code.typeMismatch
-        }
     }
 
     func encode<JSONEncoder: PostgresJSONEncoder>(
@@ -119,45 +106,46 @@ extension Int32: PostgresCodable {
     }
 }
 
-extension Int64: PostgresCodable {
+extension Int32: PostgresDecodable {
+    init<JSONDecoder: PostgresJSONDecoder>(
+        from buffer: inout ByteBuffer,
+        type: PostgresDataType,
+        format: PostgresFormat,
+        context: PostgresDecodingContext<JSONDecoder>
+    ) throws {
+        switch (format, type) {
+        case (.binary, .int2):
+            guard buffer.readableBytes == 2, let value = buffer.readInteger(as: Int16.self) else {
+                throw PostgresCastingError.Code.failure
+            }
+            self = Int32(value)
+        case (.binary, .int4):
+            guard buffer.readableBytes == 4, let value = buffer.readInteger(as: Int32.self) else {
+                throw PostgresCastingError.Code.failure
+            }
+            self = Int32(value)
+        case (.text, .int2), (.text, .int4):
+            guard let string = buffer.readString(length: buffer.readableBytes), let value = Int32(string) else {
+                throw PostgresCastingError.Code.failure
+            }
+            self = value
+        default:
+            throw PostgresCastingError.Code.typeMismatch
+        }
+    }
+}
+
+extension Int32: PostgresCodable {}
+
+// MARK: Int64
+
+extension Int64: PostgresEncodable {
     var psqlType: PostgresDataType {
         .int8
     }
 
     var psqlFormat: PostgresFormat {
         .binary
-    }
-
-    static func decode<JSONDecoder: PostgresJSONDecoder>(
-        from buffer: inout ByteBuffer,
-        type: PostgresDataType,
-        format: PostgresFormat,
-        context: PostgresDecodingContext<JSONDecoder>
-    ) throws -> Self {
-        switch (format, type) {
-        case (.binary, .int2):
-            guard buffer.readableBytes == 2, let value = buffer.readInteger(as: Int16.self) else {
-                throw PostgresCastingError.Code.failure
-            }
-            return Int64(value)
-        case (.binary, .int4):
-            guard buffer.readableBytes == 4, let value = buffer.readInteger(as: Int32.self) else {
-                throw PostgresCastingError.Code.failure
-            }
-            return Int64(value)
-        case (.binary, .int8):
-            guard buffer.readableBytes == 8, let value = buffer.readInteger(as: Int64.self) else {
-                throw PostgresCastingError.Code.failure
-            }
-            return value
-        case (.text, .int2), (.text, .int4), (.text, .int8):
-            guard let string = buffer.readString(length: buffer.readableBytes), let value = Int64(string) else {
-                throw PostgresCastingError.Code.failure
-            }
-            return value
-        default:
-            throw PostgresCastingError.Code.typeMismatch
-        }
     }
 
     func encode<JSONEncoder: PostgresJSONEncoder>(
@@ -168,7 +156,45 @@ extension Int64: PostgresCodable {
     }
 }
 
-extension Int: PostgresCodable {
+extension Int64: PostgresDecodable {
+    init<JSONDecoder: PostgresJSONDecoder>(
+        from buffer: inout ByteBuffer,
+        type: PostgresDataType,
+        format: PostgresFormat,
+        context: PostgresDecodingContext<JSONDecoder>
+    ) throws {
+        switch (format, type) {
+        case (.binary, .int2):
+            guard buffer.readableBytes == 2, let value = buffer.readInteger(as: Int16.self) else {
+                throw PostgresCastingError.Code.failure
+            }
+            self = Int64(value)
+        case (.binary, .int4):
+            guard buffer.readableBytes == 4, let value = buffer.readInteger(as: Int32.self) else {
+                throw PostgresCastingError.Code.failure
+            }
+            self = Int64(value)
+        case (.binary, .int8):
+            guard buffer.readableBytes == 8, let value = buffer.readInteger(as: Int64.self) else {
+                throw PostgresCastingError.Code.failure
+            }
+            self = value
+        case (.text, .int2), (.text, .int4), (.text, .int8):
+            guard let string = buffer.readString(length: buffer.readableBytes), let value = Int64(string) else {
+                throw PostgresCastingError.Code.failure
+            }
+            self = value
+        default:
+            throw PostgresCastingError.Code.typeMismatch
+        }
+    }
+}
+
+extension Int64: PostgresCodable {}
+
+// MARK: Int
+
+extension Int: PostgresEncodable {
     var psqlType: PostgresDataType {
         switch self.bitWidth {
         case Int32.bitWidth:
@@ -184,38 +210,6 @@ extension Int: PostgresCodable {
         .binary
     }
 
-    static func decode<JSONDecoder: PostgresJSONDecoder>(
-        from buffer: inout ByteBuffer,
-        type: PostgresDataType,
-        format: PostgresFormat,
-        context: PostgresDecodingContext<JSONDecoder>
-    ) throws -> Self {
-        switch (format, type) {
-        case (.binary, .int2):
-            guard buffer.readableBytes == 2, let value = buffer.readInteger(as: Int16.self) else {
-                throw PostgresCastingError.Code.failure
-            }
-            return Int(value)
-        case (.binary, .int4):
-            guard buffer.readableBytes == 4, let value = buffer.readInteger(as: Int32.self) else {
-                throw PostgresCastingError.Code.failure
-            }
-            return Int(value)
-        case (.binary, .int8) where Int.bitWidth == 64:
-            guard buffer.readableBytes == 8, let value = buffer.readInteger(as: Int.self) else {
-                throw PostgresCastingError.Code.failure
-            }
-            return value
-        case (.text, .int2), (.text, .int4), (.text, .int8):
-            guard let string = buffer.readString(length: buffer.readableBytes), let value = Int(string) else {
-                throw PostgresCastingError.Code.failure
-            }
-            return value
-        default:
-            throw PostgresCastingError.Code.typeMismatch
-        }
-    }
-
     func encode<JSONEncoder: PostgresJSONEncoder>(
         into byteBuffer: inout ByteBuffer,
         context: PostgresEncodingContext<JSONEncoder>
@@ -223,3 +217,39 @@ extension Int: PostgresCodable {
         byteBuffer.writeInteger(self, as: Int.self)
     }
 }
+
+extension Int: PostgresDecodable {
+    init<JSONDecoder: PostgresJSONDecoder>(
+        from buffer: inout ByteBuffer,
+        type: PostgresDataType,
+        format: PostgresFormat,
+        context: PostgresDecodingContext<JSONDecoder>
+    ) throws {
+        switch (format, type) {
+        case (.binary, .int2):
+            guard buffer.readableBytes == 2, let value = buffer.readInteger(as: Int16.self) else {
+                throw PostgresCastingError.Code.failure
+            }
+            self = Int(value)
+        case (.binary, .int4):
+            guard buffer.readableBytes == 4, let value = buffer.readInteger(as: Int32.self) else {
+                throw PostgresCastingError.Code.failure
+            }
+            self = Int(value)
+        case (.binary, .int8) where Int.bitWidth == 64:
+            guard buffer.readableBytes == 8, let value = buffer.readInteger(as: Int.self) else {
+                throw PostgresCastingError.Code.failure
+            }
+            self = value
+        case (.text, .int2), (.text, .int4), (.text, .int8):
+            guard let string = buffer.readString(length: buffer.readableBytes), let value = Int(string) else {
+                throw PostgresCastingError.Code.failure
+            }
+            self = value
+        default:
+            throw PostgresCastingError.Code.typeMismatch
+        }
+    }
+}
+
+extension Int: PostgresCodable {}

--- a/Sources/PostgresNIO/New/Data/JSON+PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/Data/JSON+PostgresCodable.swift
@@ -5,32 +5,13 @@ import class Foundation.JSONDecoder
 
 private let JSONBVersionByte: UInt8 = 0x01
 
-extension PostgresCodable where Self: Codable {
+extension PostgresEncodable where Self: Codable {
     var psqlType: PostgresDataType {
         .jsonb
     }
     
     var psqlFormat: PostgresFormat {
         .binary
-    }
-    
-    static func decode<JSONDecoder: PostgresJSONDecoder>(
-        from buffer: inout ByteBuffer,
-        type: PostgresDataType,
-        format: PostgresFormat,
-        context: PostgresDecodingContext<JSONDecoder>
-    ) throws -> Self {
-        switch (format, type) {
-        case (.binary, .jsonb):
-            guard JSONBVersionByte == buffer.readInteger(as: UInt8.self) else {
-                throw PostgresCastingError.Code.failure
-            }
-            return try context.jsonDecoder.decode(Self.self, from: buffer)
-        case (.binary, .json), (.text, .jsonb), (.text, .json):
-            return try context.jsonDecoder.decode(Self.self, from: buffer)
-        default:
-            throw PostgresCastingError.Code.typeMismatch
-        }
     }
     
     func encode<JSONEncoder: PostgresJSONEncoder>(
@@ -41,3 +22,26 @@ extension PostgresCodable where Self: Codable {
         try context.jsonEncoder.encode(self, into: &byteBuffer)
     }
 }
+
+extension PostgresDecodable where Self: Codable {
+    init<JSONDecoder: PostgresJSONDecoder>(
+        from buffer: inout ByteBuffer,
+        type: PostgresDataType,
+        format: PostgresFormat,
+        context: PostgresDecodingContext<JSONDecoder>
+    ) throws {
+        switch (format, type) {
+        case (.binary, .jsonb):
+            guard JSONBVersionByte == buffer.readInteger(as: UInt8.self) else {
+                throw PostgresCastingError.Code.failure
+            }
+            self = try context.jsonDecoder.decode(Self.self, from: buffer)
+        case (.binary, .json), (.text, .jsonb), (.text, .json):
+            self = try context.jsonDecoder.decode(Self.self, from: buffer)
+        default:
+            throw PostgresCastingError.Code.typeMismatch
+        }
+    }
+}
+
+extension PostgresCodable where Self: Codable {}

--- a/Sources/PostgresNIO/New/Data/RawRepresentable+PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/Data/RawRepresentable+PostgresCodable.swift
@@ -1,26 +1,12 @@
 import NIOCore
 
-extension PostgresCodable where Self: RawRepresentable, RawValue: PostgresCodable {
+extension PostgresEncodable where Self: RawRepresentable, RawValue: PostgresEncodable {
     var psqlType: PostgresDataType {
         self.rawValue.psqlType
     }
     
     var psqlFormat: PostgresFormat {
         self.rawValue.psqlFormat
-    }
-    
-    static func decode<JSONDecoder: PostgresJSONDecoder>(
-        from buffer: inout ByteBuffer,
-        type: PostgresDataType,
-        format: PostgresFormat,
-        context: PostgresDecodingContext<JSONDecoder>
-    ) throws -> Self {
-        guard let rawValue = try? RawValue.decode(from: &buffer, type: type, format: format, context: context),
-              let selfValue = Self.init(rawValue: rawValue) else {
-            throw PostgresCastingError.Code.failure
-        }
-        
-        return selfValue
     }
     
     func encode<JSONEncoder: PostgresJSONEncoder>(
@@ -30,3 +16,21 @@ extension PostgresCodable where Self: RawRepresentable, RawValue: PostgresCodabl
         try rawValue.encode(into: &byteBuffer, context: context)
     }
 }
+
+extension PostgresDecodable where Self: RawRepresentable, RawValue: PostgresDecodable, RawValue._DecodableType == RawValue {
+    init<JSONDecoder: PostgresJSONDecoder>(
+        from buffer: inout ByteBuffer,
+        type: PostgresDataType,
+        format: PostgresFormat,
+        context: PostgresDecodingContext<JSONDecoder>
+    ) throws {
+        guard let rawValue = try? RawValue(from: &buffer, type: type, format: format, context: context),
+              let selfValue = Self.init(rawValue: rawValue) else {
+            throw PostgresCastingError.Code.failure
+        }
+
+        self = selfValue
+    }
+}
+
+extension PostgresCodable where Self: RawRepresentable, RawValue: PostgresCodable, RawValue._DecodableType == RawValue {}

--- a/Tests/PostgresNIOTests/New/Data/Array+PSQLCodableTests.swift
+++ b/Tests/PostgresNIOTests/New/Data/Array+PSQLCodableTests.swift
@@ -64,7 +64,7 @@ class Array_PSQLCodableTests: XCTestCase {
         XCTAssertNoThrow(try values.encode(into: &buffer, context: .default))
         
         var result: [String]?
-        XCTAssertNoThrow(result = try [String].decode(from: &buffer, type: .textArray, format: .binary, context: .default))
+        XCTAssertNoThrow(result = try [String](from: &buffer, type: .textArray, format: .binary, context: .default))
         XCTAssertEqual(values, result)
     }
     
@@ -75,7 +75,7 @@ class Array_PSQLCodableTests: XCTestCase {
         XCTAssertNoThrow(try values.encode(into: &buffer, context: .default))
         
         var result: [String]?
-        XCTAssertNoThrow(result = try [String].decode(from: &buffer, type: .textArray, format: .binary, context: .default))
+        XCTAssertNoThrow(result = try [String](from: &buffer, type: .textArray, format: .binary, context: .default))
         XCTAssertEqual(values, result)
     }
     
@@ -85,7 +85,7 @@ class Array_PSQLCodableTests: XCTestCase {
         buffer.writeInteger(Int32(0))
         buffer.writeInteger(String.psqlArrayElementType.rawValue)
         
-        XCTAssertThrowsError(try [String].decode(from: &buffer, type: .textArray, format: .binary, context: .default)) {
+        XCTAssertThrowsError(try [String](from: &buffer, type: .textArray, format: .binary, context: .default)) {
             XCTAssertEqual($0 as? PostgresCastingError.Code, .failure)
         }
     }
@@ -96,7 +96,7 @@ class Array_PSQLCodableTests: XCTestCase {
         buffer.writeInteger(Int32(1)) // invalid value, must always be 0
         buffer.writeInteger(String.psqlArrayElementType.rawValue)
         
-        XCTAssertThrowsError(try [String].decode(from: &buffer, type: .textArray, format: .binary, context: .default)) {
+        XCTAssertThrowsError(try [String](from: &buffer, type: .textArray, format: .binary, context: .default)) {
             XCTAssertEqual($0 as? PostgresCastingError.Code, .failure)
         }
     }
@@ -106,7 +106,7 @@ class Array_PSQLCodableTests: XCTestCase {
         var buffer = ByteBuffer()
         value.encode(into: &buffer, context: .default)
 
-        XCTAssertThrowsError(try [String].decode(from: &buffer, type: .textArray, format: .binary, context: .default)) {
+        XCTAssertThrowsError(try [String](from: &buffer, type: .textArray, format: .binary, context: .default)) {
             XCTAssertEqual($0 as? PostgresCastingError.Code, .failure)
         }
     }
@@ -119,7 +119,7 @@ class Array_PSQLCodableTests: XCTestCase {
         buffer.writeInteger(Int32(-123)) // expected element count
         buffer.writeInteger(Int32(1)) // dimensions... must be one
 
-        XCTAssertThrowsError(try [String].decode(from: &buffer, type: .textArray, format: .binary, context: .default)) {
+        XCTAssertThrowsError(try [String](from: &buffer, type: .textArray, format: .binary, context: .default)) {
             XCTAssertEqual($0 as? PostgresCastingError.Code, .failure)
         }
     }
@@ -132,7 +132,7 @@ class Array_PSQLCodableTests: XCTestCase {
         buffer.writeInteger(Int32(1)) // expected element count
         buffer.writeInteger(Int32(2)) // dimensions... must be one
         
-        XCTAssertThrowsError(try [String].decode(from: &buffer, type: .textArray, format: .binary, context: .default)) {
+        XCTAssertThrowsError(try [String](from: &buffer, type: .textArray, format: .binary, context: .default)) {
             XCTAssertEqual($0 as? PostgresCastingError.Code, .failure)
         }
     }
@@ -146,7 +146,7 @@ class Array_PSQLCodableTests: XCTestCase {
         unexpectedEndInElementLengthBuffer.writeInteger(Int32(1)) // dimensions
         unexpectedEndInElementLengthBuffer.writeInteger(Int16(1)) // length of element, must be Int32
         
-        XCTAssertThrowsError(try [String].decode(from: &unexpectedEndInElementLengthBuffer, type: .textArray, format: .binary, context: .default)) {
+        XCTAssertThrowsError(try [String](from: &unexpectedEndInElementLengthBuffer, type: .textArray, format: .binary, context: .default)) {
             XCTAssertEqual($0 as? PostgresCastingError.Code, .failure)
         }
         
@@ -159,7 +159,7 @@ class Array_PSQLCodableTests: XCTestCase {
         unexpectedEndInElementBuffer.writeInteger(Int32(12)) // length of element, must be Int32
         unexpectedEndInElementBuffer.writeString("Hello World") // only 11 bytes, 12 needed!
         
-        XCTAssertThrowsError(try [String].decode(from: &unexpectedEndInElementBuffer, type: .textArray, format: .binary, context: .default)) {
+        XCTAssertThrowsError(try [String](from: &unexpectedEndInElementBuffer, type: .textArray, format: .binary, context: .default)) {
             XCTAssertEqual($0 as? PostgresCastingError.Code, .failure)
         }
     }

--- a/Tests/PostgresNIOTests/New/Data/Bool+PSQLCodableTests.swift
+++ b/Tests/PostgresNIOTests/New/Data/Bool+PSQLCodableTests.swift
@@ -17,7 +17,7 @@ class Bool_PSQLCodableTests: XCTestCase {
         XCTAssertEqual(buffer.getInteger(at: buffer.readerIndex, as: UInt8.self), 1)
         
         var result: Bool?
-        XCTAssertNoThrow(result = try Bool.decode(from: &buffer, type: .bool, format: .binary, context: .default))
+        XCTAssertNoThrow(result = try Bool(from: &buffer, type: .bool, format: .binary, context: .default))
         XCTAssertEqual(value, result)
     }
     
@@ -32,7 +32,7 @@ class Bool_PSQLCodableTests: XCTestCase {
         XCTAssertEqual(buffer.getInteger(at: buffer.readerIndex, as: UInt8.self), 0)
 
         var result: Bool?
-        XCTAssertNoThrow(result = try Bool.decode(from: &buffer, type: .bool, format: .binary, context: .default))
+        XCTAssertNoThrow(result = try Bool(from: &buffer, type: .bool, format: .binary, context: .default))
         XCTAssertEqual(value, result)
     }
     
@@ -40,7 +40,7 @@ class Bool_PSQLCodableTests: XCTestCase {
         var buffer = ByteBuffer()
         buffer.writeInteger(Int64(1))
 
-        XCTAssertThrowsError(try Bool.decode(from: &buffer, type: .bool, format: .binary, context: .default)) {
+        XCTAssertThrowsError(try Bool(from: &buffer, type: .bool, format: .binary, context: .default)) {
             XCTAssertEqual($0 as? PostgresCastingError.Code, .failure)
         }
     }
@@ -49,7 +49,7 @@ class Bool_PSQLCodableTests: XCTestCase {
         var buffer = ByteBuffer()
         buffer.writeInteger(UInt8(13))
 
-        XCTAssertThrowsError(try Bool.decode(from: &buffer, type: .bool, format: .binary, context: .default)) {
+        XCTAssertThrowsError(try Bool(from: &buffer, type: .bool, format: .binary, context: .default)) {
             XCTAssertEqual($0 as? PostgresCastingError.Code, .failure)
         }
     }
@@ -63,7 +63,7 @@ class Bool_PSQLCodableTests: XCTestCase {
         buffer.writeInteger(UInt8(ascii: "t"))
 
         var result: Bool?
-        XCTAssertNoThrow(result = try Bool.decode(from: &buffer, type: .bool, format: .text, context: .default))
+        XCTAssertNoThrow(result = try Bool(from: &buffer, type: .bool, format: .text, context: .default))
         XCTAssertEqual(value, result)
     }
     
@@ -74,7 +74,7 @@ class Bool_PSQLCodableTests: XCTestCase {
         buffer.writeInteger(UInt8(ascii: "f"))
 
         var result: Bool?
-        XCTAssertNoThrow(result = try Bool.decode(from: &buffer, type: .bool, format: .text, context: .default))
+        XCTAssertNoThrow(result = try Bool(from: &buffer, type: .bool, format: .text, context: .default))
         XCTAssertEqual(value, result)
     }
     
@@ -82,7 +82,7 @@ class Bool_PSQLCodableTests: XCTestCase {
         var buffer = ByteBuffer()
         buffer.writeInteger(UInt8(13))
 
-        XCTAssertThrowsError(try Bool.decode(from: &buffer, type: .bool, format: .text, context: .default)) {
+        XCTAssertThrowsError(try Bool(from: &buffer, type: .bool, format: .text, context: .default)) {
             XCTAssertEqual($0 as? PostgresCastingError.Code, .failure)
         }
     }

--- a/Tests/PostgresNIOTests/New/Data/Bytes+PSQLCodableTests.swift
+++ b/Tests/PostgresNIOTests/New/Data/Bytes+PSQLCodableTests.swift
@@ -12,7 +12,7 @@ class Bytes_PSQLCodableTests: XCTestCase {
         XCTAssertEqual(data.psqlType, .bytea)
         
         var result: Data?
-        XCTAssertNoThrow(result = try Data.decode(from: &buffer, type: .bytea, format: .binary, context: .default))
+        result = Data(from: &buffer, type: .bytea, format: .binary, context: .default)
         XCTAssertEqual(data, result)
     }
     
@@ -24,7 +24,7 @@ class Bytes_PSQLCodableTests: XCTestCase {
         XCTAssertEqual(bytes.psqlType, .bytea)
         
         var result: ByteBuffer?
-        XCTAssertNoThrow(result = try ByteBuffer.decode(from: &buffer, type: .bytea, format: .binary, context: .default))
+        result = ByteBuffer(from: &buffer, type: .bytea, format: .binary, context: .default)
         XCTAssertEqual(bytes, result)
     }
     

--- a/Tests/PostgresNIOTests/New/Data/Date+PSQLCodableTests.swift
+++ b/Tests/PostgresNIOTests/New/Data/Date+PSQLCodableTests.swift
@@ -13,7 +13,7 @@ class Date_PSQLCodableTests: XCTestCase {
         XCTAssertEqual(buffer.readableBytes, 8)
 
         var result: Date?
-        XCTAssertNoThrow(result = try Date.decode(from: &buffer, type: .timestamptz, format: .binary, context: .default))
+        XCTAssertNoThrow(result = try Date(from: &buffer, type: .timestamptz, format: .binary, context: .default))
         XCTAssertEqual(value, result)
     }
     
@@ -22,7 +22,7 @@ class Date_PSQLCodableTests: XCTestCase {
         buffer.writeInteger(Int64.random(in: Int64.min...Int64.max))
 
         var result: Date?
-        XCTAssertNoThrow(result = try Date.decode(from: &buffer, type: .timestamptz, format: .binary, context: .default))
+        XCTAssertNoThrow(result = try Date(from: &buffer, type: .timestamptz, format: .binary, context: .default))
         XCTAssertNotNil(result)
     }
     
@@ -31,7 +31,7 @@ class Date_PSQLCodableTests: XCTestCase {
         buffer.writeInteger(Int64.random(in: Int64.min...Int64.max))
         buffer.writeInteger(Int64.random(in: Int64.min...Int64.max))
 
-        XCTAssertThrowsError(try Date.decode(from: &buffer, type: .timestamptz, format: .binary, context: .default)) {
+        XCTAssertThrowsError(try Date(from: &buffer, type: .timestamptz, format: .binary, context: .default)) {
             XCTAssertEqual($0 as? PostgresCastingError.Code, .failure)
         }
     }
@@ -41,14 +41,14 @@ class Date_PSQLCodableTests: XCTestCase {
         firstDateBuffer.writeInteger(Int32.min)
         
         var firstDate: Date?
-        XCTAssertNoThrow(firstDate = try Date.decode(from: &firstDateBuffer, type: .date, format: .binary, context: .default))
+        XCTAssertNoThrow(firstDate = try Date(from: &firstDateBuffer, type: .date, format: .binary, context: .default))
         XCTAssertNotNil(firstDate)
         
         var lastDateBuffer = ByteBuffer()
         lastDateBuffer.writeInteger(Int32.max)
 
         var lastDate: Date?
-        XCTAssertNoThrow(lastDate = try Date.decode(from: &lastDateBuffer, type: .date, format: .binary, context: .default))
+        XCTAssertNoThrow(lastDate = try Date(from: &lastDateBuffer, type: .date, format: .binary, context: .default))
         XCTAssertNotNil(lastDate)
     }
     
@@ -57,14 +57,14 @@ class Date_PSQLCodableTests: XCTestCase {
         firstDateBuffer.writeInteger(Int32.min)
         
         var firstDate: Date?
-        XCTAssertNoThrow(firstDate = try Date.decode(from: &firstDateBuffer, type: .date, format: .binary, context: .default))
+        XCTAssertNoThrow(firstDate = try Date(from: &firstDateBuffer, type: .date, format: .binary, context: .default))
         XCTAssertNotNil(firstDate)
         
         var lastDateBuffer = ByteBuffer()
         lastDateBuffer.writeInteger(Int32.max)
         
         var lastDate: Date?
-        XCTAssertNoThrow(lastDate = try Date.decode(from: &lastDateBuffer, type: .date, format: .binary, context: .default))
+        XCTAssertNoThrow(lastDate = try Date(from: &lastDateBuffer, type: .date, format: .binary, context: .default))
         XCTAssertNotNil(lastDate)
     }
     
@@ -72,7 +72,7 @@ class Date_PSQLCodableTests: XCTestCase {
         var buffer = ByteBuffer()
         buffer.writeInteger(Int64(0))
 
-        XCTAssertThrowsError(try Date.decode(from: &buffer, type: .date, format: .binary, context: .default)) {
+        XCTAssertThrowsError(try Date(from: &buffer, type: .date, format: .binary, context: .default)) {
             XCTAssertEqual($0 as? PostgresCastingError.Code, .failure)
         }
     }
@@ -81,7 +81,7 @@ class Date_PSQLCodableTests: XCTestCase {
         var buffer = ByteBuffer()
         buffer.writeInteger(Int64(0))
 
-        XCTAssertThrowsError(try Date.decode(from: &buffer, type: .int8, format: .binary, context: .default)) {
+        XCTAssertThrowsError(try Date(from: &buffer, type: .int8, format: .binary, context: .default)) {
             XCTAssertEqual($0 as? PostgresCastingError.Code, .typeMismatch)
         }
     }

--- a/Tests/PostgresNIOTests/New/Data/Decimal+PSQLCodableTests.swift
+++ b/Tests/PostgresNIOTests/New/Data/Decimal+PSQLCodableTests.swift
@@ -13,7 +13,7 @@ class Decimal_PSQLCodableTests: XCTestCase {
             XCTAssertEqual(value.psqlType, .numeric)
 
             var result: Decimal?
-            XCTAssertNoThrow(result = try Decimal.decode(from: &buffer, type: .numeric, format: .binary, context: .default))
+            XCTAssertNoThrow(result = try Decimal(from: &buffer, type: .numeric, format: .binary, context: .default))
             XCTAssertEqual(value, result)
         }
     }
@@ -22,7 +22,7 @@ class Decimal_PSQLCodableTests: XCTestCase {
         var buffer = ByteBuffer()
         buffer.writeInteger(Int64(0))
         
-        XCTAssertThrowsError(try Decimal.decode(from: &buffer, type: .int8, format: .binary, context: .default)) {
+        XCTAssertThrowsError(try Decimal(from: &buffer, type: .int8, format: .binary, context: .default)) {
             XCTAssertEqual($0 as? PostgresCastingError.Code, .typeMismatch)
         }
     }

--- a/Tests/PostgresNIOTests/New/Data/Float+PSQLCodableTests.swift
+++ b/Tests/PostgresNIOTests/New/Data/Float+PSQLCodableTests.swift
@@ -14,7 +14,7 @@ class Float_PSQLCodableTests: XCTestCase {
             XCTAssertEqual(buffer.readableBytes, 8)
 
             var result: Double?
-            XCTAssertNoThrow(result = try Double.decode(from: &buffer, type: .float8, format: .binary, context: .default))
+            XCTAssertNoThrow(result = try Double(from: &buffer, type: .float8, format: .binary, context: .default))
             XCTAssertEqual(value, result)
         }
     }
@@ -29,7 +29,7 @@ class Float_PSQLCodableTests: XCTestCase {
             XCTAssertEqual(buffer.readableBytes, 4)
 
             var result: Float?
-            XCTAssertNoThrow(result = try Float.decode(from: &buffer, type: .float4, format: .binary, context: .default))
+            XCTAssertNoThrow(result = try Float(from: &buffer, type: .float4, format: .binary, context: .default))
             XCTAssertEqual(value, result)
         }
     }
@@ -43,7 +43,7 @@ class Float_PSQLCodableTests: XCTestCase {
         XCTAssertEqual(buffer.readableBytes, 8)
 
         var result: Double?
-        XCTAssertNoThrow(result = try Double.decode(from: &buffer, type: .float8, format: .binary, context: .default))
+        XCTAssertNoThrow(result = try Double(from: &buffer, type: .float8, format: .binary, context: .default))
         XCTAssertEqual(result?.isNaN, true)
     }
     
@@ -56,7 +56,7 @@ class Float_PSQLCodableTests: XCTestCase {
         XCTAssertEqual(buffer.readableBytes, 8)
 
         var result: Double?
-        XCTAssertNoThrow(result = try Double.decode(from: &buffer, type: .float8, format: .binary, context: .default))
+        XCTAssertNoThrow(result = try Double(from: &buffer, type: .float8, format: .binary, context: .default))
         XCTAssertEqual(result?.isInfinite, true)
     }
     
@@ -70,7 +70,7 @@ class Float_PSQLCodableTests: XCTestCase {
             XCTAssertEqual(buffer.readableBytes, 4)
 
             var result: Double?
-            XCTAssertNoThrow(result = try Double.decode(from: &buffer, type: .float4, format: .binary, context: .default))
+            XCTAssertNoThrow(result = try Double(from: &buffer, type: .float4, format: .binary, context: .default))
             XCTAssertEqual(result, Double(value))
         }
     }
@@ -85,7 +85,7 @@ class Float_PSQLCodableTests: XCTestCase {
             XCTAssertEqual(buffer.readableBytes, 8)
 
             var result: Float?
-            XCTAssertNoThrow(result = try Float.decode(from: &buffer, type: .float8, format: .binary, context: .default))
+            XCTAssertNoThrow(result = try Float(from: &buffer, type: .float8, format: .binary, context: .default))
             XCTAssertEqual(result, Float(value))
         }
     }
@@ -97,22 +97,22 @@ class Float_PSQLCodableTests: XCTestCase {
         fourByteBuffer.writeInteger(Int32(0))
 
         var toLongBuffer1 = eightByteBuffer
-        XCTAssertThrowsError(try Double.decode(from: &toLongBuffer1, type: .float4, format: .binary, context: .default)) {
+        XCTAssertThrowsError(try Double(from: &toLongBuffer1, type: .float4, format: .binary, context: .default)) {
             XCTAssertEqual($0 as? PostgresCastingError.Code, .failure)
         }
 
         var toLongBuffer2 = eightByteBuffer
-        XCTAssertThrowsError(try Float.decode(from: &toLongBuffer2, type: .float4, format: .binary, context: .default)) {
+        XCTAssertThrowsError(try Float(from: &toLongBuffer2, type: .float4, format: .binary, context: .default)) {
             XCTAssertEqual($0 as? PostgresCastingError.Code, .failure)
         }
 
         var toShortBuffer1 = fourByteBuffer
-        XCTAssertThrowsError(try Double.decode(from: &toShortBuffer1, type: .float8, format: .binary, context: .default)) {
+        XCTAssertThrowsError(try Double(from: &toShortBuffer1, type: .float8, format: .binary, context: .default)) {
             XCTAssertEqual($0 as? PostgresCastingError.Code, .failure)
         }
 
         var toShortBuffer2 = fourByteBuffer
-        XCTAssertThrowsError(try Float.decode(from: &toShortBuffer2, type: .float8, format: .binary, context: .default)) {
+        XCTAssertThrowsError(try Float(from: &toShortBuffer2, type: .float8, format: .binary, context: .default)) {
             XCTAssertEqual($0 as? PostgresCastingError.Code, .failure)
         }
     }
@@ -122,12 +122,12 @@ class Float_PSQLCodableTests: XCTestCase {
         buffer.writeInteger(Int64(0))
 
         var copy1 = buffer
-        XCTAssertThrowsError(try Double.decode(from: &copy1, type: .int8, format: .binary, context: .default)) {
+        XCTAssertThrowsError(try Double(from: &copy1, type: .int8, format: .binary, context: .default)) {
             XCTAssertEqual($0 as? PostgresCastingError.Code, .typeMismatch)
         }
 
         var copy2 = buffer
-        XCTAssertThrowsError(try Float.decode(from: &copy2, type: .int8, format: .binary, context: .default)) {
+        XCTAssertThrowsError(try Float(from: &copy2, type: .int8, format: .binary, context: .default)) {
             XCTAssertEqual($0 as? PostgresCastingError.Code, .typeMismatch)
         }
     }

--- a/Tests/PostgresNIOTests/New/Data/JSON+PSQLCodableTests.swift
+++ b/Tests/PostgresNIOTests/New/Data/JSON+PSQLCodableTests.swift
@@ -22,7 +22,7 @@ class JSON_PSQLCodableTests: XCTestCase {
         XCTAssertEqual(buffer.getInteger(at: buffer.readerIndex, as: UInt8.self), 1)
 
         var result: Hello?
-        XCTAssertNoThrow(result = try Hello.decode(from: &buffer, type: .jsonb, format: .binary, context: .default))
+        XCTAssertNoThrow(result = try Hello(from: &buffer, type: .jsonb, format: .binary, context: .default))
         XCTAssertEqual(result, hello)
     }
     
@@ -31,7 +31,7 @@ class JSON_PSQLCodableTests: XCTestCase {
         buffer.writeString(#"{"hello":"world"}"#)
 
         var result: Hello?
-        XCTAssertNoThrow(result = try Hello.decode(from: &buffer, type: .json, format: .binary, context: .default))
+        XCTAssertNoThrow(result = try Hello(from: &buffer, type: .json, format: .binary, context: .default))
         XCTAssertEqual(result, Hello(name: "world"))
     }
     
@@ -45,7 +45,7 @@ class JSON_PSQLCodableTests: XCTestCase {
         for (format, dataType) in combinations {
             var loopBuffer = buffer
             var result: Hello?
-            XCTAssertNoThrow(result = try Hello.decode(from: &loopBuffer, type: dataType, format: format, context: .default))
+            XCTAssertNoThrow(result = try Hello(from: &loopBuffer, type: dataType, format: format, context: .default))
             XCTAssertEqual(result, Hello(name: "world"))
         }
     }
@@ -54,7 +54,7 @@ class JSON_PSQLCodableTests: XCTestCase {
         var buffer = ByteBuffer()
         buffer.writeString(#"{"hello":"world"}"#)
 
-        XCTAssertThrowsError(try Hello.decode(from: &buffer, type: .jsonb, format: .binary, context: .default)) {
+        XCTAssertThrowsError(try Hello(from: &buffer, type: .jsonb, format: .binary, context: .default)) {
             XCTAssertEqual($0 as? PostgresCastingError.Code, .failure)
         }
     }
@@ -63,7 +63,7 @@ class JSON_PSQLCodableTests: XCTestCase {
         var buffer = ByteBuffer()
         buffer.writeString(#"{"hello":"world"}"#)
 
-        XCTAssertThrowsError(try Hello.decode(from: &buffer, type: .text, format: .binary, context: .default)) {
+        XCTAssertThrowsError(try Hello(from: &buffer, type: .text, format: .binary, context: .default)) {
             XCTAssertEqual($0 as? PostgresCastingError.Code, .typeMismatch)
         }
     }

--- a/Tests/PostgresNIOTests/New/Data/RawRepresentable+PSQLCodableTests.swift
+++ b/Tests/PostgresNIOTests/New/Data/RawRepresentable+PSQLCodableTests.swift
@@ -20,7 +20,7 @@ class RawRepresentable_PSQLCodableTests: XCTestCase {
             XCTAssertEqual(buffer.readableBytes, 2)
 
             var result: MyRawRepresentable?
-            XCTAssertNoThrow(result = try MyRawRepresentable.decode(from: &buffer, type: Int16.psqlArrayElementType, format: .binary, context: .default))
+            XCTAssertNoThrow(result = try MyRawRepresentable(from: &buffer, type: Int16.psqlArrayElementType, format: .binary, context: .default))
             XCTAssertEqual(value, result)
         }
     }
@@ -29,7 +29,7 @@ class RawRepresentable_PSQLCodableTests: XCTestCase {
         var buffer = ByteBuffer()
         buffer.writeInteger(Int16(4)) // out of bounds
 
-        XCTAssertThrowsError(try MyRawRepresentable.decode(from: &buffer, type: Int16.psqlArrayElementType, format: .binary, context: .default)) {
+        XCTAssertThrowsError(try MyRawRepresentable(from: &buffer, type: Int16.psqlArrayElementType, format: .binary, context: .default)) {
             XCTAssertEqual($0 as? PostgresCastingError.Code, .failure)
         }
     }
@@ -38,7 +38,7 @@ class RawRepresentable_PSQLCodableTests: XCTestCase {
         var buffer = ByteBuffer()
         buffer.writeInteger(Int32(1)) // out of bounds
 
-        XCTAssertThrowsError(try MyRawRepresentable.decode(from: &buffer, type: Int32.psqlArrayElementType, format: .binary, context: .default)) {
+        XCTAssertThrowsError(try MyRawRepresentable(from: &buffer, type: Int32.psqlArrayElementType, format: .binary, context: .default)) {
             XCTAssertEqual($0 as? PostgresCastingError.Code, .failure)
         }
     }

--- a/Tests/PostgresNIOTests/New/Data/String+PSQLCodableTests.swift
+++ b/Tests/PostgresNIOTests/New/Data/String+PSQLCodableTests.swift
@@ -26,7 +26,7 @@ class String_PSQLCodableTests: XCTestCase {
         for dataType in dataTypes {
             var loopBuffer = buffer
             var result: String?
-            XCTAssertNoThrow(result = try String.decode(from: &loopBuffer, type: dataType, format: .binary, context: .default))
+            XCTAssertNoThrow(result = try String(from: &loopBuffer, type: dataType, format: .binary, context: .default))
             XCTAssertEqual(result, expected)
         }
     }
@@ -37,7 +37,7 @@ class String_PSQLCodableTests: XCTestCase {
         
         for dataType in dataTypes {
             var loopBuffer = buffer
-            XCTAssertThrowsError(try String.decode(from: &loopBuffer, type: dataType, format: .binary, context: .default)) {
+            XCTAssertThrowsError(try String(from: &loopBuffer, type: dataType, format: .binary, context: .default)) {
                 XCTAssertEqual($0 as? PostgresCastingError.Code, .typeMismatch)
             }
         }
@@ -49,7 +49,7 @@ class String_PSQLCodableTests: XCTestCase {
         uuid.encode(into: &buffer, context: .default)
         
         var decoded: String?
-        XCTAssertNoThrow(decoded = try String.decode(from: &buffer, type: .uuid, format: .binary, context: .default))
+        XCTAssertNoThrow(decoded = try String(from: &buffer, type: .uuid, format: .binary, context: .default))
         XCTAssertEqual(decoded, uuid.uuidString)
     }
     
@@ -60,7 +60,7 @@ class String_PSQLCodableTests: XCTestCase {
         // this makes only 15 bytes readable. this should lead to an error
         buffer.moveReaderIndex(forwardBy: 1)
         
-        XCTAssertThrowsError(try String.decode(from: &buffer, type: .uuid, format: .binary, context: .default)) {
+        XCTAssertThrowsError(try String(from: &buffer, type: .uuid, format: .binary, context: .default)) {
             XCTAssertEqual($0 as? PostgresCastingError.Code, .failure)
         }
     }

--- a/Tests/PostgresNIOTests/New/Data/UUID+PSQLCodableTests.swift
+++ b/Tests/PostgresNIOTests/New/Data/UUID+PSQLCodableTests.swift
@@ -34,7 +34,7 @@ class UUID_PSQLCodableTests: XCTestCase {
             XCTAssertEqual(byteIterator.next(), uuid.uuid.15)
             
             var decoded: UUID?
-            XCTAssertNoThrow(decoded = try UUID.decode(from: &buffer, type: .uuid, format: .binary, context: .default))
+            XCTAssertNoThrow(decoded = try UUID(from: &buffer, type: .uuid, format: .binary, context: .default))
             XCTAssertEqual(decoded, uuid)
         }
     }
@@ -57,7 +57,7 @@ class UUID_PSQLCodableTests: XCTestCase {
             for (format, dataType) in options {
                 var loopBuffer = lowercaseBuffer
                 var decoded: UUID?
-                XCTAssertNoThrow(decoded = try UUID.decode(from: &loopBuffer, type: dataType, format: format, context: .default))
+                XCTAssertNoThrow(decoded = try UUID(from: &loopBuffer, type: dataType, format: format, context: .default))
                 XCTAssertEqual(decoded, uuid)
             }
             
@@ -68,7 +68,7 @@ class UUID_PSQLCodableTests: XCTestCase {
             for (format, dataType) in options {
                 var loopBuffer = uppercaseBuffer
                 var decoded: UUID?
-                XCTAssertNoThrow(decoded = try UUID.decode(from: &loopBuffer, type: dataType, format: format, context: .default))
+                XCTAssertNoThrow(decoded = try UUID(from: &loopBuffer, type: dataType, format: format, context: .default))
                 XCTAssertEqual(decoded, uuid)
             }
         }
@@ -82,7 +82,7 @@ class UUID_PSQLCodableTests: XCTestCase {
         // this makes only 15 bytes readable. this should lead to an error
         buffer.moveReaderIndex(forwardBy: 1)
         
-        XCTAssertThrowsError(try UUID.decode(from: &buffer, type: .uuid, format: .binary, context: .default)) { error in
+        XCTAssertThrowsError(try UUID(from: &buffer, type: .uuid, format: .binary, context: .default)) { error in
             XCTAssertEqual(error as? PostgresCastingError.Code, .failure)
         }
     }
@@ -98,7 +98,7 @@ class UUID_PSQLCodableTests: XCTestCase {
         
         for dataType in dataTypes {
             var loopBuffer = buffer
-            XCTAssertThrowsError(try UUID.decode(from: &loopBuffer, type: dataType, format: .binary, context: .default)) {
+            XCTAssertThrowsError(try UUID(from: &loopBuffer, type: dataType, format: .binary, context: .default)) {
                 XCTAssertEqual($0 as? PostgresCastingError.Code, .failure)
             }
         }
@@ -113,7 +113,7 @@ class UUID_PSQLCodableTests: XCTestCase {
         
         for dataType in dataTypes {
             var copy = buffer            
-            XCTAssertThrowsError(try UUID.decode(from: &copy, type: dataType, format: .binary, context: .default)) {
+            XCTAssertThrowsError(try UUID(from: &copy, type: dataType, format: .binary, context: .default)) {
                 XCTAssertEqual($0 as? PostgresCastingError.Code, .typeMismatch)
             }
         }


### PR DESCRIPTION
### Motivation

Before we make the `PostgresDecodable` public, let's revisit it. In Swift prefer initializer over static named methods for type creation.

### Changes

- Replace the `static func decode` with an `init`
- Cleanup the default implementations. Put the impl. into their correct protocol conformance.