### PR TITLE
Allow unsafe raw SQL injection in PostgresQuery

### DIFF
--- a/Sources/PostgresNIO/New/PostgresQuery.swift
+++ b/Sources/PostgresNIO/New/PostgresQuery.swift
@@ -67,6 +67,11 @@ extension PostgresQuery {
             try self.binds.append(value, context: context)
             self.sql.append(contentsOf: "$\(self.binds.count)")
         }
+
+        @inlinable
+        public mutating func appendInterpolation(unescaped interpolated: String) {
+            self.sql.append(contentsOf: interpolated)
+        }
     }
 }
 


### PR DESCRIPTION
### Motivation

Sometimes developers want to have the freedom to inject values into a PostgresQuery that are not bindable. Examples for this can be tableNames or columnNames.

### Changes

- Allow adopters to interpolate raw sql into the PostgresQuery

### Result

More use-cases covered. Make unsafe code explicit unsafe.

### Open question

What is the best unsafe marker word? Right now I have `unsafeSQLInjection`. I like this because it makes potential users google for SQL injection... This is rather long. Other previously discussed options are: `raw`, `unsafeRaw`.