### PR TITLE
Rename PostgresChannelHandler

### DIFF
--- a/Sources/PostgresNIO/Connection/PostgresConnection.swift
+++ b/Sources/PostgresNIO/Connection/PostgresConnection.swift
@@ -170,7 +170,7 @@ public final class PostgresConnection {
             }
         }
 
-        let channelHandler = PSQLChannelHandler(
+        let channelHandler = PostgresChannelHandler(
             configuration: configuration,
             logger: logger,
             configureSSLCallback: configureSSLCallback
@@ -576,7 +576,7 @@ extension PostgresConnection {
 
         let listenContext = PostgresListenContext()
 
-        self.channel.pipeline.handler(type: PSQLChannelHandler.self).whenSuccess { handler in
+        self.channel.pipeline.handler(type: PostgresChannelHandler.self).whenSuccess { handler in
             if self.notificationListeners[channel] != nil {
                 self.notificationListeners[channel]!.append((listenContext, notificationHandler))
             }

--- a/Sources/PostgresNIO/New/PSQLEventsHandler.swift
+++ b/Sources/PostgresNIO/New/PSQLEventsHandler.swift
@@ -3,7 +3,7 @@ import NIOTLS
 import Logging
 
 enum PSQLOutgoingEvent {    
-    /// the event we send down the channel to inform the `PSQLChannelHandler` to authenticate
+    /// the event we send down the channel to inform the ``PostgresChannelHandler`` to authenticate
     ///
     /// this shall be removed with the next breaking change and always supplied with `PSQLConnection.Configuration`
     case authenticate(AuthContext)
@@ -11,10 +11,10 @@ enum PSQLOutgoingEvent {
 
 enum PSQLEvent {
     
-    /// the event that is used to inform upstream handlers that `PSQLChannelHandler` has established a connection
+    /// the event that is used to inform upstream handlers that ``PostgresChannelHandler`` has established a connection
     case readyForStartup
     
-    /// the event that is used to inform upstream handlers that `PSQLChannelHandler` is currently idle
+    /// the event that is used to inform upstream handlers that ``PostgresChannelHandler`` is currently idle
     case readyForQuery
 }
 

--- a/Sources/PostgresNIO/New/PostgresChannelHandler.swift
+++ b/Sources/PostgresNIO/New/PostgresChannelHandler.swift
@@ -7,7 +7,7 @@ protocol PSQLChannelHandlerNotificationDelegate: AnyObject {
     func notificationReceived(_: PostgresBackendMessage.NotificationResponse)
 }
 
-final class PSQLChannelHandler: ChannelDuplexHandler {
+final class PostgresChannelHandler: ChannelDuplexHandler {
     typealias OutboundIn = PSQLTask
     typealias InboundIn = ByteBuffer
     typealias OutboundOut = ByteBuffer
@@ -501,7 +501,7 @@ final class PSQLChannelHandler: ChannelDuplexHandler {
     }
 }
 
-extension PSQLChannelHandler: PSQLRowsDataSource {
+extension PostgresChannelHandler: PSQLRowsDataSource {
     func request(for stream: PSQLRowStream) {
         guard self.rowStream === stream else {
             return
@@ -587,7 +587,7 @@ extension ConnectionStateMachine.TLSConfiguration {
     }
 }
 
-extension PSQLChannelHandler {
+extension PostgresChannelHandler {
     convenience init(
         configuration: PostgresConnection.InternalConfiguration,
         configureSSLCallback: ((Channel) throws -> Void)?)

--- a/Tests/PostgresNIOTests/New/PostgresChannelHandlerTests.swift
+++ b/Tests/PostgresNIOTests/New/PostgresChannelHandlerTests.swift
@@ -5,13 +5,13 @@ import NIOSSL
 import NIOEmbedded
 @testable import PostgresNIO
 
-class PSQLChannelHandlerTests: XCTestCase {
+class PostgresChannelHandlerTests: XCTestCase {
     
     // MARK: Startup
     
     func testHandlerAddedWithoutSSL() {
         let config = self.testConnectionConfiguration()
-        let handler = PSQLChannelHandler(configuration: config, configureSSLCallback: nil)
+        let handler = PostgresChannelHandler(configuration: config, configureSSLCallback: nil)
         let embedded = EmbeddedChannel(handlers: [
             ReverseByteToMessageHandler(PSQLFrontendMessageDecoder()),
             ReverseMessageToByteHandler(PSQLBackendMessageEncoder()),
@@ -40,7 +40,7 @@ class PSQLChannelHandlerTests: XCTestCase {
         var config = self.testConnectionConfiguration()
         XCTAssertNoThrow(config.tls = .require(try NIOSSLContext(configuration: .makeClientConfiguration())))
         var addSSLCallbackIsHit = false
-        let handler = PSQLChannelHandler(configuration: config) { channel in
+        let handler = PostgresChannelHandler(configuration: config) { channel in
             addSSLCallbackIsHit = true
         }
         let embedded = EmbeddedChannel(handlers: [
@@ -82,7 +82,7 @@ class PSQLChannelHandlerTests: XCTestCase {
         var config = self.testConnectionConfiguration()
         XCTAssertNoThrow(config.tls = .require(try NIOSSLContext(configuration: .makeClientConfiguration())))
         
-        let handler = PSQLChannelHandler(configuration: config) { channel in
+        let handler = PostgresChannelHandler(configuration: config) { channel in
             XCTFail("This callback should never be exectuded")
             throw PSQLError.sslUnsupported
         }
@@ -118,7 +118,7 @@ class PSQLChannelHandlerTests: XCTestCase {
             database: config.authentication?.database
         )
         let state = ConnectionStateMachine(.waitingToStartAuthentication)
-        let handler = PSQLChannelHandler(configuration: config, state: state, configureSSLCallback: nil)
+        let handler = PostgresChannelHandler(configuration: config, state: state, configureSSLCallback: nil)
         let embedded = EmbeddedChannel(handlers: [
             ReverseByteToMessageHandler(PSQLFrontendMessageDecoder()),
             ReverseMessageToByteHandler(PSQLBackendMessageEncoder()),
@@ -147,7 +147,7 @@ class PSQLChannelHandlerTests: XCTestCase {
             database: config.authentication?.database
         )
         let state = ConnectionStateMachine(.waitingToStartAuthentication)
-        let handler = PSQLChannelHandler(configuration: config, state: state, configureSSLCallback: nil)
+        let handler = PostgresChannelHandler(configuration: config, state: state, configureSSLCallback: nil)
         let embedded = EmbeddedChannel(handlers: [
             ReverseByteToMessageHandler(PSQLFrontendMessageDecoder()),
             ReverseMessageToByteHandler(PSQLBackendMessageEncoder()),


### PR DESCRIPTION
Same old story: Drop PSQL prefix, use Postgres prefix.