### PR TITLE
Continue to make forward progress when cancelled

### DIFF
--- a/Sources/PostgresNIO/New/Connection State Machine/ConnectionStateMachine.swift
+++ b/Sources/PostgresNIO/New/Connection State Machine/ConnectionStateMachine.swift
@@ -842,7 +842,15 @@ struct ConnectionStateMachine {
     // MARK: Consumer
     
     mutating func cancelQueryStream() -> ConnectionAction {
-        preconditionFailure("Unimplemented")
+        guard case .extendedQuery(var queryState, let connectionContext) = self.state, !queryState.isComplete else {
+            preconditionFailure("Tried to cancel stream, without active query")
+        }
+
+        return self.avoidingStateMachineCoW { machine -> ConnectionAction in
+            let action = queryState.cancel()
+            machine.state = .extendedQuery(queryState, connectionContext)
+            return machine.modify(with: action)
+        }
     }
     
     mutating func requestQueryRows() -> ConnectionAction {
@@ -1074,6 +1082,8 @@ extension ConnectionStateMachine {
             return true
         case .failedToAddSSLHandler:
             return true
+        case .queryCancelled:
+            return false
         case .server(let message):
             guard let sqlState = message.fields[.sqlState] else {
                 // any error message that doesn't have a sql state field, is unexpected by default.

--- a/Sources/PostgresNIO/New/Connection State Machine/ConnectionStateMachine.swift
+++ b/Sources/PostgresNIO/New/Connection State Machine/ConnectionStateMachine.swift
@@ -843,7 +843,7 @@ struct ConnectionStateMachine {
     
     mutating func cancelQueryStream() -> ConnectionAction {
         guard case .extendedQuery(var queryState, let connectionContext) = self.state, !queryState.isComplete else {
-            preconditionFailure("Tried to cancel stream, without active query")
+            preconditionFailure("Tried to cancel stream without active query")
         }
 
         return self.avoidingStateMachineCoW { machine -> ConnectionAction in

--- a/Sources/PostgresNIO/New/Connection State Machine/ExtendedQueryStateMachine.swift
+++ b/Sources/PostgresNIO/New/Connection State Machine/ExtendedQueryStateMachine.swift
@@ -15,7 +15,7 @@ struct ExtendedQueryStateMachine {
         /// used after receiving a `bindComplete` message
         case bindCompleteReceived(ExtendedQueryContext)
         case streaming([RowDescription.Column], RowStreamStateMachine)
-        /// A state that is used, if the current query was cancelled, and we want to drain rows from the connection ASAP
+        /// Indicates that the current query was cancelled and we want to drain rows from the connection ASAP
         case drain([RowDescription.Column])
         
         case commandComplete(commandTag: String)

--- a/Sources/PostgresNIO/New/Connection State Machine/ExtendedQueryStateMachine.swift
+++ b/Sources/PostgresNIO/New/Connection State Machine/ExtendedQueryStateMachine.swift
@@ -253,7 +253,7 @@ struct ExtendedQueryStateMachine {
         case .drain:
             precondition(self.isCancelled)
             self.state = .commandComplete(commandTag: commandTag)
-            return .forwardStreamComplete([], commandTag: commandTag)
+            return .wait
         
         case .initialized,
              .parseDescribeBindExecuteSyncSent,

--- a/Sources/PostgresNIO/New/Connection State Machine/ExtendedQueryStateMachine.swift
+++ b/Sources/PostgresNIO/New/Connection State Machine/ExtendedQueryStateMachine.swift
@@ -2,7 +2,7 @@ import NIOCore
 
 struct ExtendedQueryStateMachine {
     
-    enum State {
+    private enum State {
         case initialized(ExtendedQueryContext)
         case parseDescribeBindExecuteSyncSent(ExtendedQueryContext)
         
@@ -15,6 +15,8 @@ struct ExtendedQueryStateMachine {
         /// used after receiving a `bindComplete` message
         case bindCompleteReceived(ExtendedQueryContext)
         case streaming([RowDescription.Column], RowStreamStateMachine)
+        /// A state that is used, if the current query was cancelled, and we want to drain rows from the connection ASAP
+        case drain([RowDescription.Column])
         
         case commandComplete(commandTag: String)
         case error(PSQLError)
@@ -41,9 +43,11 @@ struct ExtendedQueryStateMachine {
         case wait
     }
     
-    var state: State
+    private var state: State
+    private var isCancelled: Bool
     
     init(queryContext: ExtendedQueryContext) {
+        self.isCancelled = false
         self.state = .initialized(queryContext)
     }
     
@@ -69,6 +73,44 @@ struct ExtendedQueryStateMachine {
                 }
                 return .sendBindExecuteSync(prepared)
             }
+        }
+    }
+
+    mutating func cancel() -> Action {
+        switch self.state {
+        case .initialized:
+            preconditionFailure("Start must be called immediatly after the query was created")
+
+        case .parseDescribeBindExecuteSyncSent(let queryContext),
+             .parseCompleteReceived(let queryContext),
+             .parameterDescriptionReceived(let queryContext),
+             .rowDescriptionReceived(let queryContext, _),
+             .noDataMessageReceived(let queryContext),
+             .bindCompleteReceived(let queryContext):
+            guard !self.isCancelled else {
+                return .wait
+            }
+
+            self.isCancelled = true
+            return .failQuery(queryContext, with: .queryCancelled)
+
+        case .streaming(let columns, var streamStateMachine):
+            precondition(!self.isCancelled)
+            self.isCancelled = true
+            self.state = .drain(columns)
+            switch streamStateMachine.fail() {
+            case .wait:
+                return .forwardStreamError(.queryCancelled, read: false)
+            case .read:
+                return .forwardStreamError(.queryCancelled, read: true)
+            }
+
+        case .commandComplete, .error, .drain:
+            // the stream has already finished.
+            return .wait
+
+        case .modifying:
+            preconditionFailure("Invalid state: \(self.state)")
         }
     }
     
@@ -147,9 +189,11 @@ struct ExtendedQueryStateMachine {
              .parameterDescriptionReceived,
              .bindCompleteReceived,
              .streaming,
+             .drain,
              .commandComplete,
              .error:
             return self.setAndFireError(.unexpectedBackendMessage(.bindComplete))
+
         case .modifying:
             preconditionFailure("Invalid state")
         }
@@ -169,6 +213,13 @@ struct ExtendedQueryStateMachine {
                 state = .streaming(columns, demandStateMachine)
                 return .wait
             }
+
+        case .drain(let columns):
+            guard dataRow.columnCount == columns.count else {
+                return self.setAndFireError(.unexpectedBackendMessage(.dataRow(dataRow)))
+            }
+            // we ignore all rows and wait for readyForQuery
+            return .wait
             
         case .initialized,
              .parseDescribeBindExecuteSyncSent,
@@ -198,6 +249,11 @@ struct ExtendedQueryStateMachine {
                 state = .commandComplete(commandTag: commandTag)
                 return .forwardStreamComplete(demandStateMachine.end(), commandTag: commandTag)
             }
+
+        case .drain:
+            precondition(self.isCancelled)
+            self.state = .commandComplete(commandTag: commandTag)
+            return .forwardStreamComplete([], commandTag: commandTag)
         
         case .initialized,
              .parseDescribeBindExecuteSyncSent,
@@ -229,7 +285,7 @@ struct ExtendedQueryStateMachine {
             return self.setAndFireError(error)
         case .rowDescriptionReceived, .noDataMessageReceived:
             return self.setAndFireError(error)
-        case .streaming:
+        case .streaming, .drain:
             return self.setAndFireError(error)
         case .commandComplete:
             return self.setAndFireError(.unexpectedBackendMessage(.error(errorMessage)))
@@ -269,6 +325,9 @@ struct ExtendedQueryStateMachine {
                 }
             }
 
+        case .drain:
+            return .wait
+
         case .initialized,
              .parseDescribeBindExecuteSyncSent,
              .parseCompleteReceived,
@@ -291,6 +350,7 @@ struct ExtendedQueryStateMachine {
         switch self.state {
         case .initialized,
              .commandComplete,
+             .drain,
              .error,
              .parseDescribeBindExecuteSyncSent,
              .parseCompleteReceived,
@@ -327,6 +387,7 @@ struct ExtendedQueryStateMachine {
              .bindCompleteReceived:
             return .read
         case .streaming(let columns, var demandStateMachine):
+            precondition(!self.isCancelled)
             return self.avoidingStateMachineCoW { state -> Action in
                 let action = demandStateMachine.read()
                 state = .streaming(columns, demandStateMachine)
@@ -339,6 +400,7 @@ struct ExtendedQueryStateMachine {
             }
         case .initialized,
              .commandComplete,
+             .drain,
              .error:
             // we already have the complete stream received, now we are waiting for a
             // `readyForQuery` package. To receive this we need to read!
@@ -361,10 +423,19 @@ struct ExtendedQueryStateMachine {
              .bindCompleteReceived(let context):
             self.state = .error(error)
             return .failQuery(context, with: error)
-            
-        case .streaming:
+
+        case .drain:
             self.state = .error(error)
             return .forwardStreamError(error, read: false)
+            
+        case .streaming(_, var streamStateMachine):
+            self.state = .error(error)
+            switch streamStateMachine.fail() {
+            case .wait:
+                return .forwardStreamError(error, read: false)
+            case .read:
+                return .forwardStreamError(error, read: true)
+            }
             
         case .commandComplete, .error:
             preconditionFailure("""

--- a/Sources/PostgresNIO/New/PSQLError.swift
+++ b/Sources/PostgresNIO/New/PSQLError.swift
@@ -11,7 +11,8 @@ struct PSQLError: Error {
         case unsupportedAuthMechanism(PSQLAuthScheme)
         case authMechanismRequiresPassword
         case saslError(underlyingError: Error)
-        
+
+        case queryCancelled
         case tooManyParameters
         case connectionQuiescing
         case connectionClosed
@@ -57,6 +58,10 @@ struct PSQLError: Error {
     
     static func sasl(underlying: Error) -> PSQLError {
         Self.init(.saslError(underlyingError: underlying))
+    }
+
+    static var queryCancelled: PSQLError {
+        Self.init(.queryCancelled)
     }
     
     static var tooManyParameters: PSQLError {

--- a/Sources/PostgresNIO/Postgres+PSQLCompat.swift
+++ b/Sources/PostgresNIO/Postgres+PSQLCompat.swift
@@ -3,6 +3,8 @@ import NIOCore
 extension PSQLError {
     func toPostgresError() -> Error {
         switch self.base {
+        case .queryCancelled:
+            return self
         case .server(let errorMessage):
             var fields = [PostgresMessage.Error.Field: String]()
             fields.reserveCapacity(errorMessage.fields.count)

--- a/Tests/PostgresNIOTests/New/Connection State Machine/ExtendedQueryStateMachineTests.swift
+++ b/Tests/PostgresNIOTests/New/Connection State Machine/ExtendedQueryStateMachineTests.swift
@@ -96,4 +96,89 @@ class ExtendedQueryStateMachineTests: XCTestCase {
                        .failQuery(queryContext, with: psqlError, cleanupContext: .init(action: .close, tasks: [], error: psqlError, closePromise: nil)))
     }
 
+    func testExtendedQueryIsCancelledImmediatly() {
+        var state = ConnectionStateMachine.readyForQuery()
+
+        let logger = Logger.psqlTest
+        let promise = EmbeddedEventLoop().makePromise(of: PSQLRowStream.self)
+        promise.fail(PSQLError.uncleanShutdown) // we don't care about the error at all.
+        let query: PostgresQuery = "SELECT version()"
+        let queryContext = ExtendedQueryContext(query: query, logger: logger, promise: promise)
+
+        XCTAssertEqual(state.enqueue(task: .extendedQuery(queryContext)), .sendParseDescribeBindExecuteSync(query))
+        XCTAssertEqual(state.parseCompleteReceived(), .wait)
+        XCTAssertEqual(state.parameterDescriptionReceived(.init(dataTypes: [.int8])), .wait)
+
+        // We need to ensure that even though the row description from the wire says that we
+        // will receive data in `.text` format, we will actually receive it in binary format,
+        // since we requested it in binary with our bind message.
+        let input: [RowDescription.Column] = [
+            .init(name: "version", tableOID: 0, columnAttributeNumber: 0, dataType: .text, dataTypeSize: -1, dataTypeModifier: -1, format: .text)
+        ]
+        let expected: [RowDescription.Column] = input.map {
+            .init(name: $0.name, tableOID: $0.tableOID, columnAttributeNumber: $0.columnAttributeNumber, dataType: $0.dataType,
+                  dataTypeSize: $0.dataTypeSize, dataTypeModifier: $0.dataTypeModifier, format: .binary)
+        }
+
+        XCTAssertEqual(state.rowDescriptionReceived(.init(columns: input)), .wait)
+        XCTAssertEqual(state.bindCompleteReceived(), .succeedQuery(queryContext, columns: expected))
+        XCTAssertEqual(state.cancelQueryStream(), .forwardStreamError(.queryCancelled, read: false, cleanupContext: nil))
+        XCTAssertEqual(state.dataRowReceived([ByteBuffer(string: "test1")]), .wait)
+        XCTAssertEqual(state.channelReadComplete(), .wait)
+        XCTAssertEqual(state.readEventCaught(), .read)
+
+        XCTAssertEqual(state.dataRowReceived([ByteBuffer(string: "test2")]), .wait)
+        XCTAssertEqual(state.dataRowReceived([ByteBuffer(string: "test3")]), .wait)
+        XCTAssertEqual(state.dataRowReceived([ByteBuffer(string: "test4")]), .wait)
+        XCTAssertEqual(state.channelReadComplete(), .wait)
+        XCTAssertEqual(state.readEventCaught(), .read)
+
+        XCTAssertEqual(state.channelReadComplete(), .wait)
+        XCTAssertEqual(state.readEventCaught(), .read)
+
+        XCTAssertEqual(state.commandCompletedReceived("SELECT 2"), .wait)
+        XCTAssertEqual(state.readyForQueryReceived(.idle), .fireEventReadyForQuery)
+    }
+
+    func testExtendedQueryIsCancelledWithReadPending() {
+        var state = ConnectionStateMachine.readyForQuery()
+
+        let logger = Logger.psqlTest
+        let promise = EmbeddedEventLoop().makePromise(of: PSQLRowStream.self)
+        promise.fail(PSQLError.uncleanShutdown) // we don't care about the error at all.
+        let query: PostgresQuery = "SELECT version()"
+        let queryContext = ExtendedQueryContext(query: query, logger: logger, promise: promise)
+
+        XCTAssertEqual(state.enqueue(task: .extendedQuery(queryContext)), .sendParseDescribeBindExecuteSync(query))
+        XCTAssertEqual(state.parseCompleteReceived(), .wait)
+        XCTAssertEqual(state.parameterDescriptionReceived(.init(dataTypes: [.int8])), .wait)
+
+        // We need to ensure that even though the row description from the wire says that we
+        // will receive data in `.text` format, we will actually receive it in binary format,
+        // since we requested it in binary with our bind message.
+        let input: [RowDescription.Column] = [
+            .init(name: "version", tableOID: 0, columnAttributeNumber: 0, dataType: .text, dataTypeSize: -1, dataTypeModifier: -1, format: .text)
+        ]
+        let expected: [RowDescription.Column] = input.map {
+            .init(name: $0.name, tableOID: $0.tableOID, columnAttributeNumber: $0.columnAttributeNumber, dataType: $0.dataType,
+                  dataTypeSize: $0.dataTypeSize, dataTypeModifier: $0.dataTypeModifier, format: .binary)
+        }
+
+        XCTAssertEqual(state.rowDescriptionReceived(.init(columns: input)), .wait)
+        XCTAssertEqual(state.bindCompleteReceived(), .succeedQuery(queryContext, columns: expected))
+        let row1: DataRow = [ByteBuffer(string: "test1")]
+        XCTAssertEqual(state.dataRowReceived(row1), .wait)
+        XCTAssertEqual(state.channelReadComplete(), .forwardRows([row1]))
+        XCTAssertEqual(state.readEventCaught(), .wait)
+        XCTAssertEqual(state.cancelQueryStream(), .forwardStreamError(.queryCancelled, read: true, cleanupContext: nil))
+
+        XCTAssertEqual(state.dataRowReceived([ByteBuffer(string: "test2")]), .wait)
+        XCTAssertEqual(state.dataRowReceived([ByteBuffer(string: "test3")]), .wait)
+        XCTAssertEqual(state.dataRowReceived([ByteBuffer(string: "test4")]), .wait)
+        XCTAssertEqual(state.channelReadComplete(), .wait)
+        XCTAssertEqual(state.readEventCaught(), .read)
+
+        XCTAssertEqual(state.commandCompletedReceived("SELECT 4"), .wait)
+        XCTAssertEqual(state.readyForQueryReceived(.idle), .fireEventReadyForQuery)
+    }
 }

--- a/Tests/PostgresNIOTests/New/Extensions/ConnectionAction+TestUtils.swift
+++ b/Tests/PostgresNIOTests/New/Extensions/ConnectionAction+TestUtils.swift
@@ -36,6 +36,8 @@ extension ConnectionStateMachine.ConnectionAction: Equatable {
             return lhsRows == rhsRows
         case (.forwardStreamComplete(let lhsBuffer, let lhsCommandTag), .forwardStreamComplete(let rhsBuffer, let rhsCommandTag)):
             return lhsBuffer == rhsBuffer && lhsCommandTag == rhsCommandTag
+        case (.forwardStreamError(let lhsError, let lhsRead, let lhsCleanupContext), .forwardStreamError(let rhsError , let rhsRead, let rhsCleanupContext)):
+            return lhsError == rhsError && lhsRead == rhsRead && lhsCleanupContext == rhsCleanupContext
         case (.sendParseDescribeSync(let lhsName, let lhsQuery), .sendParseDescribeSync(let rhsName, let rhsQuery)):
             return lhsName == rhsName && lhsQuery == rhsQuery
         case (.succeedPreparedStatementCreation(let lhsContext, let lhsRowDescription), .succeedPreparedStatementCreation(let rhsContext, let rhsRowDescription)):


### PR DESCRIPTION
### Motivation

With the async/await interface we introduced the option to ignore a rowStream (by dropping the `AsyncSequence` or `AsyncIterator`). In those cases we must fail the stream and drain the connection ASAP. Otherwise we will lock up the connection.

### Changes

- Drain connection, if the row stream was cancelled

### Result

Connection is reusable, even if previous queries were cancelled.

### Note:

Needs more unit tests