### PR TITLE
Add method to connect using existing channel

### DIFF
--- a/Tests/IntegrationTests/PSQLIntegrationTests.swift
+++ b/Tests/IntegrationTests/PSQLIntegrationTests.swift
@@ -17,6 +17,16 @@ final class IntegrationTests: XCTestCase {
         XCTAssertNoThrow(try conn?.close().wait())
     }
 
+    func testConnectAndCloseUsingChannel() throws {
+        let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully()) }
+        let eventLoop = eventLoopGroup.next()
+        
+        var conn: PostgresConnection?
+        XCTAssertNoThrow(conn = try PostgresConnection.testWithChannel(on: eventLoop).wait())
+        XCTAssertNoThrow(try conn?.close().wait())
+    }
+
     func testAuthenticationFailure() throws {
         // If the postgres server trusts every connection, it is really hard to create an
         // authentication failure.

--- a/Tests/IntegrationTests/PostgresNIOTests.swift
+++ b/Tests/IntegrationTests/PostgresNIOTests.swift
@@ -41,6 +41,16 @@ final class PostgresNIOTests: XCTestCase {
         XCTAssertEqual(rows?.count, 1)
         XCTAssertEqual(try rows?.first?.decode(String.self, context: .default).contains("PostgreSQL"), true)
     }
+    
+    func testSimpleQueryVersionUsingChannel() {
+        var conn: PostgresConnection?
+        XCTAssertNoThrow(conn = try PostgresConnection.testWithChannel(on: eventLoop).wait())
+        defer { XCTAssertNoThrow( try conn?.close().wait() ) }
+        var rows: [PostgresRow]?
+        XCTAssertNoThrow(rows = try conn?.simpleQuery("SELECT version()").wait())
+        XCTAssertEqual(rows?.count, 1)
+        XCTAssertEqual(try rows?.first?.decode(String.self, context: .default).contains("PostgreSQL"), true)
+    }
 
     func testQueryVersion() {
         var conn: PostgresConnection?


### PR DESCRIPTION
Add a `connect` method that allows using an existing `Channel` for the connection.

This makes it possible to for example create an SSH tunnel and establish a Postgres connection on the SSH Channel.