### PR TITLE
Replace Lock with new NIOLock

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,12 +14,12 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-atomics.git", from: "1.0.2"),
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.41.1"),
-        .package(url: "https://github.com/apple/swift-nio-transport-services.git", from: "1.11.4"),
-        .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.14.1"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.42.0"),
+        .package(url: "https://github.com/apple/swift-nio-transport-services.git", from: "1.13.1"),
+        .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.22.1"),
         .package(url: "https://github.com/apple/swift-crypto.git", "1.0.0" ..< "3.0.0"),
         .package(url: "https://github.com/apple/swift-metrics.git", from: "2.0.0"),
-        .package(url: "https://github.com/apple/swift-log.git", from: "1.4.0"),
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.4.4"),
     ],
     targets: [
         .target(name: "PostgresNIO", dependencies: [

--- a/Sources/PostgresNIO/New/PostgresRowSequence.swift
+++ b/Sources/PostgresNIO/New/PostgresRowSequence.swift
@@ -70,7 +70,7 @@ extension PostgresRowSequence {
 }
 
 final class AsyncStreamConsumer {
-    let lock = Lock()
+    let lock = NIOLock()
 
     let lookupTable: [String: Int]
     let columns: [RowDescription.Column]


### PR DESCRIPTION
SwiftNIO 2.42.0 has deprecated Lock and replaced it with a new NIOLock. This commit removes all uses of Lock and replaces them with NIOLock. Further, require new package versions.