### PR TITLE
Use provided logger consistently in `PostgresConnection.send(_:logger:)`

### DIFF
--- a/Sources/PostgresNIO/Connection/PostgresConnection.swift
+++ b/Sources/PostgresNIO/Connection/PostgresConnection.swift
@@ -601,7 +601,7 @@ extension PostgresConnection: PostgresDatabase {
             }
 
         case .prepareQuery(let request):
-            resultFuture = self.prepareStatement(request.query, with: request.name, logger: self.logger).map {
+            resultFuture = self.prepareStatement(request.query, with: request.name, logger: logger).map {
                 request.prepared = PreparedQuery(underlying: $0, database: self)
             }
 


### PR DESCRIPTION
Probably affects no one whatsoever, since using a non-default logger per-query isn't actually implemented anywhere that I've seen, but might as well be consistent just the same.