### PR TITLE
Fix new NIO warnings

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-atomics.git", from: "1.0.2"),
-        .package(url: "https://github.com/apple/swift-nio.git", .branch("main")),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.41.1"),
         .package(url: "https://github.com/apple/swift-nio-transport-services.git", from: "1.11.4"),
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.14.1"),
         .package(url: "https://github.com/apple/swift-crypto.git", "1.0.0" ..< "3.0.0"),

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,8 @@ let package = Package(
         .library(name: "PostgresNIO", targets: ["PostgresNIO"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.35.0"),
+        .package(url: "https://github.com/apple/swift-atomics.git", from: "1.0.2"),
+        .package(url: "https://github.com/apple/swift-nio.git", .branch("main")),
         .package(url: "https://github.com/apple/swift-nio-transport-services.git", from: "1.11.4"),
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.14.1"),
         .package(url: "https://github.com/apple/swift-crypto.git", "1.0.0" ..< "3.0.0"),
@@ -22,6 +23,7 @@ let package = Package(
     ],
     targets: [
         .target(name: "PostgresNIO", dependencies: [
+            .product(name: "Atomics", package: "swift-atomics"),
             .product(name: "Crypto", package: "swift-crypto"),
             .product(name: "Logging", package: "swift-log"),
             .product(name: "Metrics", package: "swift-metrics"),

--- a/Sources/PostgresNIO/Connection/PostgresConnection.swift
+++ b/Sources/PostgresNIO/Connection/PostgresConnection.swift
@@ -1,5 +1,5 @@
+import Atomics
 import NIOCore
-import NIOConcurrencyHelpers
 #if canImport(Network)
 import NIOTransportServices
 #endif
@@ -379,7 +379,7 @@ public final class PostgresConnection {
 // MARK: Connect
 
 extension PostgresConnection {
-    static let idGenerator = NIOAtomic.makeAtomic(value: 0)
+    static let idGenerator = ManagedAtomic(0)
 
     @available(*, deprecated,
         message: "Use the new connect method that allows you to connect and authenticate in a single step",
@@ -412,7 +412,7 @@ extension PostgresConnection {
             )
 
             return PostgresConnection.connect(
-                connectionID: idGenerator.add(1),
+                connectionID: self.idGenerator.wrappingIncrementThenLoad(ordering: .relaxed),
                 configuration: configuration,
                 logger: logger,
                 on: eventLoop

--- a/Sources/PostgresNIO/Data/PostgresData.swift
+++ b/Sources/PostgresNIO/Data/PostgresData.swift
@@ -1,9 +1,5 @@
-#if swift(>=5.6)
-@preconcurrency import NIOCore
-#else
 import NIOCore
-#endif
-import Foundation
+import struct Foundation.UUID
 
 public struct PostgresData: CustomStringConvertible, CustomDebugStringConvertible {
     public static var null: PostgresData {

--- a/Sources/PostgresNIO/Data/PostgresRow.swift
+++ b/Sources/PostgresNIO/Data/PostgresRow.swift
@@ -1,8 +1,4 @@
-#if swift(>=5.6)
-@preconcurrency import NIOCore
-#else
 import NIOCore
-#endif
 import class Foundation.JSONDecoder
 
 /// `PostgresRow` represents a single table row that is received from the server for a query or a prepared statement.

--- a/Sources/PostgresNIO/New/Messages/DataRow.swift
+++ b/Sources/PostgresNIO/New/Messages/DataRow.swift
@@ -1,8 +1,4 @@
-#if swift(>=5.6)
-@preconcurrency import NIOCore
-#else
 import NIOCore
-#endif
 
 /// A backend data row message.
 ///

--- a/Sources/PostgresNIO/New/PostgresCell.swift
+++ b/Sources/PostgresNIO/New/PostgresCell.swift
@@ -1,8 +1,4 @@
-#if swift(>=5.6)
-@preconcurrency import NIOCore
-#else
 import NIOCore
-#endif
 
 public struct PostgresCell: Equatable {
     public var bytes: ByteBuffer?

--- a/Tests/PostgresNIOTests/New/PostgresRowSequenceTests.swift
+++ b/Tests/PostgresNIOTests/New/PostgresRowSequenceTests.swift
@@ -1,5 +1,5 @@
+import Atomics
 import NIOEmbedded
-import NIOConcurrencyHelpers
 import Dispatch
 import XCTest
 @testable import PostgresNIO
@@ -445,22 +445,22 @@ final class PostgresRowSequenceTests: XCTestCase {
 
 final class MockRowDataSource: PSQLRowsDataSource {
     var requestCount: Int {
-        self._requestCount.load()
+        self._requestCount.load(ordering: .relaxed)
     }
 
     var cancelCount: Int {
-        self._cancelCount.load()
+        self._cancelCount.load(ordering: .relaxed)
     }
 
-    private let _requestCount = NIOAtomic.makeAtomic(value: 0)
-    private let _cancelCount = NIOAtomic.makeAtomic(value: 0)
+    private let _requestCount = ManagedAtomic(0)
+    private let _cancelCount = ManagedAtomic(0)
 
     func request(for stream: PSQLRowStream) {
-        self._requestCount.add(1)
+        self._requestCount.wrappingIncrement(ordering: .relaxed)
     }
 
     func cancel(for stream: PSQLRowStream) {
-        self._cancelCount.add(1)
+        self._cancelCount.wrappingIncrement(ordering: .relaxed)
     }
 }
 #endif


### PR DESCRIPTION
This PR brings us up to speed with current Swift NIO main branch and fixes the warnings that will show up once a new NIO release is cut.