### PR TITLE
Drop Swift 5.2 and 5.3 support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.2
+// swift-tools-version:5.4
 import PackageDescription
 
 let package = Package(


### PR DESCRIPTION
SwiftNIO has dropped support for Swift 5.2 and 5.3. https://github.com/apple/swift-nio/pull/2080 We should do the same.