### PR TITLE
Make DataRow Sendable

### DIFF
--- a/Sources/PostgresNIO/New/Messages/DataRow.swift
+++ b/Sources/PostgresNIO/New/Messages/DataRow.swift
@@ -1,4 +1,8 @@
+#if swift(>=5.6)
+@preconcurrency import NIOCore
+#else
 import NIOCore
+#endif
 
 /// A backend data row message.
 ///
@@ -116,3 +120,7 @@ extension DataRow {
         return self[byteIndex]
     }
 }
+
+#if swift(>=5.6)
+extension DataRow: Sendable {}
+#endif


### PR DESCRIPTION
### Motivation

For Swift 5.6, we want to support Sendable checks. `DataRow` generates a lot of warnings in CI today.

### Changes

- Make `DataRow` `Sendable`