### PR TITLE
Make PostgresRowSequence public

### DIFF
--- a/Sources/PostgresNIO/New/PostgresRowSequence-multi-decode.swift
+++ b/Sources/PostgresNIO/New/PostgresRowSequence-multi-decode.swift
@@ -2,91 +2,121 @@
 
 #if swift(>=5.5) && canImport(_Concurrency)
 extension PostgresRowSequence {
-    func decode<T0: PostgresDecodable, JSONDecoder: PostgresJSONDecoder>(_: (T0).Type, context: PostgresDecodingContext<JSONDecoder>, file: String = #file, line: Int = #line) -> AsyncThrowingMapSequence<PostgresRowSequence, (T0)> {
+    @inlinable
+    @_alwaysEmitIntoClient
+    public func decode<T0: PostgresDecodable, JSONDecoder: PostgresJSONDecoder>(_: (T0).Type, context: PostgresDecodingContext<JSONDecoder>, file: String = #file, line: Int = #line) -> AsyncThrowingMapSequence<PostgresRowSequence, (T0)> {
         self.map { row in
             try row.decode(T0.self, context: context, file: file, line: line)
         }
     }
 
-    func decode<T0: PostgresDecodable, T1: PostgresDecodable, JSONDecoder: PostgresJSONDecoder>(_: (T0, T1).Type, context: PostgresDecodingContext<JSONDecoder>, file: String = #file, line: Int = #line) -> AsyncThrowingMapSequence<PostgresRowSequence, (T0, T1)> {
+    @inlinable
+    @_alwaysEmitIntoClient
+    public func decode<T0: PostgresDecodable, T1: PostgresDecodable, JSONDecoder: PostgresJSONDecoder>(_: (T0, T1).Type, context: PostgresDecodingContext<JSONDecoder>, file: String = #file, line: Int = #line) -> AsyncThrowingMapSequence<PostgresRowSequence, (T0, T1)> {
         self.map { row in
             try row.decode((T0, T1).self, context: context, file: file, line: line)
         }
     }
 
-    func decode<T0: PostgresDecodable, T1: PostgresDecodable, T2: PostgresDecodable, JSONDecoder: PostgresJSONDecoder>(_: (T0, T1, T2).Type, context: PostgresDecodingContext<JSONDecoder>, file: String = #file, line: Int = #line) -> AsyncThrowingMapSequence<PostgresRowSequence, (T0, T1, T2)> {
+    @inlinable
+    @_alwaysEmitIntoClient
+    public func decode<T0: PostgresDecodable, T1: PostgresDecodable, T2: PostgresDecodable, JSONDecoder: PostgresJSONDecoder>(_: (T0, T1, T2).Type, context: PostgresDecodingContext<JSONDecoder>, file: String = #file, line: Int = #line) -> AsyncThrowingMapSequence<PostgresRowSequence, (T0, T1, T2)> {
         self.map { row in
             try row.decode((T0, T1, T2).self, context: context, file: file, line: line)
         }
     }
 
-    func decode<T0: PostgresDecodable, T1: PostgresDecodable, T2: PostgresDecodable, T3: PostgresDecodable, JSONDecoder: PostgresJSONDecoder>(_: (T0, T1, T2, T3).Type, context: PostgresDecodingContext<JSONDecoder>, file: String = #file, line: Int = #line) -> AsyncThrowingMapSequence<PostgresRowSequence, (T0, T1, T2, T3)> {
+    @inlinable
+    @_alwaysEmitIntoClient
+    public func decode<T0: PostgresDecodable, T1: PostgresDecodable, T2: PostgresDecodable, T3: PostgresDecodable, JSONDecoder: PostgresJSONDecoder>(_: (T0, T1, T2, T3).Type, context: PostgresDecodingContext<JSONDecoder>, file: String = #file, line: Int = #line) -> AsyncThrowingMapSequence<PostgresRowSequence, (T0, T1, T2, T3)> {
         self.map { row in
             try row.decode((T0, T1, T2, T3).self, context: context, file: file, line: line)
         }
     }
 
-    func decode<T0: PostgresDecodable, T1: PostgresDecodable, T2: PostgresDecodable, T3: PostgresDecodable, T4: PostgresDecodable, JSONDecoder: PostgresJSONDecoder>(_: (T0, T1, T2, T3, T4).Type, context: PostgresDecodingContext<JSONDecoder>, file: String = #file, line: Int = #line) -> AsyncThrowingMapSequence<PostgresRowSequence, (T0, T1, T2, T3, T4)> {
+    @inlinable
+    @_alwaysEmitIntoClient
+    public func decode<T0: PostgresDecodable, T1: PostgresDecodable, T2: PostgresDecodable, T3: PostgresDecodable, T4: PostgresDecodable, JSONDecoder: PostgresJSONDecoder>(_: (T0, T1, T2, T3, T4).Type, context: PostgresDecodingContext<JSONDecoder>, file: String = #file, line: Int = #line) -> AsyncThrowingMapSequence<PostgresRowSequence, (T0, T1, T2, T3, T4)> {
         self.map { row in
             try row.decode((T0, T1, T2, T3, T4).self, context: context, file: file, line: line)
         }
     }
 
-    func decode<T0: PostgresDecodable, T1: PostgresDecodable, T2: PostgresDecodable, T3: PostgresDecodable, T4: PostgresDecodable, T5: PostgresDecodable, JSONDecoder: PostgresJSONDecoder>(_: (T0, T1, T2, T3, T4, T5).Type, context: PostgresDecodingContext<JSONDecoder>, file: String = #file, line: Int = #line) -> AsyncThrowingMapSequence<PostgresRowSequence, (T0, T1, T2, T3, T4, T5)> {
+    @inlinable
+    @_alwaysEmitIntoClient
+    public func decode<T0: PostgresDecodable, T1: PostgresDecodable, T2: PostgresDecodable, T3: PostgresDecodable, T4: PostgresDecodable, T5: PostgresDecodable, JSONDecoder: PostgresJSONDecoder>(_: (T0, T1, T2, T3, T4, T5).Type, context: PostgresDecodingContext<JSONDecoder>, file: String = #file, line: Int = #line) -> AsyncThrowingMapSequence<PostgresRowSequence, (T0, T1, T2, T3, T4, T5)> {
         self.map { row in
             try row.decode((T0, T1, T2, T3, T4, T5).self, context: context, file: file, line: line)
         }
     }
 
-    func decode<T0: PostgresDecodable, T1: PostgresDecodable, T2: PostgresDecodable, T3: PostgresDecodable, T4: PostgresDecodable, T5: PostgresDecodable, T6: PostgresDecodable, JSONDecoder: PostgresJSONDecoder>(_: (T0, T1, T2, T3, T4, T5, T6).Type, context: PostgresDecodingContext<JSONDecoder>, file: String = #file, line: Int = #line) -> AsyncThrowingMapSequence<PostgresRowSequence, (T0, T1, T2, T3, T4, T5, T6)> {
+    @inlinable
+    @_alwaysEmitIntoClient
+    public func decode<T0: PostgresDecodable, T1: PostgresDecodable, T2: PostgresDecodable, T3: PostgresDecodable, T4: PostgresDecodable, T5: PostgresDecodable, T6: PostgresDecodable, JSONDecoder: PostgresJSONDecoder>(_: (T0, T1, T2, T3, T4, T5, T6).Type, context: PostgresDecodingContext<JSONDecoder>, file: String = #file, line: Int = #line) -> AsyncThrowingMapSequence<PostgresRowSequence, (T0, T1, T2, T3, T4, T5, T6)> {
         self.map { row in
             try row.decode((T0, T1, T2, T3, T4, T5, T6).self, context: context, file: file, line: line)
         }
     }
 
-    func decode<T0: PostgresDecodable, T1: PostgresDecodable, T2: PostgresDecodable, T3: PostgresDecodable, T4: PostgresDecodable, T5: PostgresDecodable, T6: PostgresDecodable, T7: PostgresDecodable, JSONDecoder: PostgresJSONDecoder>(_: (T0, T1, T2, T3, T4, T5, T6, T7).Type, context: PostgresDecodingContext<JSONDecoder>, file: String = #file, line: Int = #line) -> AsyncThrowingMapSequence<PostgresRowSequence, (T0, T1, T2, T3, T4, T5, T6, T7)> {
+    @inlinable
+    @_alwaysEmitIntoClient
+    public func decode<T0: PostgresDecodable, T1: PostgresDecodable, T2: PostgresDecodable, T3: PostgresDecodable, T4: PostgresDecodable, T5: PostgresDecodable, T6: PostgresDecodable, T7: PostgresDecodable, JSONDecoder: PostgresJSONDecoder>(_: (T0, T1, T2, T3, T4, T5, T6, T7).Type, context: PostgresDecodingContext<JSONDecoder>, file: String = #file, line: Int = #line) -> AsyncThrowingMapSequence<PostgresRowSequence, (T0, T1, T2, T3, T4, T5, T6, T7)> {
         self.map { row in
             try row.decode((T0, T1, T2, T3, T4, T5, T6, T7).self, context: context, file: file, line: line)
         }
     }
 
-    func decode<T0: PostgresDecodable, T1: PostgresDecodable, T2: PostgresDecodable, T3: PostgresDecodable, T4: PostgresDecodable, T5: PostgresDecodable, T6: PostgresDecodable, T7: PostgresDecodable, T8: PostgresDecodable, JSONDecoder: PostgresJSONDecoder>(_: (T0, T1, T2, T3, T4, T5, T6, T7, T8).Type, context: PostgresDecodingContext<JSONDecoder>, file: String = #file, line: Int = #line) -> AsyncThrowingMapSequence<PostgresRowSequence, (T0, T1, T2, T3, T4, T5, T6, T7, T8)> {
+    @inlinable
+    @_alwaysEmitIntoClient
+    public func decode<T0: PostgresDecodable, T1: PostgresDecodable, T2: PostgresDecodable, T3: PostgresDecodable, T4: PostgresDecodable, T5: PostgresDecodable, T6: PostgresDecodable, T7: PostgresDecodable, T8: PostgresDecodable, JSONDecoder: PostgresJSONDecoder>(_: (T0, T1, T2, T3, T4, T5, T6, T7, T8).Type, context: PostgresDecodingContext<JSONDecoder>, file: String = #file, line: Int = #line) -> AsyncThrowingMapSequence<PostgresRowSequence, (T0, T1, T2, T3, T4, T5, T6, T7, T8)> {
         self.map { row in
             try row.decode((T0, T1, T2, T3, T4, T5, T6, T7, T8).self, context: context, file: file, line: line)
         }
     }
 
-    func decode<T0: PostgresDecodable, T1: PostgresDecodable, T2: PostgresDecodable, T3: PostgresDecodable, T4: PostgresDecodable, T5: PostgresDecodable, T6: PostgresDecodable, T7: PostgresDecodable, T8: PostgresDecodable, T9: PostgresDecodable, JSONDecoder: PostgresJSONDecoder>(_: (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9).Type, context: PostgresDecodingContext<JSONDecoder>, file: String = #file, line: Int = #line) -> AsyncThrowingMapSequence<PostgresRowSequence, (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9)> {
+    @inlinable
+    @_alwaysEmitIntoClient
+    public func decode<T0: PostgresDecodable, T1: PostgresDecodable, T2: PostgresDecodable, T3: PostgresDecodable, T4: PostgresDecodable, T5: PostgresDecodable, T6: PostgresDecodable, T7: PostgresDecodable, T8: PostgresDecodable, T9: PostgresDecodable, JSONDecoder: PostgresJSONDecoder>(_: (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9).Type, context: PostgresDecodingContext<JSONDecoder>, file: String = #file, line: Int = #line) -> AsyncThrowingMapSequence<PostgresRowSequence, (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9)> {
         self.map { row in
             try row.decode((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9).self, context: context, file: file, line: line)
         }
     }
 
-    func decode<T0: PostgresDecodable, T1: PostgresDecodable, T2: PostgresDecodable, T3: PostgresDecodable, T4: PostgresDecodable, T5: PostgresDecodable, T6: PostgresDecodable, T7: PostgresDecodable, T8: PostgresDecodable, T9: PostgresDecodable, T10: PostgresDecodable, JSONDecoder: PostgresJSONDecoder>(_: (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10).Type, context: PostgresDecodingContext<JSONDecoder>, file: String = #file, line: Int = #line) -> AsyncThrowingMapSequence<PostgresRowSequence, (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)> {
+    @inlinable
+    @_alwaysEmitIntoClient
+    public func decode<T0: PostgresDecodable, T1: PostgresDecodable, T2: PostgresDecodable, T3: PostgresDecodable, T4: PostgresDecodable, T5: PostgresDecodable, T6: PostgresDecodable, T7: PostgresDecodable, T8: PostgresDecodable, T9: PostgresDecodable, T10: PostgresDecodable, JSONDecoder: PostgresJSONDecoder>(_: (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10).Type, context: PostgresDecodingContext<JSONDecoder>, file: String = #file, line: Int = #line) -> AsyncThrowingMapSequence<PostgresRowSequence, (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)> {
         self.map { row in
             try row.decode((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10).self, context: context, file: file, line: line)
         }
     }
 
-    func decode<T0: PostgresDecodable, T1: PostgresDecodable, T2: PostgresDecodable, T3: PostgresDecodable, T4: PostgresDecodable, T5: PostgresDecodable, T6: PostgresDecodable, T7: PostgresDecodable, T8: PostgresDecodable, T9: PostgresDecodable, T10: PostgresDecodable, T11: PostgresDecodable, JSONDecoder: PostgresJSONDecoder>(_: (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11).Type, context: PostgresDecodingContext<JSONDecoder>, file: String = #file, line: Int = #line) -> AsyncThrowingMapSequence<PostgresRowSequence, (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)> {
+    @inlinable
+    @_alwaysEmitIntoClient
+    public func decode<T0: PostgresDecodable, T1: PostgresDecodable, T2: PostgresDecodable, T3: PostgresDecodable, T4: PostgresDecodable, T5: PostgresDecodable, T6: PostgresDecodable, T7: PostgresDecodable, T8: PostgresDecodable, T9: PostgresDecodable, T10: PostgresDecodable, T11: PostgresDecodable, JSONDecoder: PostgresJSONDecoder>(_: (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11).Type, context: PostgresDecodingContext<JSONDecoder>, file: String = #file, line: Int = #line) -> AsyncThrowingMapSequence<PostgresRowSequence, (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)> {
         self.map { row in
             try row.decode((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11).self, context: context, file: file, line: line)
         }
     }
 
-    func decode<T0: PostgresDecodable, T1: PostgresDecodable, T2: PostgresDecodable, T3: PostgresDecodable, T4: PostgresDecodable, T5: PostgresDecodable, T6: PostgresDecodable, T7: PostgresDecodable, T8: PostgresDecodable, T9: PostgresDecodable, T10: PostgresDecodable, T11: PostgresDecodable, T12: PostgresDecodable, JSONDecoder: PostgresJSONDecoder>(_: (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12).Type, context: PostgresDecodingContext<JSONDecoder>, file: String = #file, line: Int = #line) -> AsyncThrowingMapSequence<PostgresRowSequence, (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)> {
+    @inlinable
+    @_alwaysEmitIntoClient
+    public func decode<T0: PostgresDecodable, T1: PostgresDecodable, T2: PostgresDecodable, T3: PostgresDecodable, T4: PostgresDecodable, T5: PostgresDecodable, T6: PostgresDecodable, T7: PostgresDecodable, T8: PostgresDecodable, T9: PostgresDecodable, T10: PostgresDecodable, T11: PostgresDecodable, T12: PostgresDecodable, JSONDecoder: PostgresJSONDecoder>(_: (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12).Type, context: PostgresDecodingContext<JSONDecoder>, file: String = #file, line: Int = #line) -> AsyncThrowingMapSequence<PostgresRowSequence, (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)> {
         self.map { row in
             try row.decode((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12).self, context: context, file: file, line: line)
         }
     }
 
-    func decode<T0: PostgresDecodable, T1: PostgresDecodable, T2: PostgresDecodable, T3: PostgresDecodable, T4: PostgresDecodable, T5: PostgresDecodable, T6: PostgresDecodable, T7: PostgresDecodable, T8: PostgresDecodable, T9: PostgresDecodable, T10: PostgresDecodable, T11: PostgresDecodable, T12: PostgresDecodable, T13: PostgresDecodable, JSONDecoder: PostgresJSONDecoder>(_: (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13).Type, context: PostgresDecodingContext<JSONDecoder>, file: String = #file, line: Int = #line) -> AsyncThrowingMapSequence<PostgresRowSequence, (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)> {
+    @inlinable
+    @_alwaysEmitIntoClient
+    public func decode<T0: PostgresDecodable, T1: PostgresDecodable, T2: PostgresDecodable, T3: PostgresDecodable, T4: PostgresDecodable, T5: PostgresDecodable, T6: PostgresDecodable, T7: PostgresDecodable, T8: PostgresDecodable, T9: PostgresDecodable, T10: PostgresDecodable, T11: PostgresDecodable, T12: PostgresDecodable, T13: PostgresDecodable, JSONDecoder: PostgresJSONDecoder>(_: (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13).Type, context: PostgresDecodingContext<JSONDecoder>, file: String = #file, line: Int = #line) -> AsyncThrowingMapSequence<PostgresRowSequence, (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)> {
         self.map { row in
             try row.decode((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13).self, context: context, file: file, line: line)
         }
     }
 
-    func decode<T0: PostgresDecodable, T1: PostgresDecodable, T2: PostgresDecodable, T3: PostgresDecodable, T4: PostgresDecodable, T5: PostgresDecodable, T6: PostgresDecodable, T7: PostgresDecodable, T8: PostgresDecodable, T9: PostgresDecodable, T10: PostgresDecodable, T11: PostgresDecodable, T12: PostgresDecodable, T13: PostgresDecodable, T14: PostgresDecodable, JSONDecoder: PostgresJSONDecoder>(_: (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14).Type, context: PostgresDecodingContext<JSONDecoder>, file: String = #file, line: Int = #line) -> AsyncThrowingMapSequence<PostgresRowSequence, (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)> {
+    @inlinable
+    @_alwaysEmitIntoClient
+    public func decode<T0: PostgresDecodable, T1: PostgresDecodable, T2: PostgresDecodable, T3: PostgresDecodable, T4: PostgresDecodable, T5: PostgresDecodable, T6: PostgresDecodable, T7: PostgresDecodable, T8: PostgresDecodable, T9: PostgresDecodable, T10: PostgresDecodable, T11: PostgresDecodable, T12: PostgresDecodable, T13: PostgresDecodable, T14: PostgresDecodable, JSONDecoder: PostgresJSONDecoder>(_: (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14).Type, context: PostgresDecodingContext<JSONDecoder>, file: String = #file, line: Int = #line) -> AsyncThrowingMapSequence<PostgresRowSequence, (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)> {
         self.map { row in
             try row.decode((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14).self, context: context, file: file, line: line)
         }

--- a/Sources/PostgresNIO/New/PostgresRowSequence.swift
+++ b/Sources/PostgresNIO/New/PostgresRowSequence.swift
@@ -5,9 +5,8 @@ import NIOConcurrencyHelpers
 /// An async sequence of ``PostgresRow``s.
 ///
 /// - Note: This is a struct to allow us to move to a move only type easily once they become available.
-struct PostgresRowSequence: AsyncSequence {
-    typealias Element = PostgresRow
-    typealias AsyncIterator = Iterator
+public struct PostgresRowSequence: AsyncSequence {
+    public typealias Element = PostgresRow
 
     final class _Internal {
 
@@ -22,7 +21,7 @@ struct PostgresRowSequence: AsyncSequence {
             self.consumer.sequenceDeinitialized()
         }
 
-        func makeAsyncIterator() -> Iterator {
+        func makeAsyncIterator() -> AsyncIterator {
             self.consumer.makeAsyncIterator()
         }
     }
@@ -33,14 +32,14 @@ struct PostgresRowSequence: AsyncSequence {
         self._internal = .init(consumer: consumer)
     }
 
-    func makeAsyncIterator() -> Iterator {
+    public func makeAsyncIterator() -> AsyncIterator {
         self._internal.makeAsyncIterator()
     }
 }
 
 extension PostgresRowSequence {
-    struct Iterator: AsyncIteratorProtocol {
-        typealias Element = PostgresRow
+    public struct AsyncIterator: AsyncIteratorProtocol {
+        public typealias Element = PostgresRow
 
         let _internal: _Internal
 
@@ -48,7 +47,7 @@ extension PostgresRowSequence {
             self._internal = _Internal(consumer: consumer)
         }
 
-        mutating func next() async throws -> PostgresRow? {
+        public mutating func next() async throws -> PostgresRow? {
             try await self._internal.next()
         }
 
@@ -155,11 +154,11 @@ final class AsyncStreamConsumer {
         }
     }
 
-    func makeAsyncIterator() -> PostgresRowSequence.Iterator {
+    func makeAsyncIterator() -> PostgresRowSequence.AsyncIterator {
         self.lock.withLock {
             self.state.createAsyncIterator()
         }
-        let iterator = PostgresRowSequence.Iterator(consumer: self)
+        let iterator = PostgresRowSequence.AsyncIterator(consumer: self)
         return iterator
     }
 

--- a/Tests/IntegrationTests/AsyncTests.swift
+++ b/Tests/IntegrationTests/AsyncTests.swift
@@ -33,8 +33,8 @@ final class AsyncPostgresConnectionTests: XCTestCase {
         try await withTestConnection(on: eventLoop) { connection in
             let rows = try await connection.query("SELECT generate_series(\(start), \(end));", logger: .psqlTest)
             var counter = 1
-            for try await row in rows {
-                XCTAssertEqual(try row.decode(Int.self, context: .default), counter)
+            for try await element in rows.decode(Int.self, context: .default) {
+                XCTAssertEqual(element, counter)
                 counter += 1
             }
 

--- a/Tests/PostgresNIOTests/New/PostgresRowSequenceTests.swift
+++ b/Tests/PostgresNIOTests/New/PostgresRowSequenceTests.swift
@@ -90,7 +90,7 @@ final class PostgresRowSequenceTests: XCTestCase {
         let dataRows: [DataRow] = (0..<128).map { [ByteBuffer(integer: Int64($0))] }
         stream.receive(dataRows)
 
-        var iterator: PostgresRowSequence.Iterator? = rowSequence.makeAsyncIterator()
+        var iterator: PostgresRowSequence.AsyncIterator? = rowSequence.makeAsyncIterator()
         iterator = nil
 
         XCTAssertEqual(dataSource.cancelCount, 1)

--- a/dev/generate-postgresrowsequence-multi-decode.sh
+++ b/dev/generate-postgresrowsequence-multi-decode.sh
@@ -11,9 +11,9 @@ function gen() {
         echo ""
     fi
 
-    #echo "    @inlinable"
-    #echo "    @_alwaysEmitIntoClient"
-    echo -n "    func decode<T0: PostgresDecodable"
+    echo "    @inlinable"
+    echo "    @_alwaysEmitIntoClient"
+    echo -n "    public func decode<T0: PostgresDecodable"
     for ((n = 1; n<$how_many; n +=1)); do
         echo -n ", T$(($n)): PostgresDecodable"
     done


### PR DESCRIPTION
### Motivation

For the new async interface we need the `PostgresRowSequence` to be public

### Changes

- Make `PostgresRowSequence` public
- Rename `PostgresRowSequence.Iterator` to `PostgresRowSequence.AsyncIterator` (Having an `Iterator` and an `AsyncIterator` in the same type is confusing)
- Make `PostgresRowSequence` decode methods public

### Result

Only need to make encoding public