### PR TITLE
Make backend key data optional

### DIFF
--- a/Sources/PostgresNIO/Connection/PostgresConnection.swift
+++ b/Sources/PostgresNIO/Connection/PostgresConnection.swift
@@ -387,7 +387,6 @@ extension PostgresConnection {
         to socketAddress: SocketAddress,
         tlsConfiguration: TLSConfiguration? = nil,
         serverHostname: String? = nil,
-        requireBackendKeyData: Bool = true,
         logger: Logger = .init(label: "codes.vapor.postgres"),
         on eventLoop: EventLoop
     ) -> EventLoopFuture<PostgresConnection> {
@@ -406,7 +405,7 @@ extension PostgresConnection {
                 connection: .resolved(address: socketAddress, serverName: serverHostname),
                 authentication: nil,
                 tls: tls,
-                requireBackendKeyData: requireBackendKeyData
+                requireBackendKeyData: true
             )
 
             return PostgresConnection.connect(

--- a/Sources/PostgresNIO/Connection/PostgresConnection.swift
+++ b/Sources/PostgresNIO/Connection/PostgresConnection.swift
@@ -77,13 +77,23 @@ public final class PostgresConnection {
             ///
             /// - Default: 5432
             public var port: Int
-
-            public init(host: String, port: Int = 5432) {
+            
+            /// Require connection to provide `BackendKeyData`
+            ///
+            /// - Default: true
+            public var requireBackendKeyData: Bool
+            
+            public init(
+                host: String,
+                port: Int = 5432,
+                requireBackendKeyData: Bool = true
+            ) {
                 self.host = host
                 self.port = port
+                self.requireBackendKeyData = requireBackendKeyData
             }
         }
-
+        
         public var connection: Connection
 
         /// The authentication properties to send to the Postgres server during startup auth handshake
@@ -377,6 +387,7 @@ extension PostgresConnection {
         to socketAddress: SocketAddress,
         tlsConfiguration: TLSConfiguration? = nil,
         serverHostname: String? = nil,
+        requireBackendKeyData: Bool = true,
         logger: Logger = .init(label: "codes.vapor.postgres"),
         on eventLoop: EventLoop
     ) -> EventLoopFuture<PostgresConnection> {
@@ -394,7 +405,8 @@ extension PostgresConnection {
             let configuration = PostgresConnection.InternalConfiguration(
                 connection: .resolved(address: socketAddress, serverName: serverHostname),
                 authentication: nil,
-                tls: tls
+                tls: tls,
+                requireBackendKeyData: requireBackendKeyData
             )
 
             return PostgresConnection.connect(
@@ -756,6 +768,8 @@ extension PostgresConnection {
         var authentication: Configuration.Authentication?
 
         var tls: Configuration.TLS
+        
+        let requireBackendKeyData: Bool
     }
 }
 
@@ -764,6 +778,7 @@ extension PostgresConnection.InternalConfiguration {
         self.authentication = config.authentication
         self.connection = .unresolved(host: config.connection.host, port: config.connection.port)
         self.tls = config.tls
+        self.requireBackendKeyData = config.connection.requireBackendKeyData
     }
 }
 

--- a/Sources/PostgresNIO/Connection/PostgresConnection.swift
+++ b/Sources/PostgresNIO/Connection/PostgresConnection.swift
@@ -89,7 +89,7 @@ public final class PostgresConnection {
                 self.port = port
             }
         }
-        
+
         public var connection: Connection
 
         /// The authentication properties to send to the Postgres server during startup auth handshake
@@ -764,7 +764,7 @@ extension PostgresConnection {
 
         var tls: Configuration.TLS
         
-        let requireBackendKeyData: Bool
+        var requireBackendKeyData: Bool
     }
 }
 

--- a/Sources/PostgresNIO/Connection/PostgresConnection.swift
+++ b/Sources/PostgresNIO/Connection/PostgresConnection.swift
@@ -78,19 +78,15 @@ public final class PostgresConnection {
             /// - Default: 5432
             public var port: Int
             
-            /// Require connection to provide `BackendKeyData`
+            /// Require connection to provide `BackendKeyData`.
+            /// For use with Amazon RDS Proxy, this must be set to false.
             ///
             /// - Default: true
-            public var requireBackendKeyData: Bool
+            public var requireBackendKeyData: Bool = true
             
-            public init(
-                host: String,
-                port: Int = 5432,
-                requireBackendKeyData: Bool = true
-            ) {
+            public init(host: String, port: Int = 5432) {
                 self.host = host
                 self.port = port
-                self.requireBackendKeyData = requireBackendKeyData
             }
         }
         

--- a/Sources/PostgresNIO/New/Connection State Machine/ConnectionStateMachine.swift
+++ b/Sources/PostgresNIO/New/Connection State Machine/ConnectionStateMachine.swift
@@ -5,8 +5,8 @@ struct ConnectionStateMachine {
     typealias TransactionState = PostgresBackendMessage.TransactionState
     
     struct ConnectionContext {
-        let processID: Int32
-        let secretKey: Int32
+        let processID: Int32?
+        let secretKey: Int32?
         
         var parameters: [String: String]
         var transactionState: TransactionState
@@ -543,14 +543,9 @@ struct ConnectionStateMachine {
     mutating func readyForQueryReceived(_ transactionState: PostgresBackendMessage.TransactionState) -> ConnectionAction {
         switch self.state {
         case .authenticated(let backendKeyData, let parameters):
-            guard let keyData = backendKeyData else {
-                // `backendKeyData` must have been received, before receiving the first `readyForQuery`
-                return self.closeConnectionAndCleanup(.unexpectedBackendMessage(.readyForQuery(transactionState)))
-            }
-            
             let connectionContext = ConnectionContext(
-                processID: keyData.processID,
-                secretKey: keyData.secretKey,
+                processID: backendKeyData?.processID,
+                secretKey: backendKeyData?.secretKey,
                 parameters: parameters,
                 transactionState: transactionState)
             

--- a/Sources/PostgresNIO/New/Connection State Machine/ConnectionStateMachine.swift
+++ b/Sources/PostgresNIO/New/Connection State Machine/ConnectionStateMachine.swift
@@ -113,7 +113,7 @@ struct ConnectionStateMachine {
     }
     
     private var state: State
-    private var requireBackendKeyData: Bool
+    private let requireBackendKeyData: Bool
     private var taskQueue = CircularBuffer<PSQLTask>()
     private var quiescingState: QuiescingState = .notQuiescing
     

--- a/Sources/PostgresNIO/New/Connection State Machine/ConnectionStateMachine.swift
+++ b/Sources/PostgresNIO/New/Connection State Machine/ConnectionStateMachine.swift
@@ -117,7 +117,7 @@ struct ConnectionStateMachine {
     private var taskQueue = CircularBuffer<PSQLTask>()
     private var quiescingState: QuiescingState = .notQuiescing
     
-    init(requireBackendKeyData: Bool = true) {
+    init(requireBackendKeyData: Bool) {
         self.state = .initialized
         self.requireBackendKeyData = requireBackendKeyData
     }

--- a/Sources/PostgresNIO/New/Connection State Machine/ConnectionStateMachine.swift
+++ b/Sources/PostgresNIO/New/Connection State Machine/ConnectionStateMachine.swift
@@ -5,9 +5,7 @@ struct ConnectionStateMachine {
     typealias TransactionState = PostgresBackendMessage.TransactionState
     
     struct ConnectionContext {
-        let processID: Int32?
-        let secretKey: Int32?
-        
+        let backendKeyData: BackendKeyData?
         var parameters: [String: String]
         var transactionState: TransactionState
     }
@@ -551,8 +549,7 @@ struct ConnectionStateMachine {
             }
             
             let connectionContext = ConnectionContext(
-                processID: backendKeyData?.processID,
-                secretKey: backendKeyData?.secretKey,
+                backendKeyData: backendKeyData,
                 parameters: parameters,
                 transactionState: transactionState)
             
@@ -1316,8 +1313,8 @@ extension ConnectionStateMachine.State: CustomDebugStringConvertible {
 extension ConnectionStateMachine.ConnectionContext: CustomDebugStringConvertible {
     var debugDescription: String {
         """
-        (processID: \(self.processID), \
-        secretKey: \(self.secretKey), \
+        (processID: \(self.backendKeyData?.processID != nil ? String(self.backendKeyData!.processID) : "nil")), \
+        secretKey: \(self.backendKeyData?.secretKey != nil ? String(self.backendKeyData!.secretKey) : "nil")), \
         parameters: \(String(reflecting: self.parameters)))
         """
     }

--- a/Sources/PostgresNIO/New/Connection State Machine/ConnectionStateMachine.swift
+++ b/Sources/PostgresNIO/New/Connection State Machine/ConnectionStateMachine.swift
@@ -5,7 +5,7 @@ struct ConnectionStateMachine {
     typealias TransactionState = PostgresBackendMessage.TransactionState
     
     struct ConnectionContext {
-        let backendKeyData: BackendKeyData?
+        let backendKeyData: Optional<BackendKeyData>
         var parameters: [String: String]
         var transactionState: TransactionState
     }

--- a/Sources/PostgresNIO/New/PostgresChannelHandler.swift
+++ b/Sources/PostgresNIO/New/PostgresChannelHandler.swift
@@ -32,7 +32,7 @@ final class PostgresChannelHandler: ChannelDuplexHandler {
          logger: Logger,
          configureSSLCallback: ((Channel) throws -> Void)?)
     {
-        self.state = ConnectionStateMachine()
+        self.state = ConnectionStateMachine(requireBackendKeyData: configuration.requireBackendKeyData)
         self.configuration = configuration
         self.configureSSLCallback = configureSSLCallback
         self.logger = logger

--- a/Tests/PostgresNIOTests/New/Connection State Machine/AuthenticationStateMachineTests.swift
+++ b/Tests/PostgresNIOTests/New/Connection State Machine/AuthenticationStateMachineTests.swift
@@ -7,7 +7,7 @@ class AuthenticationStateMachineTests: XCTestCase {
     func testAuthenticatePlaintext() {
         let authContext = AuthContext(username: "test", password: "abc123", database: "test")
 
-        var state = ConnectionStateMachine()
+        var state = ConnectionStateMachine(requireBackendKeyData: true)
         XCTAssertEqual(state.connected(tls: .disable), .provideAuthenticationContext)
         
         XCTAssertEqual(state.provideAuthenticationContext(authContext), .sendStartupMessage(authContext))
@@ -17,7 +17,7 @@ class AuthenticationStateMachineTests: XCTestCase {
     
     func testAuthenticateMD5() {
         let authContext = AuthContext(username: "test", password: "abc123", database: "test")
-        var state = ConnectionStateMachine()
+        var state = ConnectionStateMachine(requireBackendKeyData: true)
         XCTAssertEqual(state.connected(tls: .disable), .provideAuthenticationContext)
         let salt: (UInt8, UInt8, UInt8, UInt8) = (0, 1, 2, 3)
         
@@ -28,7 +28,7 @@ class AuthenticationStateMachineTests: XCTestCase {
     
     func testAuthenticateMD5WithoutPassword() {
         let authContext = AuthContext(username: "test", password: nil, database: "test")
-        var state = ConnectionStateMachine()
+        var state = ConnectionStateMachine(requireBackendKeyData: true)
         XCTAssertEqual(state.connected(tls: .disable), .provideAuthenticationContext)
         let salt: (UInt8, UInt8, UInt8, UInt8) = (0, 1, 2, 3)
         
@@ -39,7 +39,7 @@ class AuthenticationStateMachineTests: XCTestCase {
     
     func testAuthenticateOkAfterStartUpWithoutAuthChallenge() {
         let authContext = AuthContext(username: "test", password: "abc123", database: "test")
-        var state = ConnectionStateMachine()
+        var state = ConnectionStateMachine(requireBackendKeyData: true)
         XCTAssertEqual(state.connected(tls: .disable), .provideAuthenticationContext)
         XCTAssertEqual(state.provideAuthenticationContext(authContext), .sendStartupMessage(authContext))
         XCTAssertEqual(state.authenticationMessageReceived(.ok), .wait)
@@ -47,7 +47,7 @@ class AuthenticationStateMachineTests: XCTestCase {
     
     func testAuthenticationFailure() {
         let authContext = AuthContext(username: "test", password: "abc123", database: "test")
-        var state = ConnectionStateMachine()
+        var state = ConnectionStateMachine(requireBackendKeyData: true)
         XCTAssertEqual(state.connected(tls: .disable), .provideAuthenticationContext)
         let salt: (UInt8, UInt8, UInt8, UInt8) = (0, 1, 2, 3)
         
@@ -79,7 +79,7 @@ class AuthenticationStateMachineTests: XCTestCase {
         
         for (message, mechanism) in unsupported {
             let authContext = AuthContext(username: "test", password: "abc123", database: "test")
-            var state = ConnectionStateMachine()
+            var state = ConnectionStateMachine(requireBackendKeyData: true)
             XCTAssertEqual(state.connected(tls: .disable), .provideAuthenticationContext)
             XCTAssertEqual(state.provideAuthenticationContext(authContext), .sendStartupMessage(authContext))
             XCTAssertEqual(state.authenticationMessageReceived(message),
@@ -98,7 +98,7 @@ class AuthenticationStateMachineTests: XCTestCase {
         
         for message in unexpected {
             let authContext = AuthContext(username: "test", password: "abc123", database: "test")
-            var state = ConnectionStateMachine()
+            var state = ConnectionStateMachine(requireBackendKeyData: true)
             XCTAssertEqual(state.connected(tls: .disable), .provideAuthenticationContext)
             XCTAssertEqual(state.provideAuthenticationContext(authContext), .sendStartupMessage(authContext))
             XCTAssertEqual(state.authenticationMessageReceived(message),
@@ -125,7 +125,7 @@ class AuthenticationStateMachineTests: XCTestCase {
         
         for message in unexpected {
             let authContext = AuthContext(username: "test", password: "abc123", database: "test")
-            var state = ConnectionStateMachine()
+            var state = ConnectionStateMachine(requireBackendKeyData: true)
             XCTAssertEqual(state.connected(tls: .disable), .provideAuthenticationContext)
             XCTAssertEqual(state.provideAuthenticationContext(authContext), .sendStartupMessage(authContext))
             XCTAssertEqual(state.authenticationMessageReceived(.md5(salt: salt)), .sendPasswordMessage(.md5(salt: salt), authContext))

--- a/Tests/PostgresNIOTests/New/Connection State Machine/ConnectionStateMachineTests.swift
+++ b/Tests/PostgresNIOTests/New/Connection State Machine/ConnectionStateMachineTests.swift
@@ -108,6 +108,9 @@ class ConnectionStateMachineTests: XCTestCase {
         
         XCTAssertEqual(state.readyForQueryReceived(.idle),
                        .closeConnectionAndCleanup(.init(action: .close, tasks: [], error: PSQLError.unexpectedBackendMessage(.readyForQuery(.idle)), closePromise: nil)))
+        
+        state = ConnectionStateMachine(.authenticated(nil, [:]), requireBackendKeyData: false)
+        XCTAssertEqual(state.readyForQueryReceived(.idle), .fireEventReadyForQuery)
     }
     
     func testErrorIsIgnoredWhenClosingConnection() {

--- a/Tests/PostgresNIOTests/New/Extensions/ConnectionAction+TestUtils.swift
+++ b/Tests/PostgresNIOTests/New/Extensions/ConnectionAction+TestUtils.swift
@@ -75,6 +75,8 @@ extension ConnectionStateMachine {
     }
     
     static func createConnectionContext(transactionState: PostgresBackendMessage.TransactionState = .idle) -> ConnectionContext {
+        let backendKeyData = BackendKeyData(processID: 2730, secretKey: 882037977)
+        
         let paramaters = [
             "DateStyle": "ISO, MDY",
             "application_name": "",
@@ -90,8 +92,7 @@ extension ConnectionStateMachine {
         ]
         
         return ConnectionContext(
-            processID: 2730,
-            secretKey: 882037977,
+            backendKeyData: backendKeyData,
             parameters: paramaters,
             transactionState: transactionState
         )

--- a/Tests/PostgresNIOTests/New/PostgresChannelHandlerTests.swift
+++ b/Tests/PostgresNIOTests/New/PostgresChannelHandlerTests.swift
@@ -173,7 +173,8 @@ class PostgresChannelHandlerTests: XCTestCase {
         username: String = "test",
         database: String = "postgres",
         password: String = "password",
-        tls: PostgresConnection.Configuration.TLS = .disable
+        tls: PostgresConnection.Configuration.TLS = .disable,
+        requireBackendKeyData: Bool = true
     ) -> PostgresConnection.InternalConfiguration {
         let authentication = PostgresConnection.Configuration.Authentication(
             username: username,
@@ -184,7 +185,8 @@ class PostgresChannelHandlerTests: XCTestCase {
         return PostgresConnection.InternalConfiguration(
             connection: .unresolved(host: host, port: port),
             authentication: authentication,
-            tls: tls
+            tls: tls,
+            requireBackendKeyData: requireBackendKeyData
         )
     }
 }


### PR DESCRIPTION
This allows the `ConnectionStateMachine` to be in state `readyForQuery` even if the `BackendKeyData` has not been received.

The use case that prompted this change is integration with Amazon RDS Proxy. When connecting to Postgres via RDS Proxy, any query fails with error `PSQLError(base: PostgresNIO.PSQLError.Base.unexpectedBackendMessage(.readyForQuery(.idle)))`.

According to the RDS Proxy [docs](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/rds-proxy.html#rds-proxy.limits), one limitation of RDS Proxy is "For PostgreSQL, RDS Proxy doesn't currently support canceling a query from a client." The Postgres [docs](https://www.postgresql.org/docs/current/protocol-flow.html) explain BackendKeyData's purpose as: "This message provides secret-key data that the frontend must save if it wants to be able to issue cancel requests later. The frontend should not respond to this message, but should continue listening for a ReadyForQuery message."

So, it seems that RDS Proxy for Postgres has no use for BackendKeyData and does not provide it.

Allowing `nil` for `BackendKeyData` in this function resolves the `PSQLError` error we were seeing.