### PR TITLE
Use Int(exactly:) instead of restricting to 64 bit platforms

### DIFF
--- a/Sources/PostgresNIO/Data/PostgresData+Int.swift
+++ b/Sources/PostgresNIO/Data/PostgresData+Int.swift
@@ -1,7 +1,6 @@
 extension PostgresData {
     public init(int value: Int) {
-        assert(Int.bitWidth == 64)
-        self.init(type: .int8, value: .init(integer: value))
+        self.init(type: .int8, value: .init(integer: Int64(value)))
     }
 
     public init(uint8 value: UInt8) {
@@ -32,25 +31,19 @@ extension PostgresData {
                 guard value.readableBytes == 1 else {
                     return nil
                 }
-                return value.readInteger(as: UInt8.self)
-                    .flatMap(Int.init)
+                return value.readInteger(as: UInt8.self).flatMap(Int.init)
             case .int2:
                 assert(value.readableBytes == 2)
-                return value.readInteger(as: Int16.self)
-                    .flatMap(Int.init)
+                return value.readInteger(as: Int16.self).flatMap(Int.init)
             case .int4, .regproc:
                 assert(value.readableBytes == 4)
-                return value.readInteger(as: Int32.self)
-                    .flatMap(Int.init)
+                return value.readInteger(as: Int32.self).flatMap(Int.init)
             case .oid:
                 assert(value.readableBytes == 4)
-                assert(Int.bitWidth == 64) // or else overflow is possible
-                return value.readInteger(as: UInt32.self)
-                    .flatMap(Int.init)
+                return value.readInteger(as: UInt32.self).flatMap { Int(exactly: $0) }
             case .int8:
                 assert(value.readableBytes == 8)
-                assert(Int.bitWidth == 64)
-                return value.readInteger(as: Int.self)
+                return value.readInteger(as: Int64.self).flatMap { Int(exactly: $0) }
             default:
                 return nil
             }


### PR DESCRIPTION
Fixes #199. cc @weissi