### PR TITLE
Add EventLoop API that uses PostgresQuery

### DIFF
--- a/Sources/PostgresNIO/New/Connection State Machine/ConnectionStateMachine.swift
+++ b/Sources/PostgresNIO/New/Connection State Machine/ConnectionStateMachine.swift
@@ -1098,6 +1098,8 @@ extension ConnectionStateMachine {
             return true
         case .tooManyParameters:
             return true
+        case .invalidCommandTag:
+            return true
         case .connectionQuiescing:
             preconditionFailure("Pure client error, that is thrown directly in PostgresConnection")
         case .connectionClosed:

--- a/Sources/PostgresNIO/New/PSQLError.swift
+++ b/Sources/PostgresNIO/New/PSQLError.swift
@@ -11,6 +11,7 @@ struct PSQLError: Error {
         case unsupportedAuthMechanism(PSQLAuthScheme)
         case authMechanismRequiresPassword
         case saslError(underlyingError: Error)
+        case invalidCommandTag(String)
         
         case tooManyParameters
         case connectionQuiescing
@@ -57,6 +58,10 @@ struct PSQLError: Error {
     
     static func sasl(underlying: Error) -> PSQLError {
         Self.init(.saslError(underlyingError: underlying))
+    }
+
+    static func invalidCommandTag(_ value: String) -> PSQLError {
+        Self.init(.invalidCommandTag(value))
     }
     
     static var tooManyParameters: PSQLError {

--- a/Sources/PostgresNIO/Postgres+PSQLCompat.swift
+++ b/Sources/PostgresNIO/Postgres+PSQLCompat.swift
@@ -24,7 +24,7 @@ extension PSQLError {
             return PostgresError.protocol("Unable to authenticate without password")
         case .saslError(underlyingError: let underlying):
             return underlying
-        case .tooManyParameters:
+        case .tooManyParameters, .invalidCommandTag:
             return self
         case .connectionQuiescing:
             return PostgresError.connectionClosed


### PR DESCRIPTION
### Motivation

I talked to @adam-fowler and he mentioned that it would be great if we would also offer a `PostgresQuery` based API for usage with EL.

### Changes

- Add better EL APIs based on `PostgresQuery`

### Result

Nicer API even for users that stay on the EL.