### PR TITLE
Rename PostgresBackendMessageDecoder

### DIFF
--- a/Sources/PostgresNIO/New/PSQLChannelHandler.swift
+++ b/Sources/PostgresNIO/New/PSQLChannelHandler.swift
@@ -24,7 +24,7 @@ final class PSQLChannelHandler: ChannelDuplexHandler {
     /// The context is captured in `handlerAdded` and released` in `handlerRemoved`
     private var handlerContext: ChannelHandlerContext!
     private var rowStream: PSQLRowStream?
-    private var decoder: NIOSingleStepByteToMessageProcessor<PSQLBackendMessageDecoder>
+    private var decoder: NIOSingleStepByteToMessageProcessor<PostgresBackendMessageDecoder>
     private var encoder: BufferedMessageEncoder!
     private let configuration: PostgresConnection.InternalConfiguration
     private let configureSSLCallback: ((Channel) throws -> Void)?
@@ -40,7 +40,7 @@ final class PSQLChannelHandler: ChannelDuplexHandler {
         self.configuration = configuration
         self.configureSSLCallback = configureSSLCallback
         self.logger = logger
-        self.decoder = NIOSingleStepByteToMessageProcessor(PSQLBackendMessageDecoder())
+        self.decoder = NIOSingleStepByteToMessageProcessor(PostgresBackendMessageDecoder())
     }
     
     #if DEBUG
@@ -54,7 +54,7 @@ final class PSQLChannelHandler: ChannelDuplexHandler {
         self.configuration = configuration
         self.configureSSLCallback = configureSSLCallback
         self.logger = logger
-        self.decoder = NIOSingleStepByteToMessageProcessor(PSQLBackendMessageDecoder())
+        self.decoder = NIOSingleStepByteToMessageProcessor(PostgresBackendMessageDecoder())
     }
     #endif
 

--- a/Sources/PostgresNIO/New/PostgresBackendMessageDecoder.swift
+++ b/Sources/PostgresNIO/New/PostgresBackendMessageDecoder.swift
@@ -1,4 +1,4 @@
-struct PSQLBackendMessageDecoder: NIOSingleStepByteToMessageDecoder {
+struct PostgresBackendMessageDecoder: NIOSingleStepByteToMessageDecoder {
     typealias InboundOut = PostgresBackendMessage
     
     private(set) var hasAlreadyReceivedBytes: Bool

--- a/Tests/PostgresNIOTests/New/Messages/AuthenticationTests.swift
+++ b/Tests/PostgresNIOTests/New/Messages/AuthenticationTests.swift
@@ -40,6 +40,6 @@ class AuthenticationTests: XCTestCase {
         
         XCTAssertNoThrow(try ByteToMessageDecoderVerifier.verifyDecoder(
             inputOutputPairs: [(buffer, expected)],
-            decoderFactory: { PSQLBackendMessageDecoder(hasAlreadyReceivedBytes: false) }))
+            decoderFactory: { PostgresBackendMessageDecoder(hasAlreadyReceivedBytes: false) }))
     }
 }

--- a/Tests/PostgresNIOTests/New/Messages/BackendKeyDataTests.swift
+++ b/Tests/PostgresNIOTests/New/Messages/BackendKeyDataTests.swift
@@ -16,7 +16,7 @@ class BackendKeyDataTests: XCTestCase {
         
         XCTAssertNoThrow(try ByteToMessageDecoderVerifier.verifyDecoder(
             inputOutputPairs: expectedInOuts,
-            decoderFactory: { PSQLBackendMessageDecoder(hasAlreadyReceivedBytes: false) }))
+            decoderFactory: { PostgresBackendMessageDecoder(hasAlreadyReceivedBytes: false) }))
     }
     
     func testDecodeInvalidLength() {
@@ -32,7 +32,7 @@ class BackendKeyDataTests: XCTestCase {
         
         XCTAssertThrowsError(try ByteToMessageDecoderVerifier.verifyDecoder(
             inputOutputPairs: expected,
-            decoderFactory: { PSQLBackendMessageDecoder(hasAlreadyReceivedBytes: false) })) {
+            decoderFactory: { PostgresBackendMessageDecoder(hasAlreadyReceivedBytes: false) })) {
             XCTAssert($0 is PSQLDecodingError)
         }
     }

--- a/Tests/PostgresNIOTests/New/Messages/DataRowTests.swift
+++ b/Tests/PostgresNIOTests/New/Messages/DataRowTests.swift
@@ -28,7 +28,7 @@ class DataRowTests: XCTestCase {
 
         XCTAssertNoThrow(try ByteToMessageDecoderVerifier.verifyDecoder(
             inputOutputPairs: expectedInOuts,
-            decoderFactory: { PSQLBackendMessageDecoder(hasAlreadyReceivedBytes: false) }))
+            decoderFactory: { PostgresBackendMessageDecoder(hasAlreadyReceivedBytes: false) }))
     }
     
     func testIteratingElements() {

--- a/Tests/PostgresNIOTests/New/Messages/ErrorResponseTests.swift
+++ b/Tests/PostgresNIOTests/New/Messages/ErrorResponseTests.swift
@@ -30,6 +30,6 @@ class ErrorResponseTests: XCTestCase {
         
         XCTAssertNoThrow(try ByteToMessageDecoderVerifier.verifyDecoder(
             inputOutputPairs: expectedInOuts,
-            decoderFactory: { PSQLBackendMessageDecoder(hasAlreadyReceivedBytes: false) }))
+            decoderFactory: { PostgresBackendMessageDecoder(hasAlreadyReceivedBytes: false) }))
     }
 }

--- a/Tests/PostgresNIOTests/New/Messages/NotificationResponseTests.swift
+++ b/Tests/PostgresNIOTests/New/Messages/NotificationResponseTests.swift
@@ -27,7 +27,7 @@ class NotificationResponseTests: XCTestCase {
         
         XCTAssertNoThrow(try ByteToMessageDecoderVerifier.verifyDecoder(
             inputOutputPairs: [(buffer, expected)],
-            decoderFactory: { PSQLBackendMessageDecoder(hasAlreadyReceivedBytes: true) }))
+            decoderFactory: { PostgresBackendMessageDecoder(hasAlreadyReceivedBytes: true) }))
     }
     
     func testDecodeFailureBecauseOfMissingNullTermination() {
@@ -40,7 +40,7 @@ class NotificationResponseTests: XCTestCase {
         
         XCTAssertThrowsError(try ByteToMessageDecoderVerifier.verifyDecoder(
             inputOutputPairs: [(buffer, [])],
-            decoderFactory: { PSQLBackendMessageDecoder(hasAlreadyReceivedBytes: true) })) {
+            decoderFactory: { PostgresBackendMessageDecoder(hasAlreadyReceivedBytes: true) })) {
             XCTAssert($0 is PSQLDecodingError)
         }
     }
@@ -55,7 +55,7 @@ class NotificationResponseTests: XCTestCase {
         
         XCTAssertThrowsError(try ByteToMessageDecoderVerifier.verifyDecoder(
             inputOutputPairs: [(buffer, [])],
-            decoderFactory: { PSQLBackendMessageDecoder(hasAlreadyReceivedBytes: true) })) {
+            decoderFactory: { PostgresBackendMessageDecoder(hasAlreadyReceivedBytes: true) })) {
             XCTAssert($0 is PSQLDecodingError)
         }
     }

--- a/Tests/PostgresNIOTests/New/Messages/ParameterDescriptionTests.swift
+++ b/Tests/PostgresNIOTests/New/Messages/ParameterDescriptionTests.swift
@@ -27,7 +27,7 @@ class ParameterDescriptionTests: XCTestCase {
         
         XCTAssertNoThrow(try ByteToMessageDecoderVerifier.verifyDecoder(
             inputOutputPairs: [(buffer, expected)],
-            decoderFactory: { PSQLBackendMessageDecoder(hasAlreadyReceivedBytes: true) }))
+            decoderFactory: { PostgresBackendMessageDecoder(hasAlreadyReceivedBytes: true) }))
     }
     
     func testDecodeWithNegativeCount() {
@@ -43,7 +43,7 @@ class ParameterDescriptionTests: XCTestCase {
         
         XCTAssertThrowsError(try ByteToMessageDecoderVerifier.verifyDecoder(
             inputOutputPairs: [(buffer, [])],
-            decoderFactory: { PSQLBackendMessageDecoder(hasAlreadyReceivedBytes: true) })) {
+            decoderFactory: { PostgresBackendMessageDecoder(hasAlreadyReceivedBytes: true) })) {
             XCTAssert($0 is PSQLDecodingError)
         }
     }
@@ -62,7 +62,7 @@ class ParameterDescriptionTests: XCTestCase {
         
         XCTAssertThrowsError(try ByteToMessageDecoderVerifier.verifyDecoder(
             inputOutputPairs: [(buffer, [])],
-            decoderFactory: { PSQLBackendMessageDecoder(hasAlreadyReceivedBytes: true) })) {
+            decoderFactory: { PostgresBackendMessageDecoder(hasAlreadyReceivedBytes: true) })) {
             XCTAssert($0 is PSQLDecodingError)
         }
     }

--- a/Tests/PostgresNIOTests/New/Messages/ParameterStatusTests.swift
+++ b/Tests/PostgresNIOTests/New/Messages/ParameterStatusTests.swift
@@ -42,7 +42,7 @@ class ParameterStatusTests: XCTestCase {
         
         XCTAssertNoThrow(try ByteToMessageDecoderVerifier.verifyDecoder(
             inputOutputPairs: [(buffer, expected)],
-            decoderFactory: { PSQLBackendMessageDecoder(hasAlreadyReceivedBytes: true) }))
+            decoderFactory: { PostgresBackendMessageDecoder(hasAlreadyReceivedBytes: true) }))
     }
     
     func testDecodeFailureBecauseOfMissingNullTermination() {
@@ -54,7 +54,7 @@ class ParameterStatusTests: XCTestCase {
         
         XCTAssertThrowsError(try ByteToMessageDecoderVerifier.verifyDecoder(
             inputOutputPairs: [(buffer, [])],
-            decoderFactory: { PSQLBackendMessageDecoder(hasAlreadyReceivedBytes: true) })) {
+            decoderFactory: { PostgresBackendMessageDecoder(hasAlreadyReceivedBytes: true) })) {
             XCTAssert($0 is PSQLDecodingError)
         }
     }
@@ -68,7 +68,7 @@ class ParameterStatusTests: XCTestCase {
         
         XCTAssertThrowsError(try ByteToMessageDecoderVerifier.verifyDecoder(
             inputOutputPairs: [(buffer, [])],
-            decoderFactory: { PSQLBackendMessageDecoder(hasAlreadyReceivedBytes: true) })) {
+            decoderFactory: { PostgresBackendMessageDecoder(hasAlreadyReceivedBytes: true) })) {
             XCTAssert($0 is PSQLDecodingError)
         }
     }

--- a/Tests/PostgresNIOTests/New/Messages/ReadyForQueryTests.swift
+++ b/Tests/PostgresNIOTests/New/Messages/ReadyForQueryTests.swift
@@ -33,7 +33,7 @@ class ReadyForQueryTests: XCTestCase {
         
         XCTAssertNoThrow(try ByteToMessageDecoderVerifier.verifyDecoder(
             inputOutputPairs: [(buffer, expected)],
-            decoderFactory: { PSQLBackendMessageDecoder(hasAlreadyReceivedBytes: true) }))
+            decoderFactory: { PostgresBackendMessageDecoder(hasAlreadyReceivedBytes: true) }))
 
     }
     
@@ -47,7 +47,7 @@ class ReadyForQueryTests: XCTestCase {
         
         XCTAssertThrowsError(try ByteToMessageDecoderVerifier.verifyDecoder(
             inputOutputPairs: [(buffer, [])],
-            decoderFactory: { PSQLBackendMessageDecoder(hasAlreadyReceivedBytes: true) })) {
+            decoderFactory: { PostgresBackendMessageDecoder(hasAlreadyReceivedBytes: true) })) {
             XCTAssert($0 is PSQLDecodingError)
         }
     }
@@ -61,7 +61,7 @@ class ReadyForQueryTests: XCTestCase {
         
         XCTAssertThrowsError(try ByteToMessageDecoderVerifier.verifyDecoder(
             inputOutputPairs: [(buffer, [])],
-            decoderFactory: { PSQLBackendMessageDecoder(hasAlreadyReceivedBytes: true) })) {
+            decoderFactory: { PostgresBackendMessageDecoder(hasAlreadyReceivedBytes: true) })) {
             XCTAssert($0 is PSQLDecodingError)
         }
     }

--- a/Tests/PostgresNIOTests/New/Messages/RowDescriptionTests.swift
+++ b/Tests/PostgresNIOTests/New/Messages/RowDescriptionTests.swift
@@ -38,7 +38,7 @@ class RowDescriptionTests: XCTestCase {
         
         XCTAssertNoThrow(try ByteToMessageDecoderVerifier.verifyDecoder(
             inputOutputPairs: [(buffer, expected)],
-            decoderFactory: { PSQLBackendMessageDecoder(hasAlreadyReceivedBytes: true) }))
+            decoderFactory: { PostgresBackendMessageDecoder(hasAlreadyReceivedBytes: true) }))
     }
     
     func testDecodeFailureBecauseOfMissingNullTerminationInColumnName() {
@@ -59,7 +59,7 @@ class RowDescriptionTests: XCTestCase {
         
         XCTAssertThrowsError(try ByteToMessageDecoderVerifier.verifyDecoder(
             inputOutputPairs: [(buffer, [])],
-            decoderFactory: { PSQLBackendMessageDecoder(hasAlreadyReceivedBytes: true) })) {
+            decoderFactory: { PostgresBackendMessageDecoder(hasAlreadyReceivedBytes: true) })) {
             XCTAssert($0 is PSQLDecodingError)
         }
     }
@@ -81,7 +81,7 @@ class RowDescriptionTests: XCTestCase {
         
         XCTAssertThrowsError(try ByteToMessageDecoderVerifier.verifyDecoder(
             inputOutputPairs: [(buffer, [])],
-            decoderFactory: { PSQLBackendMessageDecoder(hasAlreadyReceivedBytes: true) })) {
+            decoderFactory: { PostgresBackendMessageDecoder(hasAlreadyReceivedBytes: true) })) {
             XCTAssert($0 is PSQLDecodingError)
         }
     }
@@ -104,7 +104,7 @@ class RowDescriptionTests: XCTestCase {
         
         XCTAssertThrowsError(try ByteToMessageDecoderVerifier.verifyDecoder(
             inputOutputPairs: [(buffer, [])],
-            decoderFactory: { PSQLBackendMessageDecoder(hasAlreadyReceivedBytes: true) })) {
+            decoderFactory: { PostgresBackendMessageDecoder(hasAlreadyReceivedBytes: true) })) {
             XCTAssert($0 is PSQLDecodingError)
         }
     }
@@ -127,7 +127,7 @@ class RowDescriptionTests: XCTestCase {
         
         XCTAssertThrowsError(try ByteToMessageDecoderVerifier.verifyDecoder(
             inputOutputPairs: [(buffer, [])],
-            decoderFactory: { PSQLBackendMessageDecoder(hasAlreadyReceivedBytes: true) })) {
+            decoderFactory: { PostgresBackendMessageDecoder(hasAlreadyReceivedBytes: true) })) {
             XCTAssert($0 is PSQLDecodingError)
         }
     }

--- a/Tests/PostgresNIOTests/New/PSQLBackendMessageTests.swift
+++ b/Tests/PostgresNIOTests/New/PSQLBackendMessageTests.swift
@@ -97,7 +97,7 @@ class PSQLBackendMessageTests: XCTestCase {
             expectedMessages.append(.parameterStatus(parameterStatus))
         }
         
-        let handler = ByteToMessageHandler(PSQLBackendMessageDecoder())
+        let handler = ByteToMessageHandler(PostgresBackendMessageDecoder())
         let embedded = EmbeddedChannel(handler: handler)
         XCTAssertNoThrow(try embedded.writeInbound(buffer))
         
@@ -137,7 +137,7 @@ class PSQLBackendMessageTests: XCTestCase {
             buffer.writeInteger(0, as: UInt8.self) // signal done
         }
         
-        let handler = ByteToMessageHandler(PSQLBackendMessageDecoder())
+        let handler = ByteToMessageHandler(PostgresBackendMessageDecoder())
         let embedded = EmbeddedChannel(handler: handler)
         XCTAssertNoThrow(try embedded.writeInbound(buffer))
         
@@ -174,7 +174,7 @@ class PSQLBackendMessageTests: XCTestCase {
         
         XCTAssertNoThrow(try ByteToMessageDecoderVerifier.verifyDecoder(
             inputOutputPairs: [(buffer, expected)],
-            decoderFactory: { PSQLBackendMessageDecoder(hasAlreadyReceivedBytes: false) }))
+            decoderFactory: { PostgresBackendMessageDecoder(hasAlreadyReceivedBytes: false) }))
     }
     
     func testPayloadsWithoutAssociatedValuesInvalidLength() {
@@ -195,7 +195,7 @@ class PSQLBackendMessageTests: XCTestCase {
             
             XCTAssertThrowsError(try ByteToMessageDecoderVerifier.verifyDecoder(
                 inputOutputPairs: [(buffer, [])],
-                decoderFactory: { PSQLBackendMessageDecoder(hasAlreadyReceivedBytes: false) })) {
+                decoderFactory: { PostgresBackendMessageDecoder(hasAlreadyReceivedBytes: false) })) {
                 XCTAssert($0 is PSQLDecodingError)
             }
         }
@@ -222,7 +222,7 @@ class PSQLBackendMessageTests: XCTestCase {
         
         XCTAssertNoThrow(try ByteToMessageDecoderVerifier.verifyDecoder(
             inputOutputPairs: [(okBuffer, expected)],
-            decoderFactory: { PSQLBackendMessageDecoder(hasAlreadyReceivedBytes: false) }))
+            decoderFactory: { PostgresBackendMessageDecoder(hasAlreadyReceivedBytes: false) }))
         
         // test commandTag is not null terminated
         for message in expected {
@@ -237,7 +237,7 @@ class PSQLBackendMessageTests: XCTestCase {
             
             XCTAssertThrowsError(try ByteToMessageDecoderVerifier.verifyDecoder(
                 inputOutputPairs: [(failBuffer, [])],
-                decoderFactory: { PSQLBackendMessageDecoder(hasAlreadyReceivedBytes: false) })) {
+                decoderFactory: { PostgresBackendMessageDecoder(hasAlreadyReceivedBytes: false) })) {
                 XCTAssert($0 is PSQLDecodingError)
             }
         }
@@ -250,7 +250,7 @@ class PSQLBackendMessageTests: XCTestCase {
         
         XCTAssertThrowsError(try ByteToMessageDecoderVerifier.verifyDecoder(
             inputOutputPairs: [(buffer, [])],
-            decoderFactory: { PSQLBackendMessageDecoder(hasAlreadyReceivedBytes: false) })) {
+            decoderFactory: { PostgresBackendMessageDecoder(hasAlreadyReceivedBytes: false) })) {
             XCTAssert($0 is PSQLDecodingError)
         }
     }


### PR DESCRIPTION
Same old story: Drop PSQL prefix, use Postgres prefix.