### PR TITLE
Make Postgres Encodable public

### DIFF
--- a/Sources/PostgresNIO/New/Data/Array+PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/Data/Array+PostgresCodable.swift
@@ -1,82 +1,103 @@
 import NIOCore
 import struct Foundation.UUID
 
+// MARK: Protocols
+
 /// A type, of which arrays can be encoded into and decoded from a postgres binary format
-protocol PSQLArrayElement: PostgresCodable {
+public protocol PostgresArrayEncodable: PostgresEncodable {
     static var psqlArrayType: PostgresDataType { get }
-    static var psqlArrayElementType: PostgresDataType { get }
 }
 
-extension Bool: PSQLArrayElement {
-    static var psqlArrayType: PostgresDataType { .boolArray }
-    static var psqlArrayElementType: PostgresDataType { .bool }
+/// A type that can be decoded into a Swift Array of its own type from a Postgres array.
+public protocol PostgresArrayDecodable: PostgresDecodable {}
+
+// MARK: Element conformances
+
+extension Bool: PostgresArrayDecodable {}
+
+extension Bool: PostgresArrayEncodable {
+    public static var psqlArrayType: PostgresDataType { .boolArray }
 }
 
-extension ByteBuffer: PSQLArrayElement {
-    static var psqlArrayType: PostgresDataType { .byteaArray }
-    static var psqlArrayElementType: PostgresDataType { .bytea }
+extension ByteBuffer: PostgresArrayDecodable {}
+
+extension ByteBuffer: PostgresArrayEncodable {
+    public static var psqlArrayType: PostgresDataType { .byteaArray }
 }
 
-extension UInt8: PSQLArrayElement {
-    static var psqlArrayType: PostgresDataType { .charArray }
-    static var psqlArrayElementType: PostgresDataType { .char }
+extension UInt8: PostgresArrayDecodable {}
+
+extension UInt8: PostgresArrayEncodable {
+    public static var psqlArrayType: PostgresDataType { .charArray }
 }
 
-extension Int16: PSQLArrayElement {
-    static var psqlArrayType: PostgresDataType { .int2Array }
-    static var psqlArrayElementType: PostgresDataType { .int2 }
+
+extension Int16: PostgresArrayDecodable {}
+
+extension Int16: PostgresArrayEncodable {
+    public static var psqlArrayType: PostgresDataType { .int2Array }
 }
 
-extension Int32: PSQLArrayElement {
-    static var psqlArrayType: PostgresDataType { .int4Array }
-    static var psqlArrayElementType: PostgresDataType { .int4 }
+extension Int32: PostgresArrayDecodable {}
+
+extension Int32: PostgresArrayEncodable {
+    public static var psqlArrayType: PostgresDataType { .int4Array }
 }
 
-extension Int64: PSQLArrayElement {
-    static var psqlArrayType: PostgresDataType { .int8Array }
-    static var psqlArrayElementType: PostgresDataType { .int8 }
+extension Int64: PostgresArrayDecodable {}
+
+extension Int64: PostgresArrayEncodable {
+    public static var psqlArrayType: PostgresDataType { .int8Array }
 }
 
-extension Int: PSQLArrayElement {
-    #if (arch(i386) || arch(arm))
-    static var psqlArrayType: PostgresDataType { .int4Array }
-    static var psqlArrayElementType: PostgresDataType { .int4 }
-    #else
-    static var psqlArrayType: PostgresDataType { .int8Array }
-    static var psqlArrayElementType: PostgresDataType { .int8 }
-    #endif
+extension Int: PostgresArrayDecodable {}
+
+extension Int: PostgresArrayEncodable {
+    public static var psqlArrayType: PostgresDataType {
+        if MemoryLayout<Int>.size == 8 {
+            return .int8Array
+        }
+        return .int4Array
+    }
 }
 
-extension Float: PSQLArrayElement {
-    static var psqlArrayType: PostgresDataType { .float4Array }
-    static var psqlArrayElementType: PostgresDataType { .float4 }
+extension Float: PostgresArrayDecodable {}
+
+extension Float: PostgresArrayEncodable {
+    public static var psqlArrayType: PostgresDataType { .float4Array }
 }
 
-extension Double: PSQLArrayElement {
-    static var psqlArrayType: PostgresDataType { .float8Array }
-    static var psqlArrayElementType: PostgresDataType { .float8 }
+extension Double: PostgresArrayDecodable {}
+
+extension Double: PostgresArrayEncodable {
+    public static var psqlArrayType: PostgresDataType { .float8Array }
 }
 
-extension String: PSQLArrayElement {
-    static var psqlArrayType: PostgresDataType { .textArray }
-    static var psqlArrayElementType: PostgresDataType { .text }
+extension String: PostgresArrayDecodable {}
+
+extension String: PostgresArrayEncodable {
+    public static var psqlArrayType: PostgresDataType { .textArray }
 }
 
-extension UUID: PSQLArrayElement {
-    static var psqlArrayType: PostgresDataType { .uuidArray }
-    static var psqlArrayElementType: PostgresDataType { .uuid }
+extension UUID: PostgresArrayDecodable {}
+
+extension UUID: PostgresArrayEncodable {
+    public static var psqlArrayType: PostgresDataType { .uuidArray }
 }
 
-extension Array: PostgresEncodable where Element: PSQLArrayElement {
-    static var psqlType: PostgresDataType {
+// MARK: Array conformances
+
+extension Array: PostgresEncodable where Element: PostgresArrayEncodable {
+    public static var psqlType: PostgresDataType {
         Element.psqlArrayType
     }
-    
-    static var psqlFormat: PostgresFormat {
+
+    public static var psqlFormat: PostgresFormat {
         .binary
     }
-    
-    func encode<JSONEncoder: PostgresJSONEncoder>(
+
+    @inlinable
+    public func encode<JSONEncoder: PostgresJSONEncoder>(
         into buffer: inout ByteBuffer,
         context: PostgresEncodingContext<JSONEncoder>
     ) throws {
@@ -85,13 +106,13 @@ extension Array: PostgresEncodable where Element: PSQLArrayElement {
         // b
         buffer.writeInteger(0, as: Int32.self)
         // array element type
-        buffer.writeInteger(Element.psqlArrayElementType.rawValue)
+        buffer.writeInteger(Element.psqlType.rawValue)
 
         // continue if the array is not empty
         guard !self.isEmpty else {
             return
         }
-        
+
         // length of array
         buffer.writeInteger(numericCast(self.count), as: Int32.self)
         // dimensions
@@ -103,20 +124,6 @@ extension Array: PostgresEncodable where Element: PSQLArrayElement {
     }
 }
 
-/// A type that can be decoded into a Swift Array of its own type from a Postgres array.
-public protocol PostgresArrayDecodable: PostgresDecodable {}
-
-extension Bool: PostgresArrayDecodable {}
-extension ByteBuffer: PostgresArrayDecodable {}
-extension UInt8: PostgresArrayDecodable {}
-extension Int16: PostgresArrayDecodable {}
-extension Int32: PostgresArrayDecodable {}
-extension Int64: PostgresArrayDecodable {}
-extension Int: PostgresArrayDecodable {}
-extension Float: PostgresArrayDecodable {}
-extension Double: PostgresArrayDecodable {}
-extension String: PostgresArrayDecodable {}
-extension UUID: PostgresArrayDecodable {}
 
 extension Array: PostgresDecodable where Element: PostgresArrayDecodable, Element == Element._DecodableType {
     public init<JSONDecoder: PostgresJSONDecoder>(

--- a/Sources/PostgresNIO/New/Data/Array+PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/Data/Array+PostgresCodable.swift
@@ -68,11 +68,11 @@ extension UUID: PSQLArrayElement {
 }
 
 extension Array: PostgresEncodable where Element: PSQLArrayElement {
-    var psqlType: PostgresDataType {
+    static var psqlType: PostgresDataType {
         Element.psqlArrayType
     }
     
-    var psqlFormat: PostgresFormat {
+    static var psqlFormat: PostgresFormat {
         .binary
     }
     

--- a/Sources/PostgresNIO/New/Data/Bool+PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/Data/Bool+PostgresCodable.swift
@@ -44,15 +44,16 @@ extension Bool: PostgresDecodable {
 }
 
 extension Bool: PostgresEncodable {
-    static var psqlType: PostgresDataType {
+    public static var psqlType: PostgresDataType {
         .bool
     }
     
-    static var psqlFormat: PostgresFormat {
+    public static var psqlFormat: PostgresFormat {
         .binary
     }
-    
-    func encode<JSONEncoder: PostgresJSONEncoder>(
+
+    @inlinable
+    public func encode<JSONEncoder: PostgresJSONEncoder>(
         into byteBuffer: inout ByteBuffer,
         context: PostgresEncodingContext<JSONEncoder>
     ) {

--- a/Sources/PostgresNIO/New/Data/Bool+PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/Data/Bool+PostgresCodable.swift
@@ -44,11 +44,11 @@ extension Bool: PostgresDecodable {
 }
 
 extension Bool: PostgresEncodable {
-    var psqlType: PostgresDataType {
+    static var psqlType: PostgresDataType {
         .bool
     }
     
-    var psqlFormat: PostgresFormat {
+    static var psqlFormat: PostgresFormat {
         .binary
     }
     

--- a/Sources/PostgresNIO/New/Data/Bytes+PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/Data/Bytes+PostgresCodable.swift
@@ -3,15 +3,16 @@ import NIOCore
 import NIOFoundationCompat
 
 extension PostgresEncodable where Self: Sequence, Self.Element == UInt8 {
-    static var psqlType: PostgresDataType {
+    public static var psqlType: PostgresDataType {
         .bytea
     }
     
-    static var psqlFormat: PostgresFormat {
+    public static var psqlFormat: PostgresFormat {
         .binary
     }
-    
-    func encode<JSONEncoder: PostgresJSONEncoder>(
+
+    @inlinable
+    public func encode<JSONEncoder: PostgresJSONEncoder>(
         into byteBuffer: inout ByteBuffer,
         context: PostgresEncodingContext<JSONEncoder>
     ) {
@@ -20,15 +21,16 @@ extension PostgresEncodable where Self: Sequence, Self.Element == UInt8 {
 }
 
 extension ByteBuffer: PostgresEncodable {
-    static var psqlType: PostgresDataType {
+    public static var psqlType: PostgresDataType {
         .bytea
     }
     
-    static var psqlFormat: PostgresFormat {
+    public static var psqlFormat: PostgresFormat {
         .binary
     }
-    
-    func encode<JSONEncoder: PostgresJSONEncoder>(
+
+    @inlinable
+    public func encode<JSONEncoder: PostgresJSONEncoder>(
         into byteBuffer: inout ByteBuffer,
         context: PostgresEncodingContext<JSONEncoder>
     ) {
@@ -52,15 +54,16 @@ extension ByteBuffer: PostgresDecodable {
 extension ByteBuffer: PostgresCodable {}
 
 extension Data: PostgresEncodable {
-    static var psqlType: PostgresDataType {
+    public static var psqlType: PostgresDataType {
         .bytea
     }
 
-    static var psqlFormat: PostgresFormat {
+    public static var psqlFormat: PostgresFormat {
         .binary
     }
 
-    func encode<JSONEncoder: PostgresJSONEncoder>(
+    @inlinable
+    public func encode<JSONEncoder: PostgresJSONEncoder>(
         into byteBuffer: inout ByteBuffer,
         context: PostgresEncodingContext<JSONEncoder>
     ) {

--- a/Sources/PostgresNIO/New/Data/Bytes+PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/Data/Bytes+PostgresCodable.swift
@@ -3,11 +3,11 @@ import NIOCore
 import NIOFoundationCompat
 
 extension PostgresEncodable where Self: Sequence, Self.Element == UInt8 {
-    var psqlType: PostgresDataType {
+    static var psqlType: PostgresDataType {
         .bytea
     }
     
-    var psqlFormat: PostgresFormat {
+    static var psqlFormat: PostgresFormat {
         .binary
     }
     
@@ -20,11 +20,11 @@ extension PostgresEncodable where Self: Sequence, Self.Element == UInt8 {
 }
 
 extension ByteBuffer: PostgresEncodable {
-    var psqlType: PostgresDataType {
+    static var psqlType: PostgresDataType {
         .bytea
     }
     
-    var psqlFormat: PostgresFormat {
+    static var psqlFormat: PostgresFormat {
         .binary
     }
     
@@ -52,11 +52,11 @@ extension ByteBuffer: PostgresDecodable {
 extension ByteBuffer: PostgresCodable {}
 
 extension Data: PostgresEncodable {
-    var psqlType: PostgresDataType {
+    static var psqlType: PostgresDataType {
         .bytea
     }
 
-    var psqlFormat: PostgresFormat {
+    static var psqlFormat: PostgresFormat {
         .binary
     }
 

--- a/Sources/PostgresNIO/New/Data/Date+PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/Data/Date+PostgresCodable.swift
@@ -2,15 +2,16 @@ import NIOCore
 import struct Foundation.Date
 
 extension Date: PostgresEncodable {
-    static var psqlType: PostgresDataType {
+    public static var psqlType: PostgresDataType {
         .timestamptz
     }
     
-    static var psqlFormat: PostgresFormat {
+    public static var psqlFormat: PostgresFormat {
         .binary
     }
-    
-    func encode<JSONEncoder: PostgresJSONEncoder>(
+
+    @inlinable
+    public func encode<JSONEncoder: PostgresJSONEncoder>(
         into byteBuffer: inout ByteBuffer,
         context: PostgresEncodingContext<JSONEncoder>
     ) {

--- a/Sources/PostgresNIO/New/Data/Date+PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/Data/Date+PostgresCodable.swift
@@ -2,11 +2,11 @@ import NIOCore
 import struct Foundation.Date
 
 extension Date: PostgresEncodable {
-    var psqlType: PostgresDataType {
+    static var psqlType: PostgresDataType {
         .timestamptz
     }
     
-    var psqlFormat: PostgresFormat {
+    static var psqlFormat: PostgresFormat {
         .binary
     }
     

--- a/Sources/PostgresNIO/New/Data/Decimal+PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/Data/Decimal+PostgresCodable.swift
@@ -2,11 +2,11 @@ import NIOCore
 import struct Foundation.Decimal
 
 extension Decimal: PostgresEncodable {
-    var psqlType: PostgresDataType {
+    static var psqlType: PostgresDataType {
         .numeric
     }
     
-    var psqlFormat: PostgresFormat {
+    static var psqlFormat: PostgresFormat {
         .binary
     }
     

--- a/Sources/PostgresNIO/New/Data/Decimal+PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/Data/Decimal+PostgresCodable.swift
@@ -2,15 +2,15 @@ import NIOCore
 import struct Foundation.Decimal
 
 extension Decimal: PostgresEncodable {
-    static var psqlType: PostgresDataType {
+    public static var psqlType: PostgresDataType {
         .numeric
     }
     
-    static var psqlFormat: PostgresFormat {
+    public static var psqlFormat: PostgresFormat {
         .binary
     }
-    
-    func encode<JSONEncoder: PostgresJSONEncoder>(
+
+    public func encode<JSONEncoder: PostgresJSONEncoder>(
         into byteBuffer: inout ByteBuffer,
         context: PostgresEncodingContext<JSONEncoder>
     ) {

--- a/Sources/PostgresNIO/New/Data/Float+PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/Data/Float+PostgresCodable.swift
@@ -1,15 +1,16 @@
 import NIOCore
 
 extension Float: PostgresEncodable {
-    static var psqlType: PostgresDataType {
+    public static var psqlType: PostgresDataType {
         .float4
     }
     
-    static var psqlFormat: PostgresFormat {
+    public static var psqlFormat: PostgresFormat {
         .binary
     }
-    
-    func encode<JSONEncoder: PostgresJSONEncoder>(
+
+    @inlinable
+    public func encode<JSONEncoder: PostgresJSONEncoder>(
         into byteBuffer: inout ByteBuffer,
         context: PostgresEncodingContext<JSONEncoder>
     ) {
@@ -50,15 +51,16 @@ extension Float: PostgresDecodable {
 extension Float: PostgresCodable {}
 
 extension Double: PostgresEncodable {
-    static var psqlType: PostgresDataType {
+    public static var psqlType: PostgresDataType {
         .float8
     }
     
-    static var psqlFormat: PostgresFormat {
+    public static var psqlFormat: PostgresFormat {
         .binary
     }
-    
-    func encode<JSONEncoder: PostgresJSONEncoder>(
+
+    @inlinable
+    public func encode<JSONEncoder: PostgresJSONEncoder>(
         into byteBuffer: inout ByteBuffer,
         context: PostgresEncodingContext<JSONEncoder>
     ) {

--- a/Sources/PostgresNIO/New/Data/Float+PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/Data/Float+PostgresCodable.swift
@@ -1,11 +1,11 @@
 import NIOCore
 
 extension Float: PostgresEncodable {
-    var psqlType: PostgresDataType {
+    static var psqlType: PostgresDataType {
         .float4
     }
     
-    var psqlFormat: PostgresFormat {
+    static var psqlFormat: PostgresFormat {
         .binary
     }
     
@@ -50,11 +50,11 @@ extension Float: PostgresDecodable {
 extension Float: PostgresCodable {}
 
 extension Double: PostgresEncodable {
-    var psqlType: PostgresDataType {
+    static var psqlType: PostgresDataType {
         .float8
     }
     
-    var psqlFormat: PostgresFormat {
+    static var psqlFormat: PostgresFormat {
         .binary
     }
     

--- a/Sources/PostgresNIO/New/Data/Int+PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/Data/Int+PostgresCodable.swift
@@ -3,15 +3,16 @@ import NIOCore
 // MARK: UInt8
 
 extension UInt8: PostgresEncodable {
-    static var psqlType: PostgresDataType {
+    public static var psqlType: PostgresDataType {
         .char
     }
 
-    static var psqlFormat: PostgresFormat {
+    public static var psqlFormat: PostgresFormat {
         .binary
     }
 
-    func encode<JSONEncoder: PostgresJSONEncoder>(
+    @inlinable
+    public func encode<JSONEncoder: PostgresJSONEncoder>(
         into byteBuffer: inout ByteBuffer,
         context: PostgresEncodingContext<JSONEncoder>
     ) {
@@ -45,15 +46,16 @@ extension UInt8: PostgresCodable {}
 // MARK: Int16
 
 extension Int16: PostgresEncodable {
-    static var psqlType: PostgresDataType {
+    public static var psqlType: PostgresDataType {
         .int2
     }
 
-    static var psqlFormat: PostgresFormat {
+    public static var psqlFormat: PostgresFormat {
         .binary
     }
 
-    func encode<JSONEncoder: PostgresJSONEncoder>(
+    @inlinable
+    public func encode<JSONEncoder: PostgresJSONEncoder>(
         into byteBuffer: inout ByteBuffer,
         context: PostgresEncodingContext<JSONEncoder>
     ) {
@@ -91,15 +93,16 @@ extension Int16: PostgresCodable {}
 // MARK: Int32
 
 extension Int32: PostgresEncodable {
-    static var psqlType: PostgresDataType {
+    public static var psqlType: PostgresDataType {
         .int4
     }
     
-    static var psqlFormat: PostgresFormat {
+    public static var psqlFormat: PostgresFormat {
         .binary
     }
 
-    func encode<JSONEncoder: PostgresJSONEncoder>(
+    @inlinable
+    public func encode<JSONEncoder: PostgresJSONEncoder>(
         into byteBuffer: inout ByteBuffer,
         context: PostgresEncodingContext<JSONEncoder>
     ) {
@@ -142,15 +145,16 @@ extension Int32: PostgresCodable {}
 // MARK: Int64
 
 extension Int64: PostgresEncodable {
-    static var psqlType: PostgresDataType {
+    public static var psqlType: PostgresDataType {
         .int8
     }
 
-    static var psqlFormat: PostgresFormat {
+    public static var psqlFormat: PostgresFormat {
         .binary
     }
 
-    func encode<JSONEncoder: PostgresJSONEncoder>(
+    @inlinable
+    public func encode<JSONEncoder: PostgresJSONEncoder>(
         into byteBuffer: inout ByteBuffer,
         context: PostgresEncodingContext<JSONEncoder>
     ) {
@@ -198,22 +202,23 @@ extension Int64: PostgresCodable {}
 // MARK: Int
 
 extension Int: PostgresEncodable {
-    static var psqlType: PostgresDataType {
-        switch self.bitWidth {
-        case Int32.bitWidth:
+    public static var psqlType: PostgresDataType {
+        switch MemoryLayout<Int>.size {
+        case 4:
             return .int4
-        case Int64.bitWidth:
+        case 8:
             return .int8
         default:
             preconditionFailure("Int is expected to be an Int32 or Int64")
         }
     }
     
-    static var psqlFormat: PostgresFormat {
+    public static var psqlFormat: PostgresFormat {
         .binary
     }
 
-    func encode<JSONEncoder: PostgresJSONEncoder>(
+    @inlinable
+    public func encode<JSONEncoder: PostgresJSONEncoder>(
         into byteBuffer: inout ByteBuffer,
         context: PostgresEncodingContext<JSONEncoder>
     ) {
@@ -236,12 +241,12 @@ extension Int: PostgresDecodable {
             }
             self = Int(value)
         case (.binary, .int4):
-            guard buffer.readableBytes == 4, let value = buffer.readInteger(as: Int32.self) else {
+            guard buffer.readableBytes == 4, let value = buffer.readInteger(as: Int32.self).flatMap({ Int(exactly: $0) }) else {
                 throw PostgresCastingError.Code.failure
             }
-            self = Int(value)
-        case (.binary, .int8) where Int.bitWidth == 64:
-            guard buffer.readableBytes == 8, let value = buffer.readInteger(as: Int.self) else {
+            self = value
+        case (.binary, .int8):
+            guard buffer.readableBytes == 8, let value = buffer.readInteger(as: Int.self).flatMap({ Int(exactly: $0) }) else {
                 throw PostgresCastingError.Code.failure
             }
             self = value

--- a/Sources/PostgresNIO/New/Data/Int+PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/Data/Int+PostgresCodable.swift
@@ -3,11 +3,11 @@ import NIOCore
 // MARK: UInt8
 
 extension UInt8: PostgresEncodable {
-    var psqlType: PostgresDataType {
+    static var psqlType: PostgresDataType {
         .char
     }
 
-    var psqlFormat: PostgresFormat {
+    static var psqlFormat: PostgresFormat {
         .binary
     }
 
@@ -45,12 +45,11 @@ extension UInt8: PostgresCodable {}
 // MARK: Int16
 
 extension Int16: PostgresEncodable {
-    
-    var psqlType: PostgresDataType {
+    static var psqlType: PostgresDataType {
         .int2
     }
 
-    var psqlFormat: PostgresFormat {
+    static var psqlFormat: PostgresFormat {
         .binary
     }
 
@@ -92,11 +91,11 @@ extension Int16: PostgresCodable {}
 // MARK: Int32
 
 extension Int32: PostgresEncodable {
-    var psqlType: PostgresDataType {
+    static var psqlType: PostgresDataType {
         .int4
     }
     
-    var psqlFormat: PostgresFormat {
+    static var psqlFormat: PostgresFormat {
         .binary
     }
 
@@ -143,11 +142,11 @@ extension Int32: PostgresCodable {}
 // MARK: Int64
 
 extension Int64: PostgresEncodable {
-    var psqlType: PostgresDataType {
+    static var psqlType: PostgresDataType {
         .int8
     }
 
-    var psqlFormat: PostgresFormat {
+    static var psqlFormat: PostgresFormat {
         .binary
     }
 
@@ -199,7 +198,7 @@ extension Int64: PostgresCodable {}
 // MARK: Int
 
 extension Int: PostgresEncodable {
-    var psqlType: PostgresDataType {
+    static var psqlType: PostgresDataType {
         switch self.bitWidth {
         case Int32.bitWidth:
             return .int4
@@ -210,7 +209,7 @@ extension Int: PostgresEncodable {
         }
     }
     
-    var psqlFormat: PostgresFormat {
+    static var psqlFormat: PostgresFormat {
         .binary
     }
 

--- a/Sources/PostgresNIO/New/Data/JSON+PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/Data/JSON+PostgresCodable.swift
@@ -3,18 +3,20 @@ import NIOFoundationCompat
 import class Foundation.JSONEncoder
 import class Foundation.JSONDecoder
 
-private let JSONBVersionByte: UInt8 = 0x01
+@usableFromInline
+let JSONBVersionByte: UInt8 = 0x01
 
-extension PostgresEncodable where Self: Codable {
-    static var psqlType: PostgresDataType {
+extension PostgresEncodable where Self: Encodable {
+    public static var psqlType: PostgresDataType {
         .jsonb
     }
     
-    static var psqlFormat: PostgresFormat {
+    public static var psqlFormat: PostgresFormat {
         .binary
     }
-    
-    func encode<JSONEncoder: PostgresJSONEncoder>(
+
+    @inlinable
+    public func encode<JSONEncoder: PostgresJSONEncoder>(
         into byteBuffer: inout ByteBuffer,
         context: PostgresEncodingContext<JSONEncoder>
     ) throws {
@@ -23,7 +25,7 @@ extension PostgresEncodable where Self: Codable {
     }
 }
 
-extension PostgresDecodable where Self: Codable {
+extension PostgresDecodable where Self: Decodable {
     init<JSONDecoder: PostgresJSONDecoder>(
         from buffer: inout ByteBuffer,
         type: PostgresDataType,

--- a/Sources/PostgresNIO/New/Data/JSON+PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/Data/JSON+PostgresCodable.swift
@@ -6,11 +6,11 @@ import class Foundation.JSONDecoder
 private let JSONBVersionByte: UInt8 = 0x01
 
 extension PostgresEncodable where Self: Codable {
-    var psqlType: PostgresDataType {
+    static var psqlType: PostgresDataType {
         .jsonb
     }
     
-    var psqlFormat: PostgresFormat {
+    static var psqlFormat: PostgresFormat {
         .binary
     }
     

--- a/Sources/PostgresNIO/New/Data/RawRepresentable+PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/Data/RawRepresentable+PostgresCodable.swift
@@ -1,12 +1,12 @@
 import NIOCore
 
 extension PostgresEncodable where Self: RawRepresentable, RawValue: PostgresEncodable {
-    var psqlType: PostgresDataType {
-        self.rawValue.psqlType
+    static var psqlType: PostgresDataType {
+        RawValue.psqlType
     }
     
-    var psqlFormat: PostgresFormat {
-        self.rawValue.psqlFormat
+    static var psqlFormat: PostgresFormat {
+        RawValue.psqlFormat
     }
     
     func encode<JSONEncoder: PostgresJSONEncoder>(

--- a/Sources/PostgresNIO/New/Data/RawRepresentable+PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/Data/RawRepresentable+PostgresCodable.swift
@@ -1,15 +1,16 @@
 import NIOCore
 
 extension PostgresEncodable where Self: RawRepresentable, RawValue: PostgresEncodable {
-    static var psqlType: PostgresDataType {
+    public static var psqlType: PostgresDataType {
         RawValue.psqlType
     }
     
-    static var psqlFormat: PostgresFormat {
+    public static var psqlFormat: PostgresFormat {
         RawValue.psqlFormat
     }
-    
-    func encode<JSONEncoder: PostgresJSONEncoder>(
+
+    @inlinable
+    public func encode<JSONEncoder: PostgresJSONEncoder>(
         into byteBuffer: inout ByteBuffer,
         context: PostgresEncodingContext<JSONEncoder>
     ) throws {

--- a/Sources/PostgresNIO/New/Data/String+PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/Data/String+PostgresCodable.swift
@@ -2,15 +2,16 @@ import NIOCore
 import struct Foundation.UUID
 
 extension String: PostgresEncodable {
-    static var psqlType: PostgresDataType {
+    public static var psqlType: PostgresDataType {
         .text
     }
     
-    static var psqlFormat: PostgresFormat {
+    public static var psqlFormat: PostgresFormat {
         .binary
     }
-    
-    func encode<JSONEncoder: PostgresJSONEncoder>(
+
+    @inlinable
+    public func encode<JSONEncoder: PostgresJSONEncoder>(
         into byteBuffer: inout ByteBuffer,
         context: PostgresEncodingContext<JSONEncoder>
     ) {

--- a/Sources/PostgresNIO/New/Data/String+PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/Data/String+PostgresCodable.swift
@@ -2,11 +2,11 @@ import NIOCore
 import struct Foundation.UUID
 
 extension String: PostgresEncodable {
-    var psqlType: PostgresDataType {
+    static var psqlType: PostgresDataType {
         .text
     }
     
-    var psqlFormat: PostgresFormat {
+    static var psqlFormat: PostgresFormat {
         .binary
     }
     

--- a/Sources/PostgresNIO/New/Data/UUID+PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/Data/UUID+PostgresCodable.swift
@@ -3,15 +3,16 @@ import struct Foundation.UUID
 import typealias Foundation.uuid_t
 
 extension UUID: PostgresEncodable {
-    static var psqlType: PostgresDataType {
+    public static var psqlType: PostgresDataType {
         .uuid
     }
     
-    static var psqlFormat: PostgresFormat {
+    public static var psqlFormat: PostgresFormat {
         .binary
     }
-    
-    func encode<JSONEncoder: PostgresJSONEncoder>(
+
+    @inlinable
+    public func encode<JSONEncoder: PostgresJSONEncoder>(
         into byteBuffer: inout ByteBuffer,
         context: PostgresEncodingContext<JSONEncoder>
     ) {

--- a/Sources/PostgresNIO/New/Data/UUID+PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/Data/UUID+PostgresCodable.swift
@@ -3,11 +3,11 @@ import struct Foundation.UUID
 import typealias Foundation.uuid_t
 
 extension UUID: PostgresEncodable {
-    var psqlType: PostgresDataType {
+    static var psqlType: PostgresDataType {
         .uuid
     }
     
-    var psqlFormat: PostgresFormat {
+    static var psqlFormat: PostgresFormat {
         .binary
     }
     

--- a/Sources/PostgresNIO/New/Extensions/ByteBuffer+PSQL.swift
+++ b/Sources/PostgresNIO/New/Extensions/ByteBuffer+PSQL.swift
@@ -20,10 +20,12 @@ internal extension ByteBuffer {
         return self.readInteger(as: UInt64.self).map { Double(bitPattern: $0) }
     }
 
+    @usableFromInline
     mutating func psqlWriteFloat(_ float: Float) {
         self.writeInteger(float.bitPattern)
     }
 
+    @usableFromInline
     mutating func psqlWriteDouble(_ double: Double) {
         self.writeInteger(double.bitPattern)
     }

--- a/Sources/PostgresNIO/New/PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/PostgresCodable.swift
@@ -2,7 +2,7 @@ import NIOCore
 import Foundation
 
 /// A type that can encode itself to a postgres wire binary representation.
-protocol PostgresEncodable {
+public protocol PostgresEncodable {
     /// identifies the data type that we will encode into `byteBuffer` in `encode`
     static var psqlType: PostgresDataType { get }
     
@@ -71,6 +71,7 @@ extension PostgresDecodable {
 protocol PostgresCodable: PostgresEncodable, PostgresDecodable {}
 
 extension PostgresEncodable {
+    @inlinable
     func encodeRaw<JSONEncoder: PostgresJSONEncoder>(
         into buffer: inout ByteBuffer,
         context: PostgresEncodingContext<JSONEncoder>

--- a/Sources/PostgresNIO/New/PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/PostgresCodable.swift
@@ -4,10 +4,10 @@ import Foundation
 /// A type that can encode itself to a postgres wire binary representation.
 protocol PostgresEncodable {
     /// identifies the data type that we will encode into `byteBuffer` in `encode`
-    var psqlType: PostgresDataType { get }
+    static var psqlType: PostgresDataType { get }
     
     /// identifies the postgres format that is used to encode the value into `byteBuffer` in `encode`
-    var psqlFormat: PostgresFormat { get }
+    static var psqlFormat: PostgresFormat { get }
     
     /// Encode the entity into the `byteBuffer` in Postgres binary format, without setting
     /// the byte count. This method is called from the ``PostgresBindings``.

--- a/Sources/PostgresNIO/New/PostgresQuery.swift
+++ b/Sources/PostgresNIO/New/PostgresQuery.swift
@@ -86,7 +86,7 @@ struct PostgresBindings: Hashable {
         }
 
         init<Value: PostgresEncodable>(value: Value) {
-            self.init(dataType: value.psqlType, format: value.psqlFormat)
+            self.init(dataType: Value.psqlType, format: Value.psqlFormat)
         }
     }
 

--- a/Tests/IntegrationTests/PSQLIntegrationTests.swift
+++ b/Tests/IntegrationTests/PSQLIntegrationTests.swift
@@ -294,15 +294,17 @@ final class IntegrationTests: XCTestCase {
         XCTAssertNoThrow(conn = try PostgresConnection.test(on: eventLoop).wait())
         defer { XCTAssertNoThrow(try conn?.close().wait()) }
 
+        let uuidString = "2c68f645-9ca6-468b-b193-ee97f241c2f8"
+
         var stream: PSQLRowStream?
         XCTAssertNoThrow(stream = try conn?.query("""
-            SELECT '2c68f645-9ca6-468b-b193-ee97f241c2f8'::UUID as uuid
+            SELECT \(uuidString)::UUID as uuid
             """, logger: .psqlTest).wait())
 
         var rows: [PostgresRow]?
         XCTAssertNoThrow(rows = try stream?.all().wait())
         XCTAssertEqual(rows?.count, 1)
-        XCTAssertEqual(try rows?.first?.decode(UUID.self, context: .default), UUID(uuidString: "2c68f645-9ca6-468b-b193-ee97f241c2f8"))
+        XCTAssertEqual(try rows?.first?.decode(UUID.self, context: .default), UUID(uuidString: uuidString))
     }
 
     func testRoundTripJSONB() {

--- a/Tests/PostgresNIOTests/New/Data/Array+PSQLCodableTests.swift
+++ b/Tests/PostgresNIOTests/New/Data/Array+PSQLCodableTests.swift
@@ -7,54 +7,54 @@ class Array_PSQLCodableTests: XCTestCase {
     func testArrayTypes() {
 
         XCTAssertEqual(Bool.psqlArrayType, .boolArray)
-        XCTAssertEqual(Bool.psqlArrayElementType, .bool)
-        XCTAssertEqual([Bool]().psqlType, .boolArray)
+        XCTAssertEqual(Bool.psqlType, .bool)
+        XCTAssertEqual([Bool].psqlType, .boolArray)
 
         XCTAssertEqual(ByteBuffer.psqlArrayType, .byteaArray)
-        XCTAssertEqual(ByteBuffer.psqlArrayElementType, .bytea)
-        XCTAssertEqual([ByteBuffer]().psqlType, .byteaArray)
+        XCTAssertEqual(ByteBuffer.psqlType, .bytea)
+        XCTAssertEqual([ByteBuffer].psqlType, .byteaArray)
 
         XCTAssertEqual(UInt8.psqlArrayType, .charArray)
-        XCTAssertEqual(UInt8.psqlArrayElementType, .char)
-        XCTAssertEqual([UInt8]().psqlType, .charArray)
+        XCTAssertEqual(UInt8.psqlType, .char)
+        XCTAssertEqual([UInt8].psqlType, .charArray)
 
         XCTAssertEqual(Int16.psqlArrayType, .int2Array)
-        XCTAssertEqual(Int16.psqlArrayElementType, .int2)
-        XCTAssertEqual([Int16]().psqlType, .int2Array)
+        XCTAssertEqual(Int16.psqlType, .int2)
+        XCTAssertEqual([Int16].psqlType, .int2Array)
 
         XCTAssertEqual(Int32.psqlArrayType, .int4Array)
-        XCTAssertEqual(Int32.psqlArrayElementType, .int4)
-        XCTAssertEqual([Int32]().psqlType, .int4Array)
+        XCTAssertEqual(Int32.psqlType, .int4)
+        XCTAssertEqual([Int32].psqlType, .int4Array)
 
         XCTAssertEqual(Int64.psqlArrayType, .int8Array)
-        XCTAssertEqual(Int64.psqlArrayElementType, .int8)
-        XCTAssertEqual([Int64]().psqlType, .int8Array)
+        XCTAssertEqual(Int64.psqlType, .int8)
+        XCTAssertEqual([Int64].psqlType, .int8Array)
         
         #if (arch(i386) || arch(arm))
         XCTAssertEqual(Int.psqlArrayType, .int4Array)
-        XCTAssertEqual(Int.psqlArrayElementType, .int4)
-        XCTAssertEqual([Int]().psqlType, .int4Array)
+        XCTAssertEqual(Int.psqlType, .int4)
+        XCTAssertEqual([Int].psqlType, .int4Array)
         #else
         XCTAssertEqual(Int.psqlArrayType, .int8Array)
-        XCTAssertEqual(Int.psqlArrayElementType, .int8)
-        XCTAssertEqual([Int]().psqlType, .int8Array)
+        XCTAssertEqual(Int.psqlType, .int8)
+        XCTAssertEqual([Int].psqlType, .int8Array)
         #endif
 
         XCTAssertEqual(Float.psqlArrayType, .float4Array)
-        XCTAssertEqual(Float.psqlArrayElementType, .float4)
-        XCTAssertEqual([Float]().psqlType, .float4Array)
+        XCTAssertEqual(Float.psqlType, .float4)
+        XCTAssertEqual([Float].psqlType, .float4Array)
 
         XCTAssertEqual(Double.psqlArrayType, .float8Array)
-        XCTAssertEqual(Double.psqlArrayElementType, .float8)
-        XCTAssertEqual([Double]().psqlType, .float8Array)
+        XCTAssertEqual(Double.psqlType, .float8)
+        XCTAssertEqual([Double].psqlType, .float8Array)
 
         XCTAssertEqual(String.psqlArrayType, .textArray)
-        XCTAssertEqual(String.psqlArrayElementType, .text)
-        XCTAssertEqual([String]().psqlType, .textArray)
+        XCTAssertEqual(String.psqlType, .text)
+        XCTAssertEqual([String].psqlType, .textArray)
 
         XCTAssertEqual(UUID.psqlArrayType, .uuidArray)
-        XCTAssertEqual(UUID.psqlArrayElementType, .uuid)
-        XCTAssertEqual([UUID]().psqlType, .uuidArray)
+        XCTAssertEqual(UUID.psqlType, .uuid)
+        XCTAssertEqual([UUID].psqlType, .uuidArray)
     }
     
     func testStringArrayRoundTrip() {
@@ -83,7 +83,7 @@ class Array_PSQLCodableTests: XCTestCase {
         var buffer = ByteBuffer()
         buffer.writeInteger(Int32(2)) // invalid value
         buffer.writeInteger(Int32(0))
-        buffer.writeInteger(String.psqlArrayElementType.rawValue)
+        buffer.writeInteger(String.psqlType.rawValue)
         
         XCTAssertThrowsError(try [String](from: &buffer, type: .textArray, format: .binary, context: .default)) {
             XCTAssertEqual($0 as? PostgresCastingError.Code, .failure)
@@ -94,7 +94,7 @@ class Array_PSQLCodableTests: XCTestCase {
         var buffer = ByteBuffer()
         buffer.writeInteger(Int32(0)) // is empty
         buffer.writeInteger(Int32(1)) // invalid value, must always be 0
-        buffer.writeInteger(String.psqlArrayElementType.rawValue)
+        buffer.writeInteger(String.psqlType.rawValue)
         
         XCTAssertThrowsError(try [String](from: &buffer, type: .textArray, format: .binary, context: .default)) {
             XCTAssertEqual($0 as? PostgresCastingError.Code, .failure)
@@ -115,7 +115,7 @@ class Array_PSQLCodableTests: XCTestCase {
         var buffer = ByteBuffer()
         buffer.writeInteger(Int32(1)) // invalid value
         buffer.writeInteger(Int32(0))
-        buffer.writeInteger(String.psqlArrayElementType.rawValue)
+        buffer.writeInteger(String.psqlType.rawValue)
         buffer.writeInteger(Int32(-123)) // expected element count
         buffer.writeInteger(Int32(1)) // dimensions... must be one
 
@@ -128,7 +128,7 @@ class Array_PSQLCodableTests: XCTestCase {
         var buffer = ByteBuffer()
         buffer.writeInteger(Int32(1)) // invalid value
         buffer.writeInteger(Int32(0))
-        buffer.writeInteger(String.psqlArrayElementType.rawValue)
+        buffer.writeInteger(String.psqlType.rawValue)
         buffer.writeInteger(Int32(1)) // expected element count
         buffer.writeInteger(Int32(2)) // dimensions... must be one
         
@@ -141,7 +141,7 @@ class Array_PSQLCodableTests: XCTestCase {
         var unexpectedEndInElementLengthBuffer = ByteBuffer()
         unexpectedEndInElementLengthBuffer.writeInteger(Int32(1)) // invalid value
         unexpectedEndInElementLengthBuffer.writeInteger(Int32(0))
-        unexpectedEndInElementLengthBuffer.writeInteger(String.psqlArrayElementType.rawValue)
+        unexpectedEndInElementLengthBuffer.writeInteger(String.psqlType.rawValue)
         unexpectedEndInElementLengthBuffer.writeInteger(Int32(1)) // expected element count
         unexpectedEndInElementLengthBuffer.writeInteger(Int32(1)) // dimensions
         unexpectedEndInElementLengthBuffer.writeInteger(Int16(1)) // length of element, must be Int32
@@ -153,7 +153,7 @@ class Array_PSQLCodableTests: XCTestCase {
         var unexpectedEndInElementBuffer = ByteBuffer()
         unexpectedEndInElementBuffer.writeInteger(Int32(1)) // invalid value
         unexpectedEndInElementBuffer.writeInteger(Int32(0))
-        unexpectedEndInElementBuffer.writeInteger(String.psqlArrayElementType.rawValue)
+        unexpectedEndInElementBuffer.writeInteger(String.psqlType.rawValue)
         unexpectedEndInElementBuffer.writeInteger(Int32(1)) // expected element count
         unexpectedEndInElementBuffer.writeInteger(Int32(1)) // dimensions
         unexpectedEndInElementBuffer.writeInteger(Int32(12)) // length of element, must be Int32

--- a/Tests/PostgresNIOTests/New/Data/Bool+PSQLCodableTests.swift
+++ b/Tests/PostgresNIOTests/New/Data/Bool+PSQLCodableTests.swift
@@ -11,8 +11,8 @@ class Bool_PSQLCodableTests: XCTestCase {
         
         var buffer = ByteBuffer()
         value.encode(into: &buffer, context: .default)
-        XCTAssertEqual(value.psqlType, .bool)
-        XCTAssertEqual(value.psqlFormat, .binary)
+        XCTAssertEqual(Bool.psqlType, .bool)
+        XCTAssertEqual(Bool.psqlFormat, .binary)
         XCTAssertEqual(buffer.readableBytes, 1)
         XCTAssertEqual(buffer.getInteger(at: buffer.readerIndex, as: UInt8.self), 1)
         
@@ -26,8 +26,8 @@ class Bool_PSQLCodableTests: XCTestCase {
         
         var buffer = ByteBuffer()
         value.encode(into: &buffer, context: .default)
-        XCTAssertEqual(value.psqlType, .bool)
-        XCTAssertEqual(value.psqlFormat, .binary)
+        XCTAssertEqual(Bool.psqlType, .bool)
+        XCTAssertEqual(Bool.psqlFormat, .binary)
         XCTAssertEqual(buffer.readableBytes, 1)
         XCTAssertEqual(buffer.getInteger(at: buffer.readerIndex, as: UInt8.self), 0)
 

--- a/Tests/PostgresNIOTests/New/Data/Bytes+PSQLCodableTests.swift
+++ b/Tests/PostgresNIOTests/New/Data/Bytes+PSQLCodableTests.swift
@@ -9,7 +9,7 @@ class Bytes_PSQLCodableTests: XCTestCase {
         
         var buffer = ByteBuffer()
         data.encode(into: &buffer, context: .default)
-        XCTAssertEqual(data.psqlType, .bytea)
+        XCTAssertEqual(ByteBuffer.psqlType, .bytea)
         
         var result: Data?
         result = Data(from: &buffer, type: .bytea, format: .binary, context: .default)
@@ -21,7 +21,7 @@ class Bytes_PSQLCodableTests: XCTestCase {
         
         var buffer = ByteBuffer()
         bytes.encode(into: &buffer, context: .default)
-        XCTAssertEqual(bytes.psqlType, .bytea)
+        XCTAssertEqual(ByteBuffer.psqlType, .bytea)
         
         var result: ByteBuffer?
         result = ByteBuffer(from: &buffer, type: .bytea, format: .binary, context: .default)
@@ -47,7 +47,7 @@ class Bytes_PSQLCodableTests: XCTestCase {
         let sequence = ByteSequence()
         var buffer = ByteBuffer()
         sequence.encode(into: &buffer, context: .default)
-        XCTAssertEqual(sequence.psqlType, .bytea)
+        XCTAssertEqual(ByteSequence.psqlType, .bytea)
         XCTAssertEqual(buffer.readableBytes, 256)
     }
 }

--- a/Tests/PostgresNIOTests/New/Data/Date+PSQLCodableTests.swift
+++ b/Tests/PostgresNIOTests/New/Data/Date+PSQLCodableTests.swift
@@ -9,7 +9,7 @@ class Date_PSQLCodableTests: XCTestCase {
         
         var buffer = ByteBuffer()
         value.encode(into: &buffer, context: .default)
-        XCTAssertEqual(value.psqlType, .timestamptz)
+        XCTAssertEqual(Date.psqlType, .timestamptz)
         XCTAssertEqual(buffer.readableBytes, 8)
 
         var result: Date?

--- a/Tests/PostgresNIOTests/New/Data/Decimal+PSQLCodableTests.swift
+++ b/Tests/PostgresNIOTests/New/Data/Decimal+PSQLCodableTests.swift
@@ -10,7 +10,7 @@ class Decimal_PSQLCodableTests: XCTestCase {
         for value in values {
             var buffer = ByteBuffer()
             value.encode(into: &buffer, context: .default)
-            XCTAssertEqual(value.psqlType, .numeric)
+            XCTAssertEqual(Decimal.psqlType, .numeric)
 
             var result: Decimal?
             XCTAssertNoThrow(result = try Decimal(from: &buffer, type: .numeric, format: .binary, context: .default))

--- a/Tests/PostgresNIOTests/New/Data/Float+PSQLCodableTests.swift
+++ b/Tests/PostgresNIOTests/New/Data/Float+PSQLCodableTests.swift
@@ -10,7 +10,7 @@ class Float_PSQLCodableTests: XCTestCase {
         for value in values {
             var buffer = ByteBuffer()
             value.encode(into: &buffer, context: .default)
-            XCTAssertEqual(value.psqlType, .float8)
+            XCTAssertEqual(Double.psqlType, .float8)
             XCTAssertEqual(buffer.readableBytes, 8)
 
             var result: Double?
@@ -25,7 +25,7 @@ class Float_PSQLCodableTests: XCTestCase {
         for value in values {
             var buffer = ByteBuffer()
             value.encode(into: &buffer, context: .default)
-            XCTAssertEqual(value.psqlType, .float4)
+            XCTAssertEqual(Float.psqlType, .float4)
             XCTAssertEqual(buffer.readableBytes, 4)
 
             var result: Float?
@@ -39,7 +39,7 @@ class Float_PSQLCodableTests: XCTestCase {
         
         var buffer = ByteBuffer()
         value.encode(into: &buffer, context: .default)
-        XCTAssertEqual(value.psqlType, .float8)
+        XCTAssertEqual(Double.psqlType, .float8)
         XCTAssertEqual(buffer.readableBytes, 8)
 
         var result: Double?
@@ -52,7 +52,7 @@ class Float_PSQLCodableTests: XCTestCase {
         
         var buffer = ByteBuffer()
         value.encode(into: &buffer, context: .default)
-        XCTAssertEqual(value.psqlType, .float8)
+        XCTAssertEqual(Double.psqlType, .float8)
         XCTAssertEqual(buffer.readableBytes, 8)
 
         var result: Double?
@@ -66,7 +66,7 @@ class Float_PSQLCodableTests: XCTestCase {
         for value in values {
             var buffer = ByteBuffer()
             value.encode(into: &buffer, context: .default)
-            XCTAssertEqual(value.psqlType, .float4)
+            XCTAssertEqual(Float.psqlType, .float4)
             XCTAssertEqual(buffer.readableBytes, 4)
 
             var result: Double?
@@ -81,7 +81,7 @@ class Float_PSQLCodableTests: XCTestCase {
         for value in values {
             var buffer = ByteBuffer()
             value.encode(into: &buffer, context: .default)
-            XCTAssertEqual(value.psqlType, .float8)
+            XCTAssertEqual(Double.psqlType, .float8)
             XCTAssertEqual(buffer.readableBytes, 8)
 
             var result: Float?

--- a/Tests/PostgresNIOTests/New/Data/JSON+PSQLCodableTests.swift
+++ b/Tests/PostgresNIOTests/New/Data/JSON+PSQLCodableTests.swift
@@ -16,7 +16,7 @@ class JSON_PSQLCodableTests: XCTestCase {
         var buffer = ByteBuffer()
         let hello = Hello(name: "world")
         XCTAssertNoThrow(try hello.encode(into: &buffer, context: .default))
-        XCTAssertEqual(hello.psqlType, .jsonb)
+        XCTAssertEqual(Hello.psqlType, .jsonb)
         
         // verify jsonb prefix byte
         XCTAssertEqual(buffer.getInteger(at: buffer.readerIndex, as: UInt8.self), 1)

--- a/Tests/PostgresNIOTests/New/Data/RawRepresentable+PSQLCodableTests.swift
+++ b/Tests/PostgresNIOTests/New/Data/RawRepresentable+PSQLCodableTests.swift
@@ -16,11 +16,11 @@ class RawRepresentable_PSQLCodableTests: XCTestCase {
         for value in values {
             var buffer = ByteBuffer()
             XCTAssertNoThrow(try value.encode(into: &buffer, context: .default))
-            XCTAssertEqual(value.psqlType, Int16.psqlArrayElementType)
+            XCTAssertEqual(MyRawRepresentable.psqlType, Int16.psqlType)
             XCTAssertEqual(buffer.readableBytes, 2)
 
             var result: MyRawRepresentable?
-            XCTAssertNoThrow(result = try MyRawRepresentable(from: &buffer, type: Int16.psqlArrayElementType, format: .binary, context: .default))
+            XCTAssertNoThrow(result = try MyRawRepresentable(from: &buffer, type: Int16.psqlType, format: .binary, context: .default))
             XCTAssertEqual(value, result)
         }
     }
@@ -29,7 +29,7 @@ class RawRepresentable_PSQLCodableTests: XCTestCase {
         var buffer = ByteBuffer()
         buffer.writeInteger(Int16(4)) // out of bounds
 
-        XCTAssertThrowsError(try MyRawRepresentable(from: &buffer, type: Int16.psqlArrayElementType, format: .binary, context: .default)) {
+        XCTAssertThrowsError(try MyRawRepresentable(from: &buffer, type: Int16.psqlType, format: .binary, context: .default)) {
             XCTAssertEqual($0 as? PostgresCastingError.Code, .failure)
         }
     }
@@ -38,7 +38,7 @@ class RawRepresentable_PSQLCodableTests: XCTestCase {
         var buffer = ByteBuffer()
         buffer.writeInteger(Int32(1)) // out of bounds
 
-        XCTAssertThrowsError(try MyRawRepresentable(from: &buffer, type: Int32.psqlArrayElementType, format: .binary, context: .default)) {
+        XCTAssertThrowsError(try MyRawRepresentable(from: &buffer, type: Int32.psqlType, format: .binary, context: .default)) {
             XCTAssertEqual($0 as? PostgresCastingError.Code, .failure)
         }
     }

--- a/Tests/PostgresNIOTests/New/Data/String+PSQLCodableTests.swift
+++ b/Tests/PostgresNIOTests/New/Data/String+PSQLCodableTests.swift
@@ -10,7 +10,7 @@ class String_PSQLCodableTests: XCTestCase {
         
         value.encode(into: &buffer, context: .default)
         
-        XCTAssertEqual(value.psqlType, .text)
+        XCTAssertEqual(String.psqlType, .text)
         XCTAssertEqual(buffer.readString(length: buffer.readableBytes), value)
     }
     

--- a/Tests/PostgresNIOTests/New/Data/UUID+PSQLCodableTests.swift
+++ b/Tests/PostgresNIOTests/New/Data/UUID+PSQLCodableTests.swift
@@ -11,8 +11,8 @@ class UUID_PSQLCodableTests: XCTestCase {
             
             uuid.encode(into: &buffer, context: .default)
             
-            XCTAssertEqual(uuid.psqlType, .uuid)
-            XCTAssertEqual(uuid.psqlFormat, .binary)
+            XCTAssertEqual(UUID.psqlType, .uuid)
+            XCTAssertEqual(UUID.psqlFormat, .binary)
             XCTAssertEqual(buffer.readableBytes, 16)
             var byteIterator = buffer.readableBytesView.makeIterator()
             


### PR DESCRIPTION
### Motivation

To finally land async/await support we still need PostgresEncodable to be public

### Changes

- make properties on `PostgresEncodable` static again
  - make `var psqlType: PostgresDataType` static
  - make `var psqlFormat: PostgresFormat` static
  - The reason for this change is fairly simple: We needed the behavior on an instance of an object to allow PostgresData to be `PostgresEncodable`. However we encode `PostgresData` directly into `PostgresBindings` today. For this reason we can make the properties static again.
  - the properties are still prefixed `psql`... Sadly we can't use `postgres` here as this would collide with the `PostgresDataConvertible` protocol
- Rename protocol `PostgresArrayElement` to `PostgresArrayEncodable`
- Make `PostgresEncodable` and `PostgresArrayEncodable` public

### Result

One final PR is needed to make async queries public.