### PR TITLE
Increase bind parameters limit

### DIFF
--- a/Sources/PostgresNIO/Connection/PostgresConnection.swift
+++ b/Sources/PostgresNIO/Connection/PostgresConnection.swift
@@ -309,7 +309,7 @@ public final class PostgresConnection {
     private func queryStream(_ query: PostgresQuery, logger: Logger) -> EventLoopFuture<PSQLRowStream> {
         var logger = logger
         logger[postgresMetadataKey: .connectionID] = "\(self.id)"
-        guard query.binds.count <= Int(Int16.max) else {
+        guard query.binds.count < Int(UInt16.max) else {
             return self.channel.eventLoop.makeFailedFuture(PSQLError.tooManyParameters)
         }
 
@@ -341,7 +341,7 @@ public final class PostgresConnection {
     }
 
     func execute(_ executeStatement: PSQLExecuteStatement, logger: Logger) -> EventLoopFuture<PSQLRowStream> {
-        guard executeStatement.binds.count <= Int(Int16.max) else {
+        guard executeStatement.binds.count < Int(UInt16.max) else {
             return self.channel.eventLoop.makeFailedFuture(PSQLError.tooManyParameters)
         }
         let promise = self.channel.eventLoop.makePromise(of: PSQLRowStream.self)
@@ -498,7 +498,7 @@ extension PostgresConnection {
         var logger = logger
         logger[postgresMetadataKey: .connectionID] = "\(self.id)"
 
-        guard query.binds.count <= Int(Int16.max) else {
+        guard query.binds.count < Int(UInt16.max) else {
             throw PSQLError.tooManyParameters
         }
         let promise = self.channel.eventLoop.makePromise(of: PSQLRowStream.self)

--- a/Sources/PostgresNIO/Connection/PostgresConnection.swift
+++ b/Sources/PostgresNIO/Connection/PostgresConnection.swift
@@ -309,7 +309,7 @@ public final class PostgresConnection {
     private func queryStream(_ query: PostgresQuery, logger: Logger) -> EventLoopFuture<PSQLRowStream> {
         var logger = logger
         logger[postgresMetadataKey: .connectionID] = "\(self.id)"
-        guard query.binds.count < Int(UInt16.max) else {
+        guard query.binds.count <= Int(UInt16.max) else {
             return self.channel.eventLoop.makeFailedFuture(PSQLError.tooManyParameters)
         }
 
@@ -341,7 +341,7 @@ public final class PostgresConnection {
     }
 
     func execute(_ executeStatement: PSQLExecuteStatement, logger: Logger) -> EventLoopFuture<PSQLRowStream> {
-        guard executeStatement.binds.count < Int(UInt16.max) else {
+        guard executeStatement.binds.count <= Int(UInt16.max) else {
             return self.channel.eventLoop.makeFailedFuture(PSQLError.tooManyParameters)
         }
         let promise = self.channel.eventLoop.makePromise(of: PSQLRowStream.self)
@@ -498,7 +498,7 @@ extension PostgresConnection {
         var logger = logger
         logger[postgresMetadataKey: .connectionID] = "\(self.id)"
 
-        guard query.binds.count < Int(UInt16.max) else {
+        guard query.binds.count <= Int(UInt16.max) else {
             throw PSQLError.tooManyParameters
         }
         let promise = self.channel.eventLoop.makePromise(of: PSQLRowStream.self)

--- a/Sources/PostgresNIO/New/Messages/Bind.swift
+++ b/Sources/PostgresNIO/New/Messages/Bind.swift
@@ -20,14 +20,14 @@ extension PostgresFrontendMessage {
             // zero to indicate that there are no parameters or that the parameters all use the
             // default format (text); or one, in which case the specified format code is applied
             // to all parameters; or it can equal the actual number of parameters.
-            buffer.writeInteger(Int16(self.bind.count))
+            buffer.writeInteger(UInt16(self.bind.count))
             
             // The parameter format codes. Each must presently be zero (text) or one (binary).
             self.bind.metadata.forEach {
                 buffer.writeInteger($0.format.rawValue)
             }
             
-            buffer.writeInteger(Int16(self.bind.count))
+            buffer.writeInteger(UInt16(self.bind.count))
 
             var parametersCopy = self.bind.bytes
             buffer.writeBuffer(&parametersCopy)

--- a/Sources/PostgresNIO/New/Messages/ParameterDescription.swift
+++ b/Sources/PostgresNIO/New/Messages/ParameterDescription.swift
@@ -7,9 +7,10 @@ extension PostgresBackendMessage {
         var dataTypes: [PostgresDataType]
         
         static func decode(from buffer: inout ByteBuffer) throws -> Self {
-            let parameterCount = try buffer.throwingReadInteger(as: Int16.self)
-            guard parameterCount >= 0 else {
-                throw PSQLPartialDecodingError.integerMustBePositiveOrNull(parameterCount)
+            let parameterCount = try buffer.throwingReadInteger(as: Int32.self)
+            guard parameterCount >= 0, parameterCount < Int(UInt16.max) else {
+                throw PSQLPartialDecodingError.integerMustBePositiveAndLessThanOrNull(
+                  parameterCount, lessThan: Int(UInt16.max))
             }
             
             var result = [PostgresDataType]()

--- a/Sources/PostgresNIO/New/Messages/ParameterDescription.swift
+++ b/Sources/PostgresNIO/New/Messages/ParameterDescription.swift
@@ -7,11 +7,7 @@ extension PostgresBackendMessage {
         var dataTypes: [PostgresDataType]
         
         static func decode(from buffer: inout ByteBuffer) throws -> Self {
-            let parameterCount = try buffer.throwingReadInteger(as: Int32.self)
-            guard parameterCount >= 0, parameterCount < Int(UInt16.max) else {
-                throw PSQLPartialDecodingError.integerMustBePositiveAndLessThanOrNull(
-                  parameterCount, lessThan: Int(UInt16.max))
-            }
+            let parameterCount = try buffer.throwingReadInteger(as: UInt16.self)
             
             var result = [PostgresDataType]()
             result.reserveCapacity(Int(parameterCount))

--- a/Sources/PostgresNIO/New/Messages/Parse.swift
+++ b/Sources/PostgresNIO/New/Messages/Parse.swift
@@ -15,7 +15,7 @@ extension PostgresFrontendMessage {
         func encode(into buffer: inout ByteBuffer) {
             buffer.writeNullTerminatedString(self.preparedStatementName)
             buffer.writeNullTerminatedString(self.query)
-            buffer.writeInteger(Int16(self.parameters.count))
+            buffer.writeInteger(UInt16(self.parameters.count))
             
             self.parameters.forEach { dataType in
                 buffer.writeInteger(dataType.rawValue)

--- a/Sources/PostgresNIO/New/PostgresBackendMessageDecoder.swift
+++ b/Sources/PostgresNIO/New/PostgresBackendMessageDecoder.swift
@@ -187,6 +187,12 @@ struct PSQLPartialDecodingError: Error {
             description: "Expected the integer to be positive or null, but got \(actual).",
             file: file, line: line)
     }
+  
+  static func integerMustBePositiveAndLessThanOrNull<Number: FixedWidthInteger>(_ actual: Number, lessThan: Int, file: String = #file, line: Int = #line) -> Self {
+    return PSQLPartialDecodingError(
+      description: "Expected the integer to be positive and less than \(lessThan), or null, but got \(actual).",
+      file: file, line: line)
+  }
 }
 
 extension ByteBuffer {

--- a/Sources/PostgresNIO/New/PostgresBackendMessageDecoder.swift
+++ b/Sources/PostgresNIO/New/PostgresBackendMessageDecoder.swift
@@ -187,12 +187,6 @@ struct PSQLPartialDecodingError: Error {
             description: "Expected the integer to be positive or null, but got \(actual).",
             file: file, line: line)
     }
-  
-  static func integerMustBePositiveAndLessThanOrNull<Number: FixedWidthInteger>(_ actual: Number, lessThan: Int, file: String = #file, line: Int = #line) -> Self {
-    return PSQLPartialDecodingError(
-      description: "Expected the integer to be positive and less than \(lessThan), or null, but got \(actual).",
-      file: file, line: line)
-  }
 }
 
 extension ByteBuffer {

--- a/Tests/IntegrationTests/PSQLIntegrationTests.swift
+++ b/Tests/IntegrationTests/PSQLIntegrationTests.swift
@@ -337,7 +337,7 @@ final class IntegrationTests: XCTestCase {
         let eventLoop = eventLoopGroup.next()
         
         try await withTestConnection(on: eventLoop) { connection in
-            // Mac binds limit is UInt16.max which is 65535 which is 3 * 5 * 17 * 257
+            // Max binds limit is UInt16.max which is 65535 which is 3 * 5 * 17 * 257
             // Max columns limit is 1664, so we will only make 5 * 257 columns which is less
             // Then we will insert 3 * 17 rows
             // In the insertion, there will be a total of 3 * 17 * 5 * 257 == UInt16.max bindings
@@ -364,7 +364,7 @@ final class IntegrationTests: XCTestCase {
             
             let insertionValues = (0..<rowsCount).map { rowIndex in
                 let indices = (0..<columnsCount).map { columnIndex -> String in
-                    "$\(rowIndex * 1_000 + columnIndex + 1)"
+                    "$\(rowIndex * columnsCount + columnIndex + 1)"
                 }
                 return "(\(indices.joined(separator: ", ")))"
             }.joined(separator: ", ")

--- a/Tests/IntegrationTests/PSQLIntegrationTests.swift
+++ b/Tests/IntegrationTests/PSQLIntegrationTests.swift
@@ -330,6 +330,7 @@ final class IntegrationTests: XCTestCase {
         }
     }
     
+#if swift(>=5.5.2)
     func testBindMaximumParameters() async throws {
         let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully()) }
@@ -377,4 +378,5 @@ final class IntegrationTests: XCTestCase {
             try await connection.query(dropQuery, logger: .psqlTest)
         }
     }
+#endif
 }

--- a/Tests/IntegrationTests/PostgresNIOTests.swift
+++ b/Tests/IntegrationTests/PostgresNIOTests.swift
@@ -1061,7 +1061,7 @@ final class PostgresNIOTests: XCTestCase {
         var conn: PostgresConnection?
         XCTAssertNoThrow(conn = try PostgresConnection.test(on: eventLoop).wait())
         defer { XCTAssertNoThrow( try conn?.close().wait() ) }
-        let binds = [PostgresData].init(repeating: .null, count: Int(Int16.max) + 1)
+        let binds = [PostgresData].init(repeating: .null, count: Int(UInt16.max))
         XCTAssertThrowsError(try conn?.query("SELECT version()", binds).wait()) { error in
             guard case .tooManyParameters = (error as? PSQLError)?.base else {
                 return XCTFail("Unexpected error: \(error)")

--- a/Tests/IntegrationTests/PostgresNIOTests.swift
+++ b/Tests/IntegrationTests/PostgresNIOTests.swift
@@ -1061,7 +1061,7 @@ final class PostgresNIOTests: XCTestCase {
         var conn: PostgresConnection?
         XCTAssertNoThrow(conn = try PostgresConnection.test(on: eventLoop).wait())
         defer { XCTAssertNoThrow( try conn?.close().wait() ) }
-        let binds = [PostgresData].init(repeating: .null, count: Int(UInt16.max))
+        let binds = [PostgresData].init(repeating: .null, count: Int(UInt16.max) + 1)
         XCTAssertThrowsError(try conn?.query("SELECT version()", binds).wait()) { error in
             guard case .tooManyParameters = (error as? PSQLError)?.base else {
                 return XCTFail("Unexpected error: \(error)")

--- a/Tests/PostgresNIOTests/New/Messages/ParseTests.swift
+++ b/Tests/PostgresNIOTests/New/Messages/ParseTests.swift
@@ -26,7 +26,7 @@ class ParseTests: XCTestCase {
         XCTAssertEqual(byteBuffer.readInteger(as: Int32.self), Int32(length - 1))
         XCTAssertEqual(byteBuffer.readNullTerminatedString(), parse.preparedStatementName)
         XCTAssertEqual(byteBuffer.readNullTerminatedString(), parse.query)
-        XCTAssertEqual(byteBuffer.readInteger(as: Int16.self), Int16(parse.parameters.count))
+        XCTAssertEqual(byteBuffer.readInteger(as: UInt16.self), UInt16(parse.parameters.count))
         XCTAssertEqual(byteBuffer.readInteger(as: UInt32.self), PostgresDataType.bool.rawValue)
         XCTAssertEqual(byteBuffer.readInteger(as: UInt32.self), PostgresDataType.int8.rawValue)
         XCTAssertEqual(byteBuffer.readInteger(as: UInt32.self), PostgresDataType.bytea.rawValue)


### PR DESCRIPTION
# The problem
Right now PostgresNIO doesn't allow queries with bind parameters count more than Int16.max (32768).
This is despite Postgres 10+ supporting up to ~~(UInt16.max - 1)~~ UInt16.max parameters (65535).
For reference for Postgres 14, see https://www.postgresql.org/docs/14/postgres-fdw.html and search the page for "batch_size". I couldn't find documentation on this on lower Postgres versions, but manually tested the PR (see below).

# Solution
This PR increases that limit to 65535 which is more appropriate.

# Tests
I don't think there is a need for adding a test, but I changed one of the test's to reflect the changes. We'll see if there is anything I missed, when the CI runs the test.

Other than that, I've manually tested this on Postgres Docker images 10, 11, 12, 13, 14 (The currently supported-by-Postgres versions).

