### PR TITLE
Update test CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
         run: swift test --enable-test-discovery --filter=^PostgresNIOTests --sanitize=thread --enable-code-coverage
       - name: Submit coverage report to Codecov.io
         if: "!contains(matrix.container, 'nightly')"
-        uses: vapor/swift-codecov-action@v0.2.1
+        uses: vapor/swift-codecov-action@v0.2
         with:
           cc_flags: 'unittests'
           cc_env_vars: 'SWIFT_VERSION,SWIFT_PLATFORM,RUNNER_OS,RUNNER_ARCH'


### PR DESCRIPTION
The test CI could use a bit of an update :)
NIO ~~has recently dropped~~ will soon drop support for swift 5.4, so we should drop swift 5.4 too.
This also updates integration-tests and api-breakage jobs to use swift 5.7.
**EDIT 1**:
Now this PR also removes the codecov checks from nightly builds because codecov doesn't seem to get along with nightlies.