### PR TITLE
Bump Swift to 5.5

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.4
+// swift-tools-version:5.5
 import PackageDescription
 
 let package = Package(

--- a/Sources/PostgresNIO/Connection/PostgresConnection.swift
+++ b/Sources/PostgresNIO/Connection/PostgresConnection.swift
@@ -449,7 +449,7 @@ extension PostgresConnection {
 
 // MARK: Async/Await Interface
 
-#if swift(>=5.5) && canImport(_Concurrency)
+#if canImport(_Concurrency)
 extension PostgresConnection {
 
     /// Creates a new connection to a Postgres server.

--- a/Sources/PostgresNIO/New/PSQLRowStream.swift
+++ b/Sources/PostgresNIO/New/PSQLRowStream.swift
@@ -22,7 +22,7 @@ final class PSQLRowStream {
         case waitingForAll([PostgresRow], EventLoopPromise<[PostgresRow]>, PSQLRowsDataSource)
         case consumed(Result<String, Error>)
         
-        #if swift(>=5.5) && canImport(_Concurrency)
+        #if canImport(_Concurrency)
         case asyncSequence(AsyncStreamConsumer, PSQLRowsDataSource)
         #endif
     }
@@ -63,7 +63,7 @@ final class PSQLRowStream {
     
     // MARK: Async Sequence
     
-    #if swift(>=5.5) && canImport(_Concurrency)
+    #if canImport(_Concurrency)
     func asyncSequence() -> PostgresRowSequence {
         self.eventLoop.preconditionInEventLoop()
 
@@ -304,7 +304,7 @@ final class PSQLRowStream {
             // immediately request more
             dataSource.request(for: self)
         
-        #if swift(>=5.5) && canImport(_Concurrency)
+        #if canImport(_Concurrency)
         case .asyncSequence(let consumer, _):
             consumer.receive(newRows)
         #endif
@@ -344,7 +344,7 @@ final class PSQLRowStream {
             self.downstreamState = .consumed(.success(commandTag))
             promise.succeed(rows)
             
-        #if swift(>=5.5) && canImport(_Concurrency)
+        #if canImport(_Concurrency)
         case .asyncSequence(let consumer, _):
             consumer.receive(completion: .success(commandTag))
             self.downstreamState = .consumed(.success(commandTag))
@@ -371,7 +371,7 @@ final class PSQLRowStream {
             self.downstreamState = .consumed(.failure(error))
             promise.fail(error)
             
-        #if swift(>=5.5) && canImport(_Concurrency)
+        #if canImport(_Concurrency)
         case .asyncSequence(let consumer, _):
             consumer.receive(completion: .failure(error))
             self.downstreamState = .consumed(.failure(error))

--- a/Sources/PostgresNIO/New/PostgresRowSequence.swift
+++ b/Sources/PostgresNIO/New/PostgresRowSequence.swift
@@ -1,7 +1,7 @@
 import NIOCore
 import NIOConcurrencyHelpers
 
-#if swift(>=5.5) && canImport(_Concurrency)
+#if canImport(_Concurrency)
 /// An async sequence of ``PostgresRow``s.
 ///
 /// - Note: This is a struct to allow us to move to a move only type easily once they become available.

--- a/Tests/IntegrationTests/AsyncTests.swift
+++ b/Tests/IntegrationTests/AsyncTests.swift
@@ -5,7 +5,7 @@ import PostgresNIO
 import NIOTransportServices
 #endif
 
-#if swift(>=5.5.2)
+#if canImport(_Concurrency)
 final class AsyncPostgresConnectionTests: XCTestCase {
 
     func test1kRoundTrips() async throws {

--- a/Tests/IntegrationTests/PSQLIntegrationTests.swift
+++ b/Tests/IntegrationTests/PSQLIntegrationTests.swift
@@ -330,7 +330,7 @@ final class IntegrationTests: XCTestCase {
         }
     }
     
-#if swift(>=5.5.2)
+#if canImport(_Concurrency)
     func testBindMaximumParameters() async throws {
         let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully()) }

--- a/Tests/PostgresNIOTests/New/PostgresRowSequenceTests.swift
+++ b/Tests/PostgresNIOTests/New/PostgresRowSequenceTests.swift
@@ -4,7 +4,7 @@ import Dispatch
 import XCTest
 @testable import PostgresNIO
 
-#if swift(>=5.5.2)
+#if canImport(_Concurrency)
 final class PostgresRowSequenceTests: XCTestCase {
 
     func testBackpressureWorks() async throws {

--- a/dev/generate-postgresrowsequence-multi-decode.sh
+++ b/dev/generate-postgresrowsequence-multi-decode.sh
@@ -96,7 +96,7 @@ cat <<"EOF"
 EOF
 echo
 
-echo "#if swift(>=5.5) && canImport(_Concurrency)"
+echo "#if canImport(_Concurrency)"
 echo "extension AsyncSequence where Element == PostgresRow {"
 
 # note:


### PR DESCRIPTION
NIO periodically updates their minimum swift version, and with swift 5.7 released, swift 5.4 is soon to be unsupported.
### Changes
This PR:
* Bumps up the minimum swift version required, to 5.5.
* Removes `#if swift(>=5.5)` checks that are no longer needed.
* Changes `#if swift(>=5.5.2)` checks to `#if canImport(_Concurrency)` as a better alternative.