### PR TITLE
Remove connection state machine log

### DIFF
--- a/Sources/PostgresNIO/New/PostgresChannelHandler.swift
+++ b/Sources/PostgresNIO/New/PostgresChannelHandler.swift
@@ -13,11 +13,7 @@ final class PostgresChannelHandler: ChannelDuplexHandler {
     typealias OutboundOut = ByteBuffer
 
     private let logger: Logger
-    private var state: ConnectionStateMachine {
-        didSet {
-            self.logger.trace("Connection state changed", metadata: [.connectionState: "\(self.state)"])
-        }
-    }
+    private var state: ConnectionStateMachine
     
     /// A `ChannelHandlerContext` to be used for non channel related events. (for example: More rows needed).
     ///


### PR DESCRIPTION
### Motivation

In trace mode we log every new state machine state. This is not necessary, since our state machine can be better described through all the inputs it receives. We log those in trace mode as well. When running a query with 2m rows, I can see in Instruments that we spend about 100ms in the trace log statement that I want to remove here – even if we don't use trace logging.

### Changes

- Remove unnecessary state log

### Motivation

A bit faster code, less verbose output