### PR TITLE
Deprecating PostgresDataConvertible, PostgresMessageType

### DIFF
--- a/Sources/PostgresNIO/Data/PostgresData+Array.swift
+++ b/Sources/PostgresNIO/Data/PostgresData+Array.swift
@@ -1,14 +1,14 @@
 import NIOCore
 
 extension PostgresData {
-    public init<T>(array: [T])
-        where T: PostgresDataConvertible
-    {
+    @available(*, deprecated, message: "Use ``PostgresQuery`` and ``PostgresBindings`` instead.")
+    public init<T>(array: [T]) where T: PostgresDataConvertible {
         self.init(
             array: array.map { $0.postgresData },
             elementType: T.postgresDataType
         )
     }
+
     public init(array: [PostgresData?], elementType: PostgresDataType) {
         var buffer = ByteBufferAllocator().buffer(capacity: 0)
         // 0 if empty, 1 if not
@@ -46,9 +46,8 @@ extension PostgresData {
         )
     }
 
-    public func array<T>(of type: T.Type = T.self) -> [T]?
-        where T: PostgresDataConvertible
-    {
+    @available(*, deprecated, message: "Use ``PostgresRow`` and ``PostgresDecodable`` instead.")
+    public func array<T>(of type: T.Type = T.self) -> [T]? where T: PostgresDataConvertible {
         guard let array = self.array else {
             return nil
         }
@@ -114,6 +113,7 @@ extension PostgresData {
     }
 }
 
+@available(*, deprecated, message: "Deprecating conformance to `PostgresDataConvertible`, since it is deprecated.")
 extension Array: PostgresDataConvertible where Element: PostgresDataConvertible {
     public static var postgresDataType: PostgresDataType {
         guard let arrayType = Element.postgresDataType.arrayType else {

--- a/Sources/PostgresNIO/Data/PostgresData+Bool.swift
+++ b/Sources/PostgresNIO/Data/PostgresData+Bool.swift
@@ -47,6 +47,7 @@ extension PostgresData: ExpressibleByBooleanLiteral {
     }
 }
 
+@available(*, deprecated, message: "Deprecating conformance to `PostgresDataConvertible`, since it is deprecated.")
 extension Bool: PostgresDataConvertible {
     public static var postgresDataType: PostgresDataType {
         return .bool

--- a/Sources/PostgresNIO/Data/PostgresData+Bytes.swift
+++ b/Sources/PostgresNIO/Data/PostgresData+Bytes.swift
@@ -21,6 +21,7 @@ extension PostgresData {
     }
 }
 
+@available(*, deprecated, message: "Deprecating conformance to `PostgresDataConvertible`, since it is deprecated.")
 extension Data: PostgresDataConvertible {
     public static var postgresDataType: PostgresDataType {
         return .bytea

--- a/Sources/PostgresNIO/Data/PostgresData+Date.swift
+++ b/Sources/PostgresNIO/Data/PostgresData+Date.swift
@@ -36,6 +36,7 @@ extension PostgresData {
     }
 }
 
+@available(*, deprecated, message: "Deprecating conformance to `PostgresDataConvertible`, since it is deprecated.")
 extension Date: PostgresDataConvertible {
     public static var postgresDataType: PostgresDataType {
         return .timestamptz

--- a/Sources/PostgresNIO/Data/PostgresData+Decimal.swift
+++ b/Sources/PostgresNIO/Data/PostgresData+Decimal.swift
@@ -16,6 +16,7 @@ extension PostgresData {
     }
 }
 
+@available(*, deprecated, message: "Deprecating conformance to `PostgresDataConvertible`, since it is deprecated.")
 extension Decimal: PostgresDataConvertible {
     public static var postgresDataType: PostgresDataType {
         return .numeric

--- a/Sources/PostgresNIO/Data/PostgresData+Double.swift
+++ b/Sources/PostgresNIO/Data/PostgresData+Double.swift
@@ -34,6 +34,7 @@ extension PostgresData {
     }
 }
 
+@available(*, deprecated, message: "Deprecating conformance to `PostgresDataConvertible`, since it is deprecated.")
 extension Double: PostgresDataConvertible {
     public static var postgresDataType: PostgresDataType {
         return .float8

--- a/Sources/PostgresNIO/Data/PostgresData+Float.swift
+++ b/Sources/PostgresNIO/Data/PostgresData+Float.swift
@@ -28,6 +28,7 @@ extension PostgresData {
     }
 }
 
+@available(*, deprecated, message: "Deprecating conformance to `PostgresDataConvertible`, since it is deprecated.")
 extension Float: PostgresDataConvertible {
     public static var postgresDataType: PostgresDataType {
         return .float4

--- a/Sources/PostgresNIO/Data/PostgresData+Int.swift
+++ b/Sources/PostgresNIO/Data/PostgresData+Int.swift
@@ -183,6 +183,7 @@ extension PostgresData {
     }
 }
 
+@available(*, deprecated, message: "Deprecating conformance to `PostgresDataConvertible`, since it is deprecated.")
 extension Int: PostgresDataConvertible {
     public static var postgresDataType: PostgresDataType { .int8 }
 
@@ -198,6 +199,7 @@ extension Int: PostgresDataConvertible {
     }
 }
 
+@available(*, deprecated, message: "Deprecating conformance to `PostgresDataConvertible`, since it is deprecated.")
 extension UInt8: PostgresDataConvertible {
     public static var postgresDataType: PostgresDataType { .char }
 
@@ -213,6 +215,7 @@ extension UInt8: PostgresDataConvertible {
     }
 }
 
+@available(*, deprecated, message: "Deprecating conformance to `PostgresDataConvertible`, since it is deprecated.")
 extension Int16: PostgresDataConvertible {
     public static var postgresDataType: PostgresDataType { .int2 }
 
@@ -228,6 +231,7 @@ extension Int16: PostgresDataConvertible {
     }
 }
 
+@available(*, deprecated, message: "Deprecating conformance to `PostgresDataConvertible`, since it is deprecated.")
 extension Int32: PostgresDataConvertible {
     public static var postgresDataType: PostgresDataType { .int4 }
 
@@ -243,6 +247,7 @@ extension Int32: PostgresDataConvertible {
     }
 }
 
+@available(*, deprecated, message: "Deprecating conformance to `PostgresDataConvertible`, since it is deprecated.")
 extension Int64: PostgresDataConvertible {
     public static var postgresDataType: PostgresDataType { .int8 }
 

--- a/Sources/PostgresNIO/Data/PostgresData+JSON.swift
+++ b/Sources/PostgresNIO/Data/PostgresData+JSON.swift
@@ -37,8 +37,10 @@ extension PostgresData {
     }
 }
 
+@available(*, deprecated, message: "This protocol is going to be replaced with ``PostgresEncodable`` and ``PostgresDecodable`` and conforming to ``Codable`` at the same time")
 public protocol PostgresJSONCodable: Codable, PostgresDataConvertible { }
 
+@available(*, deprecated, message: "Deprecating conformance to `PostgresDataConvertible`, since it is deprecated.")
 extension PostgresJSONCodable {
     public static var postgresDataType: PostgresDataType {
         return .json

--- a/Sources/PostgresNIO/Data/PostgresData+JSONB.swift
+++ b/Sources/PostgresNIO/Data/PostgresData+JSONB.swift
@@ -48,8 +48,10 @@ extension PostgresData {
     }
 }
 
+@available(*, deprecated, message: "This protocol is going to be replaced with ``PostgresEncodable`` and ``PostgresDecodable`` and conforming to ``Codable`` at the same time")
 public protocol PostgresJSONBCodable: Codable, PostgresDataConvertible { }
 
+@available(*, deprecated, message: "Deprecating conformance to `PostgresDataConvertible`, since it is deprecated.")
 extension PostgresJSONBCodable {
     public static var postgresDataType: PostgresDataType {
         return .jsonb

--- a/Sources/PostgresNIO/Data/PostgresData+Optional.swift
+++ b/Sources/PostgresNIO/Data/PostgresData+Optional.swift
@@ -1,3 +1,4 @@
+@available(*, deprecated, message: "Deprecating conformance to `PostgresDataConvertible`, since it is deprecated.")
 extension Optional: PostgresDataConvertible where Wrapped: PostgresDataConvertible {
     public static var postgresDataType: PostgresDataType {
         return Wrapped.postgresDataType

--- a/Sources/PostgresNIO/Data/PostgresData+RawRepresentable.swift
+++ b/Sources/PostgresNIO/Data/PostgresData+RawRepresentable.swift
@@ -1,3 +1,4 @@
+@available(*, deprecated, message: "Deprecating conformance to `PostgresDataConvertible`, since it is deprecated.")
 extension RawRepresentable where Self.RawValue: PostgresDataConvertible {
     public static var postgresDataType: PostgresDataType {
         RawValue.postgresDataType

--- a/Sources/PostgresNIO/Data/PostgresData+Set.swift
+++ b/Sources/PostgresNIO/Data/PostgresData+Set.swift
@@ -1,3 +1,4 @@
+@available(*, deprecated, message: "Deprecating conformance to `PostgresDataConvertible`, since it is deprecated.")
 extension Set: PostgresDataConvertible where Element: PostgresDataConvertible {
     public static var postgresDataType: PostgresDataType {
         [Element].postgresDataType

--- a/Sources/PostgresNIO/Data/PostgresData+String.swift
+++ b/Sources/PostgresNIO/Data/PostgresData+String.swift
@@ -94,6 +94,7 @@ extension PostgresData: ExpressibleByStringLiteral {
     }
 }
 
+@available(*, deprecated, message: "Deprecating conformance to `PostgresDataConvertible`, since it is deprecated.")
 extension String: PostgresDataConvertible {
     public static var postgresDataType: PostgresDataType {
         return .text

--- a/Sources/PostgresNIO/Data/PostgresData+UUID.swift
+++ b/Sources/PostgresNIO/Data/PostgresData+UUID.swift
@@ -29,6 +29,7 @@ extension PostgresData {
     }
 }
 
+@available(*, deprecated, message: "Deprecating conformance to `PostgresDataConvertible`, since it is deprecated.")
 extension UUID: PostgresDataConvertible {
     public static var postgresDataType: PostgresDataType {
         return .uuid

--- a/Sources/PostgresNIO/Data/PostgresData.swift
+++ b/Sources/PostgresNIO/Data/PostgresData.swift
@@ -1,7 +1,7 @@
 import NIOCore
 import struct Foundation.UUID
 
-public struct PostgresData: Sendable, CustomStringConvertible, CustomDebugStringConvertible {
+public struct PostgresData: Sendable {
     public static var null: PostgresData {
         return .init(type: .null)
     }
@@ -26,7 +26,10 @@ public struct PostgresData: Sendable, CustomStringConvertible, CustomDebugString
         self.formatCode = formatCode
         self.value = value
     }
-    
+}
+
+@available(*, deprecated, message: "Deprecating conformance to `CustomStringConvertible` as a first step of deprecating `PostgresData`. Please use `PostgresBindings` or `PostgresCell` instead.")
+extension PostgresData: CustomStringConvertible {
     public var description: String {
         guard var value = self.value else {
             return "<null>"
@@ -93,12 +96,16 @@ public struct PostgresData: Sendable, CustomStringConvertible, CustomDebugString
             return "\(raw) (\(self.type))"
         }
     }
+}
 
+@available(*, deprecated, message: "Deprecating conformance to `CustomDebugStringConvertible` as a first step of deprecating `PostgresData`. Please use `PostgresBindings` or `PostgresCell` instead.")
+extension PostgresData: CustomDebugStringConvertible {
     public var debugDescription: String {
         return self.description
     }
 }
 
+@available(*, deprecated, message: "Deprecating conformance to `PostgresDataConvertible`, since it is deprecated.")
 extension PostgresData: PostgresDataConvertible {
     public static var postgresDataType: PostgresDataType {
         fatalError("PostgresData cannot be statically represented as a single data type")

--- a/Sources/PostgresNIO/Data/PostgresDataConvertible.swift
+++ b/Sources/PostgresNIO/Data/PostgresDataConvertible.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+@available(*, deprecated, message: "This protocol is going to be replaced with ``PostgresEncodable`` and ``PostgresDecodable``")
 public protocol PostgresDataConvertible {
     static var postgresDataType: PostgresDataType { get }
     init?(postgresData: PostgresData)

--- a/Sources/PostgresNIO/Data/PostgresRow.swift
+++ b/Sources/PostgresNIO/Data/PostgresRow.swift
@@ -265,6 +265,7 @@ extension PostgresRandomAccessRow {
 // MARK: Deprecated API
 
 extension PostgresRow {
+    @available(*, deprecated, message: "Will be removed from public API.")
     public var rowDescription: PostgresMessage.RowDescription {
         let fields = self.columns.map { column in
             PostgresMessage.RowDescription.Field(
@@ -280,6 +281,7 @@ extension PostgresRow {
         return PostgresMessage.RowDescription(fields: fields)
     }
 
+    @available(*, deprecated, message: "Iterate the cells on `PostgresRow` instead.")
     public var dataRow: PostgresMessage.DataRow {
         let columns = self.data.map {
             PostgresMessage.DataRow.Column(value: $0)

--- a/Sources/PostgresNIO/Deprecated/PostgresMessage+SASLResponse.swift
+++ b/Sources/PostgresNIO/Deprecated/PostgresMessage+SASLResponse.swift
@@ -30,35 +30,13 @@ extension PostgresMessage {
 
 extension PostgresMessage {
     /// SASL initial challenge response message sent by the client.
-    public struct SASLInitialResponse: PostgresMessageType {
-        public static var identifier: PostgresMessage.Identifier {
-            return .saslInitialResponse
-        }
-        
+    @available(*, deprecated, message: "Will be removed from public API")
+    public struct SASLInitialResponse {
         public let mechanism: String
         public let initialData: [UInt8]
         
-        public static func parse(from buffer: inout ByteBuffer) throws -> PostgresMessage.SASLInitialResponse {
-            guard let mechanism = buffer.readNullTerminatedString() else {
-                throw PostgresError.protocol("Could not parse SASL mechanism from initial response message")
-            }
-            guard let dataLength = buffer.readInteger(as: Int32.self) else {
-                throw PostgresError.protocol("Could not parse SASL initial data length from initial response message")
-            }
-            
-            var actualData: [UInt8] = []
-            
-            if dataLength != -1 {
-                guard let data = buffer.readBytes(length: Int(dataLength)) else {
-                    throw PostgresError.protocol("Could not parse SASL initial data from initial response message")
-                }
-                actualData = data
-            }
-            return SASLInitialResponse(mechanism: mechanism, initialData: actualData)
-        }
-        
         public func serialize(into buffer: inout ByteBuffer) throws {
-            buffer.writeNullTerminatedString(mechanism)
+            buffer.writeNullTerminatedString(self.mechanism)
             if initialData.count > 0 {
                 buffer.writeInteger(Int32(initialData.count), as: Int32.self) // write(array:) writes Int16, which is incorrect here
                 buffer.writeBytes(initialData)
@@ -70,5 +48,31 @@ extension PostgresMessage {
         public var description: String {
             return "SASLInitialResponse(\(mechanism), data: \(initialData))"
         }
+    }
+}
+
+@available(*, deprecated, message: "Deprecating conformance to `PostgresMessageType` since it is deprecated.")
+extension PostgresMessage.SASLInitialResponse: PostgresMessageType {
+    public static var identifier: PostgresMessage.Identifier {
+        return .saslInitialResponse
+    }
+
+    public static func parse(from buffer: inout ByteBuffer) throws -> Self {
+        guard let mechanism = buffer.readNullTerminatedString() else {
+            throw PostgresError.protocol("Could not parse SASL mechanism from initial response message")
+        }
+        guard let dataLength = buffer.readInteger(as: Int32.self) else {
+            throw PostgresError.protocol("Could not parse SASL initial data length from initial response message")
+        }
+
+        var actualData: [UInt8] = []
+
+        if dataLength != -1 {
+            guard let data = buffer.readBytes(length: Int(dataLength)) else {
+                throw PostgresError.protocol("Could not parse SASL initial data from initial response message")
+            }
+            actualData = data
+        }
+        return .init(mechanism: mechanism, initialData: actualData)
     }
 }

--- a/Sources/PostgresNIO/Docs.docc/index.md
+++ b/Sources/PostgresNIO/Docs.docc/index.md
@@ -45,6 +45,7 @@ Features:
 - ``PostgresJSONEncoder``
 - ``PostgresJSONDecoder``
 - ``PostgresDataType``
+- ``PostgresFormat``
 - ``PostgresNumeric``
 
 ### Notifications
@@ -72,8 +73,11 @@ removed from the public API with the next major release.
 - ``PostgresRequest``
 - ``PostgresMessage``
 - ``PostgresMessageType``
+- ``PostgresFormatCode``
 - ``SASLAuthenticationManager``
 - ``SASLAuthenticationMechanism``
+- ``SASLAuthenticationError``
+- ``SASLAuthenticationStepResult``
 
 [SwiftNIO]: https://github.com/apple/swift-nio
 [SwiftLog]: https://github.com/apple/swift-log

--- a/Sources/PostgresNIO/Message/PostgresMessage+0.swift
+++ b/Sources/PostgresNIO/Message/PostgresMessage+0.swift
@@ -2,9 +2,11 @@ import NIOCore
 
 /// A frontend or backend Postgres message.
 public struct PostgresMessage: Equatable {
+    @available(*, deprecated, message: "Will be removed from public API.")
     public var identifier: Identifier
     public var data: ByteBuffer
 
+    @available(*, deprecated, message: "Will be removed from public API.")
     public init<Data>(identifier: Identifier, bytes: Data)
         where Data: Sequence, Data.Element == UInt8
     {
@@ -13,6 +15,7 @@ public struct PostgresMessage: Equatable {
         self.init(identifier: identifier, data: buffer)
     }
 
+    @available(*, deprecated, message: "Will be removed from public API.")
     public init(identifier: Identifier, data: ByteBuffer) {
         self.identifier = identifier
         self.data = data

--- a/Sources/PostgresNIO/Message/PostgresMessage+BackendKeyData.swift
+++ b/Sources/PostgresNIO/Message/PostgresMessage+BackendKeyData.swift
@@ -3,26 +3,29 @@ import NIOCore
 extension PostgresMessage {
     /// Identifies the message as cancellation key data.
     /// The frontend must save these values if it wishes to be able to issue CancelRequest messages later.
-    public struct BackendKeyData: PostgresMessageType {
-        public static var identifier: PostgresMessage.Identifier {
-            .backendKeyData
-        }
-        
-        /// Parses an instance of this message type from a byte buffer.
-        public static func parse(from buffer: inout ByteBuffer) throws -> BackendKeyData {
-            guard let processID = buffer.readInteger(as: Int32.self) else {
-                throw PostgresError.protocol("Could not parse process id from backend key data")
-            }
-            guard let secretKey = buffer.readInteger(as: Int32.self) else {
-                throw PostgresError.protocol("Could not parse secret key from backend key data")
-            }
-            return .init(processID: processID, secretKey: secretKey)
-        }
-        
+    public struct BackendKeyData {
         /// The process ID of this backend.
         public var processID: Int32
         
         /// The secret key of this backend.
         public var secretKey: Int32
+    }
+}
+
+@available(*, deprecated, message: "Deprecating conformance to `PostgresMessageType` since it is deprecated.")
+extension PostgresMessage.BackendKeyData: PostgresMessageType {
+    public static var identifier: PostgresMessage.Identifier {
+        .backendKeyData
+    }
+
+    /// Parses an instance of this message type from a byte buffer.
+    public static func parse(from buffer: inout ByteBuffer) throws -> Self {
+        guard let processID = buffer.readInteger(as: Int32.self) else {
+            throw PostgresError.protocol("Could not parse process id from backend key data")
+        }
+        guard let secretKey = buffer.readInteger(as: Int32.self) else {
+            throw PostgresError.protocol("Could not parse secret key from backend key data")
+        }
+        return .init(processID: processID, secretKey: secretKey)
     }
 }

--- a/Sources/PostgresNIO/Message/PostgresMessage+Identifier.swift
+++ b/Sources/PostgresNIO/Message/PostgresMessage+Identifier.swift
@@ -3,6 +3,7 @@ import NIOCore
 extension PostgresMessage {
     /// Identifies an incoming or outgoing postgres message. Sent as the first byte, before the message size.
     /// Values are not unique across all identifiers, meaning some messages will require keeping state to identify.
+    @available(*, deprecated, message: "Will be removed from public API.")
     public struct Identifier: ExpressibleByIntegerLiteral, Equatable, CustomStringConvertible {
         // special
         public static let none: Identifier = 0x00
@@ -143,6 +144,7 @@ extension PostgresMessage {
 }
 
 extension ByteBuffer {
+    @available(*, deprecated, message: "Will be removed from public API")
     mutating func write(identifier: PostgresMessage.Identifier) {
         self.writeInteger(identifier.value)
     }

--- a/Sources/PostgresNIO/Message/PostgresMessage+NotificationResponse.swift
+++ b/Sources/PostgresNIO/Message/PostgresMessage+NotificationResponse.swift
@@ -2,25 +2,28 @@ import NIOCore
 
 extension PostgresMessage {
     /// Identifies the message as a notification response.
-    public struct NotificationResponse: PostgresMessageType {
-        public static let identifier = Identifier.notificationResponse
-
-        /// Parses an instance of this message type from a byte buffer.
-        public static func parse(from buffer: inout ByteBuffer) throws -> Self {
-            guard let backendPID: Int32 = buffer.readInteger() else {
-                throw PostgresError.protocol("Invalid NotificationResponse message: unable to read backend PID")
-            }
-            guard let channel = buffer.readNullTerminatedString() else {
-                throw PostgresError.protocol("Invalid NotificationResponse message: unable to read channel")
-            }
-            guard let payload = buffer.readNullTerminatedString() else {
-                throw PostgresError.protocol("Invalid NotificationResponse message: unable to read payload")
-            }
-            return .init(backendPID: backendPID, channel: channel, payload: payload)
-        }
-
+    public struct NotificationResponse {
         public var backendPID: Int32
         public var channel: String
         public var payload: String
+    }
+}
+
+@available(*, deprecated, message: "Deprecating conformance to `PostgresMessageType` since it is deprecated.")
+extension PostgresMessage.NotificationResponse: PostgresMessageType {
+    public static let identifier = PostgresMessage.Identifier.notificationResponse
+
+    /// Parses an instance of this message type from a byte buffer.
+    public static func parse(from buffer: inout ByteBuffer) throws -> Self {
+        guard let backendPID: Int32 = buffer.readInteger() else {
+            throw PostgresError.protocol("Invalid NotificationResponse message: unable to read backend PID")
+        }
+        guard let channel = buffer.readNullTerminatedString() else {
+            throw PostgresError.protocol("Invalid NotificationResponse message: unable to read channel")
+        }
+        guard let payload = buffer.readNullTerminatedString() else {
+            throw PostgresError.protocol("Invalid NotificationResponse message: unable to read payload")
+        }
+        return .init(backendPID: backendPID, channel: channel, payload: payload)
     }
 }

--- a/Sources/PostgresNIO/Message/PostgresMessage+RowDescription.swift
+++ b/Sources/PostgresNIO/Message/PostgresMessage+RowDescription.swift
@@ -2,12 +2,7 @@ import NIOCore
 
 extension PostgresMessage {
     /// Identifies the message as a row description.
-    public struct RowDescription: PostgresMessageType {
-        /// See `PostgresMessageType`.
-        public static var identifier: PostgresMessage.Identifier {
-            return .rowDescription
-        }
-        
+    public struct RowDescription {
         /// Describes a single field returns in a `RowDescription` message.
         public struct Field: CustomStringConvertible {
             static func parse(from buffer: inout ByteBuffer) throws -> Field {
@@ -73,15 +68,7 @@ extension PostgresMessage {
             }
         }
         
-        /// Parses an instance of this message type from a byte buffer.
-        public static func parse(from buffer: inout ByteBuffer) throws -> RowDescription {
-            guard let fields = try buffer.read(array: Field.self, { buffer in
-                return try.parse(from: &buffer)
-            }) else {
-                throw PostgresError.protocol("Could not read row description fields")
-            }
-            return .init(fields: fields)
-        }
+
         
         /// The fields supplied in the row description.
         public var fields: [Field]
@@ -90,5 +77,23 @@ extension PostgresMessage {
         public var description: String {
             return "Row(\(self.fields)"
         }
+    }
+}
+
+@available(*, deprecated, message: "Deprecating conformance to `PostgresMessageType` since it is deprecated.")
+extension PostgresMessage.RowDescription: PostgresMessageType {
+    /// See `PostgresMessageType`.
+    public static var identifier: PostgresMessage.Identifier {
+        return .rowDescription
+    }
+
+    /// Parses an instance of this message type from a byte buffer.
+    public static func parse(from buffer: inout ByteBuffer) throws -> Self {
+        guard let fields = try buffer.read(array: Field.self, { buffer in
+            return try.parse(from: &buffer)
+        }) else {
+            throw PostgresError.protocol("Could not read row description fields")
+        }
+        return .init(fields: fields)
     }
 }

--- a/Sources/PostgresNIO/Message/PostgresMessageType.swift
+++ b/Sources/PostgresNIO/Message/PostgresMessageType.swift
@@ -1,12 +1,15 @@
 import NIOCore
 
+@available(*, deprecated, message: "Will be removed from public API. Internally we now use `PostgresBackendMessage` and `PostgresFrontendMessage`")
 public protocol PostgresMessageType {
     static var identifier: PostgresMessage.Identifier { get }
     static func parse(from buffer: inout ByteBuffer) throws -> Self
     func serialize(into buffer: inout ByteBuffer) throws
 }
 
+@available(*, deprecated, message: "`PostgresMessageType` protocol is deprecated.")
 extension PostgresMessageType {
+    @available(*, deprecated, message: "Will be removed from public API.")
     func message() throws -> PostgresMessage {
         var buffer = ByteBufferAllocator().buffer(capacity: 0)
         try self.serialize(into: &buffer)
@@ -17,7 +20,8 @@ extension PostgresMessageType {
         var message = message
         self = try Self.parse(from: &message.data)
     }
-    
+
+    @available(*, deprecated, message: "Will be removed from public API.")
     public static var identifier: PostgresMessage.Identifier {
         return .none
     }

--- a/Tests/IntegrationTests/PerformanceTests.swift
+++ b/Tests/IntegrationTests/PerformanceTests.swift
@@ -73,6 +73,7 @@ final class PerformanceTests: XCTestCase {
         }
     }
 
+    @available(*, deprecated, message: "Testing deprecated functionality")
     func testPerformanceSelectMediumModel() throws {
         let conn = try PostgresConnection.test(on: eventLoop).wait()
         defer { try! conn.close().wait() }
@@ -115,6 +116,7 @@ final class PerformanceTests: XCTestCase {
         }
     }
 
+    @available(*, deprecated, message: "Testing deprecated functionality")
     func testPerformanceSelectLargeModel() throws {
         let conn = try PostgresConnection.test(on: eventLoop).wait()
         defer { try! conn.close().wait() }

--- a/Tests/IntegrationTests/PostgresNIOTests.swift
+++ b/Tests/IntegrationTests/PostgresNIOTests.swift
@@ -558,7 +558,8 @@ final class PostgresNIOTests: XCTestCase {
         let row = rows?.first?.makeRandomAccess()
         XCTAssertEqual(row?[data: "array"].array(of: Int.self), [])
     }
-    
+
+    @available(*, deprecated, message: "Testing deprecated functionality")
     func testOptionalIntegerArrayParse() {
         var conn: PostgresConnection?
         XCTAssertNoThrow(conn = try PostgresConnection.test(on: eventLoop).wait())
@@ -617,7 +618,8 @@ final class PostgresNIOTests: XCTestCase {
         let row = rows?.first?.makeRandomAccess()
         XCTAssertEqual(row?[data: "array"].array(of: Int.self), [])
     }
-    
+
+    @available(*, deprecated, message: "Testing deprecated functionality")
     func testOptionalIntegerArraySerialize() {
         var conn: PostgresConnection?
         XCTAssertNoThrow(conn = try PostgresConnection.test(on: eventLoop).wait())

--- a/Tests/IntegrationTests/PostgresNIOTests.swift
+++ b/Tests/IntegrationTests/PostgresNIOTests.swift
@@ -531,6 +531,7 @@ final class PostgresNIOTests: XCTestCase {
         XCTAssertEqual(row?[data: "e"].string, "12345678.90")
     }
 
+    @available(*, deprecated, message: "Testing deprecated functionality")
     func testIntegerArrayParse() {
         var conn: PostgresConnection?
         XCTAssertNoThrow(conn = try PostgresConnection.test(on: eventLoop).wait())
@@ -544,6 +545,7 @@ final class PostgresNIOTests: XCTestCase {
         XCTAssertEqual(row?[data: "array"].array(of: Int.self), [1, 2, 3])
     }
 
+    @available(*, deprecated, message: "Testing deprecated functionality")
     func testEmptyIntegerArrayParse() {
         var conn: PostgresConnection?
         XCTAssertNoThrow(conn = try PostgresConnection.test(on: eventLoop).wait())
@@ -570,6 +572,7 @@ final class PostgresNIOTests: XCTestCase {
         XCTAssertEqual(row?[data: "array"].array(of: Int?.self), [1, 2, nil, 4])
     }
 
+    @available(*, deprecated, message: "Testing deprecated functionality")
     func testNullIntegerArrayParse() {
         var conn: PostgresConnection?
         XCTAssertNoThrow(conn = try PostgresConnection.test(on: eventLoop).wait())
@@ -583,6 +586,7 @@ final class PostgresNIOTests: XCTestCase {
         XCTAssertEqual(row?[data: "array"].array(of: Int.self), nil)
     }
 
+    @available(*, deprecated, message: "Testing deprecated functionality")
     func testIntegerArraySerialize() {
         var conn: PostgresConnection?
         XCTAssertNoThrow(conn = try PostgresConnection.test(on: eventLoop).wait())
@@ -598,6 +602,7 @@ final class PostgresNIOTests: XCTestCase {
         XCTAssertEqual(row?[data: "array"].array(of: Int.self), [1, 2, 3])
     }
 
+    @available(*, deprecated, message: "Testing deprecated functionality")
     func testEmptyIntegerArraySerialize() {
         var conn: PostgresConnection?
         XCTAssertNoThrow(conn = try PostgresConnection.test(on: eventLoop).wait())
@@ -855,6 +860,7 @@ final class PostgresNIOTests: XCTestCase {
         XCTAssertEqual(row?[data: "t2_dateValue"].date, dateInTable2)
     }
 
+    @available(*, deprecated, message: "Testing deprecated functionality")
     func testStringArrays() {
         let query = """
         SELECT
@@ -936,6 +942,7 @@ final class PostgresNIOTests: XCTestCase {
         XCTAssertEqual(row?[data: "char"].string, "*")
     }
 
+    @available(*, deprecated, message: "Testing deprecated functionality")
     func testDoubleArraySerialization() {
         var conn: PostgresConnection?
         XCTAssertNoThrow(conn = try PostgresConnection.test(on: eventLoop).wait())
@@ -1057,6 +1064,7 @@ final class PostgresNIOTests: XCTestCase {
         XCTAssertEqual(row?[data: "foo"].string, "qux")
     }
 
+    @available(*, deprecated, message: "Testing deprecated functionality")
     func testNullBind() {
         var conn: PostgresConnection?
         XCTAssertNoThrow(conn = try PostgresConnection.test(on: eventLoop).wait())
@@ -1106,6 +1114,7 @@ final class PostgresNIOTests: XCTestCase {
     }
 
     // https://github.com/vapor/postgres-nio/issues/113
+    @available(*, deprecated, message: "Testing deprecated functionality")
     func testVaryingCharArray() {
         var conn: PostgresConnection?
         XCTAssertNoThrow(conn = try PostgresConnection.test(on: eventLoop).wait())

--- a/Tests/PostgresNIOTests/Data/PostgresData+JSONTests.swift
+++ b/Tests/PostgresNIOTests/Data/PostgresData+JSONTests.swift
@@ -2,6 +2,7 @@ import PostgresNIO
 import XCTest
 
 class PostgresData_JSONTests: XCTestCase {
+    @available(*, deprecated, message: "Testing deprecated functionality")
     func testJSONBConvertible() {
         struct Object: PostgresJSONBCodable {
             let foo: Int


### PR DESCRIPTION
### Motivation

We want to inform users of patterns that will be going away.

### Changes

- deprecate `PostgresDataConvertible`
- deprecate `PostgresMessageType`
- deprecate `PostgresJSONCodable`
- deprecate `PostgresJSONBCodable`
