### PR TITLE
New PostgresConnection connect API

### DIFF
--- a/Sources/PostgresNIO/New/PSQLChannelHandler.swift
+++ b/Sources/PostgresNIO/New/PSQLChannelHandler.swift
@@ -26,13 +26,13 @@ final class PSQLChannelHandler: ChannelDuplexHandler {
     private var rowStream: PSQLRowStream?
     private var decoder: NIOSingleStepByteToMessageProcessor<PSQLBackendMessageDecoder>
     private var encoder: BufferedMessageEncoder!
-    private let configuration: PostgresConnection.Configuration
+    private let configuration: PostgresConnection.InternalConfiguration
     private let configureSSLCallback: ((Channel) throws -> Void)?
     
     /// this delegate should only be accessed on the connections `EventLoop`
     weak var notificationDelegate: PSQLChannelHandlerNotificationDelegate?
     
-    init(configuration: PostgresConnection.Configuration,
+    init(configuration: PostgresConnection.InternalConfiguration,
          logger: Logger,
          configureSSLCallback: ((Channel) throws -> Void)?)
     {
@@ -45,7 +45,7 @@ final class PSQLChannelHandler: ChannelDuplexHandler {
     
     #if DEBUG
     /// for testing purposes only
-    init(configuration: PostgresConnection.Configuration,
+    init(configuration: PostgresConnection.InternalConfiguration,
          state: ConnectionStateMachine = .init(.initialized),
          logger: Logger = .psqlNoOpLogger,
          configureSSLCallback: ((Channel) throws -> Void)?)
@@ -575,8 +575,8 @@ private extension Insecure.MD5.Digest {
 }
 
 extension ConnectionStateMachine.TLSConfiguration {
-    fileprivate init(_ connection: PostgresConnection.Configuration.TLS) {
-        switch connection.base {
+    fileprivate init(_ tls: PostgresConnection.Configuration.TLS) {
+        switch tls.base {
         case .disable:
             self = .disable
         case .require:
@@ -589,7 +589,7 @@ extension ConnectionStateMachine.TLSConfiguration {
 
 extension PSQLChannelHandler {
     convenience init(
-        configuration: PostgresConnection.Configuration,
+        configuration: PostgresConnection.InternalConfiguration,
         configureSSLCallback: ((Channel) throws -> Void)?)
     {
         self.init(

--- a/Tests/IntegrationTests/PSQLIntegrationTests.swift
+++ b/Tests/IntegrationTests/PSQLIntegrationTests.swift
@@ -37,7 +37,7 @@ final class IntegrationTests: XCTestCase {
         logger.logLevel = .info
 
         var connection: PostgresConnection?
-        XCTAssertThrowsError(connection = try PostgresConnection.connect(connectionID: 1, configuration: config, logger: logger, on: eventLoopGroup.next()).wait()) {
+        XCTAssertThrowsError(connection = try PostgresConnection.connect(on: eventLoopGroup.next(), configuration: config, id: 1, logger: logger).wait()) {
             XCTAssertTrue($0 is PSQLError)
         }
 

--- a/Tests/IntegrationTests/PSQLIntegrationTests.swift
+++ b/Tests/IntegrationTests/PSQLIntegrationTests.swift
@@ -23,12 +23,17 @@ final class IntegrationTests: XCTestCase {
         try XCTSkipIf(env("POSTGRES_HOST_AUTH_METHOD") == "trust")
 
         let config = PostgresConnection.Configuration(
-            host: env("POSTGRES_HOSTNAME") ?? "localhost",
-            port: 5432,
-            username: env("POSTGRES_USER") ?? "test_username",
-            database: env("POSTGRES_DB") ?? "test_database",
-            password: "wrong_password",
-            tls: .disable)
+            connection: .init(
+                host: env("POSTGRES_HOSTNAME") ?? "localhost",
+                port: 5432
+            ),
+            authentication: .init(
+                username: env("POSTGRES_USER") ?? "test_username",
+                database: env("POSTGRES_DB") ?? "test_database",
+                password: "wrong_password"
+            ),
+            tls: .disable
+        )
 
         let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully()) }

--- a/Tests/IntegrationTests/PostgresNIOTests.swift
+++ b/Tests/IntegrationTests/PostgresNIOTests.swift
@@ -707,13 +707,18 @@ final class PostgresNIOTests: XCTestCase {
         let logger = Logger(label: "test")
         let sslContext = try! NIOSSLContext(configuration: .makeClientConfiguration())
         let config = PostgresConnection.Configuration(
-            host: "elmer.db.elephantsql.com",
-            port: 5432,
-            username: "uymgphwj",
-            database: "uymgphwj",
-            password: "7_tHbREdRwkqAdu4KoIS7hQnNxr8J1LA",
+            connection: .init(
+                host: "elmer.db.elephantsql.com",
+                port: 5432
+            ),
+            authentication: .init(
+                username: "uymgphwj",
+                database: "uymgphwj",
+                password: "7_tHbREdRwkqAdu4KoIS7hQnNxr8J1LA"
+            ),
             tls: .require(sslContext)
         )
+
 
         XCTAssertNoThrow(conn = try PostgresConnection.connect(on: eventLoop, configuration: config, id: 0, logger: logger).wait())
         defer { XCTAssertNoThrow( try conn?.close().wait() ) }

--- a/Tests/IntegrationTests/Utilities.swift
+++ b/Tests/IntegrationTests/Utilities.swift
@@ -13,6 +13,7 @@ extension PostgresConnection {
         try .makeAddressResolvingHost(env("POSTGRES_HOSTNAME") ?? "localhost", port: 5432)
     }
 
+    @available(*, deprecated, message: "Test deprecated functionality")
     static func testUnauthenticated(on eventLoop: EventLoop, logLevel: Logger.Level = .info) -> EventLoopFuture<PostgresConnection> {
         var logger = Logger(label: "postgres.connection.test")
         logger.logLevel = logLevel
@@ -24,19 +25,19 @@ extension PostgresConnection {
     }
 
     static func test(on eventLoop: EventLoop, logLevel: Logger.Level = .info) -> EventLoopFuture<PostgresConnection> {
-        return testUnauthenticated(on: eventLoop, logLevel: logLevel).flatMap { conn in
-            return conn.authenticate(
-                username: env("POSTGRES_USER") ?? "test_username",
-                database: env("POSTGRES_DB") ?? "test_database",
-                password: env("POSTGRES_PASSWORD") ?? "test_password"
-            ).map {
-                return conn
-            }.flatMapError { error in
-                conn.close().flatMapThrowing {
-                    throw error
-                }
-            }
-        }
+        var logger = Logger(label: "postgres.connection.test")
+        logger.logLevel = logLevel
+
+        let config = PostgresConnection.Configuration(
+            host: env("POSTGRES_HOSTNAME") ?? "localhost",
+            port: 5432,
+            username: env("POSTGRES_USER") ?? "test_username",
+            database: env("POSTGRES_DB") ?? "test_database",
+            password: env("POSTGRES_PASSWORD") ?? "test_password",
+            tls: .disable
+        )
+
+        return PostgresConnection.connect(on: eventLoop, configuration: config, id: 0, logger: logger)
     }
 }
 

--- a/Tests/IntegrationTests/Utilities.swift
+++ b/Tests/IntegrationTests/Utilities.swift
@@ -29,11 +29,15 @@ extension PostgresConnection {
         logger.logLevel = logLevel
 
         let config = PostgresConnection.Configuration(
-            host: env("POSTGRES_HOSTNAME") ?? "localhost",
-            port: 5432,
-            username: env("POSTGRES_USER") ?? "test_username",
-            database: env("POSTGRES_DB") ?? "test_database",
-            password: env("POSTGRES_PASSWORD") ?? "test_password",
+            connection: .init(
+                host: env("POSTGRES_HOSTNAME") ?? "localhost",
+                port: 5432
+            ),
+            authentication: .init(
+                username: env("POSTGRES_USER") ?? "test_username",
+                database: env("POSTGRES_DB") ?? "test_database",
+                password: env("POSTGRES_PASSWORD") ?? "test_password"
+            ),
             tls: .disable
         )
 

--- a/Tests/PostgresNIOTests/New/PSQLChannelHandlerTests.swift
+++ b/Tests/PostgresNIOTests/New/PSQLChannelHandlerTests.swift
@@ -174,13 +174,10 @@ class PSQLChannelHandlerTests: XCTestCase {
         database: String = "postgres",
         password: String = "password",
         tls: PostgresConnection.Configuration.TLS = .disable
-    ) -> PostgresConnection.Configuration {
-        PostgresConnection.Configuration(
-            host: host,
-            port: port,
-            username: username,
-            database: database,
-            password: password,
+    ) -> PostgresConnection.InternalConfiguration {
+        PostgresConnection.InternalConfiguration(
+            connection: .unresolved(host: host, port: port),
+            authentication: .init(username: username, password: password, database: database),
             tls: tls
         )
     }

--- a/Tests/PostgresNIOTests/New/PSQLChannelHandlerTests.swift
+++ b/Tests/PostgresNIOTests/New/PSQLChannelHandlerTests.swift
@@ -175,9 +175,15 @@ class PSQLChannelHandlerTests: XCTestCase {
         password: String = "password",
         tls: PostgresConnection.Configuration.TLS = .disable
     ) -> PostgresConnection.InternalConfiguration {
-        PostgresConnection.InternalConfiguration(
+        let authentication = PostgresConnection.Configuration.Authentication(
+            username: username,
+            database: database,
+            password: password
+        )
+
+        return PostgresConnection.InternalConfiguration(
             connection: .unresolved(host: host, port: port),
-            authentication: .init(username: username, password: password, database: database),
+            authentication: authentication,
             tls: tls
         )
     }

--- a/Tests/PostgresNIOTests/New/PSQLConnectionTests.swift
+++ b/Tests/PostgresNIOTests/New/PSQLConnectionTests.swift
@@ -33,7 +33,7 @@ class PSQLConnectionTests: XCTestCase {
         var logger = Logger.psqlTest
         logger.logLevel = .trace
         
-        XCTAssertThrowsError(try PostgresConnection.connect(connectionID: 1, configuration: config, logger: logger, on: eventLoopGroup.next()).wait()) {
+        XCTAssertThrowsError(try PostgresConnection.connect(on: eventLoopGroup.next(), configuration: config, id: 1, logger: logger).wait()) {
             XCTAssertTrue($0 is PSQLError)
         }
     }

--- a/Tests/PostgresNIOTests/New/PSQLConnectionTests.swift
+++ b/Tests/PostgresNIOTests/New/PSQLConnectionTests.swift
@@ -22,11 +22,8 @@ class PSQLConnectionTests: XCTestCase {
         }
         
         let config = PostgresConnection.Configuration(
-            host: "127.0.0.1",
-            port: port,
-            username: "postgres",
-            database: "postgres",
-            password: "abc123",
+            connection: .init(host: "127.0.0.1", port: port),
+            authentication: .init(username: "postgres", database: "postgres", password: "abc123"),
             tls: .disable
         )
         


### PR DESCRIPTION
### Motivation

Our current connection creation API is very weird. Adopters first need to connect to a server and then manually call authenticate on the just created connection to auth and select the database.

### Changes

- Add new connect method that allows users to connect and auth with a single call
- Add new connect async/await API

### Result

Easier to use public interface

### Open questions:

- Parameter order in new connect method.
- Splitting up PostgresConnection.Configuration into three subtypes.