### PR TITLE
Use NIOFoundationCompat for UUID <-> ByteBuffer

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-atomics.git", from: "1.0.2"),
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.42.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.44.0"),
         .package(url: "https://github.com/apple/swift-nio-transport-services.git", from: "1.13.1"),
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.22.1"),
         .package(url: "https://github.com/apple/swift-crypto.git", "1.0.0" ..< "3.0.0"),

--- a/Sources/PostgresNIO/Data/PostgresData+String.swift
+++ b/Sources/PostgresNIO/Data/PostgresData+String.swift
@@ -22,7 +22,7 @@ extension PostgresData {
             case .numeric:
                 return self.numeric?.string
             case .uuid:
-                return value.readUUID()!.uuidString
+                return value.readUUIDBytes()!.uuidString
             case .timestamp, .timestamptz, .date:
                 return self.date?.description
             case .money:

--- a/Sources/PostgresNIO/Data/PostgresData+UUID.swift
+++ b/Sources/PostgresNIO/Data/PostgresData+UUID.swift
@@ -4,12 +4,7 @@ import NIOCore
 extension PostgresData {
     public init(uuid: UUID) {
         var buffer = ByteBufferAllocator().buffer(capacity: 16)
-        buffer.writeBytes([
-            uuid.uuid.0, uuid.uuid.1, uuid.uuid.2, uuid.uuid.3,
-            uuid.uuid.4, uuid.uuid.5, uuid.uuid.6, uuid.uuid.7,
-            uuid.uuid.8, uuid.uuid.9, uuid.uuid.10, uuid.uuid.11,
-            uuid.uuid.12, uuid.uuid.13, uuid.uuid.14, uuid.uuid.15,
-        ])
+        buffer.writeUUIDBytes(uuid)
         self.init(type: .uuid, formatCode: .binary, value: buffer)
     }
     
@@ -22,7 +17,7 @@ extension PostgresData {
         case .binary:
             switch self.type {
             case .uuid:
-                return value.readUUID()
+                return value.readUUIDBytes()
             case .varchar, .text:
                 return self.string.flatMap { UUID(uuidString: $0) }
             default:

--- a/Sources/PostgresNIO/New/Data/UUID+PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/Data/UUID+PostgresCodable.swift
@@ -16,13 +16,7 @@ extension UUID: PostgresEncodable {
         into byteBuffer: inout ByteBuffer,
         context: PostgresEncodingContext<JSONEncoder>
     ) {
-        let uuid = self.uuid
-        byteBuffer.writeBytes([
-            uuid.0, uuid.1, uuid.2, uuid.3,
-            uuid.4, uuid.5, uuid.6, uuid.7,
-            uuid.8, uuid.9, uuid.10, uuid.11,
-            uuid.12, uuid.13, uuid.14, uuid.15,
-        ])
+        byteBuffer.writeUUIDBytes(self)
     }
 }
 
@@ -36,7 +30,7 @@ extension UUID: PostgresDecodable {
     ) throws {
         switch (format, type) {
         case (.binary, .uuid):
-            guard let uuid = buffer.readUUID() else {
+            guard let uuid = buffer.readUUIDBytes() else {
                 throw PostgresDecodingError.Code.failure
             }
             self = uuid
@@ -60,28 +54,3 @@ extension UUID: PostgresDecodable {
 }
 
 extension UUID: PostgresCodable {}
-
-extension ByteBuffer {
-    @usableFromInline
-    mutating func readUUID() -> UUID? {
-        guard self.readableBytes >= MemoryLayout<uuid_t>.size else {
-            return nil
-        }
-
-        let value: UUID = self.getUUID(at: self.readerIndex)! /* must work as we have enough bytes */
-        // should be MoveReaderIndex
-        self.moveReaderIndex(forwardBy: MemoryLayout<uuid_t>.size)
-        return value
-    }
-
-    func getUUID(at index: Int) -> UUID? {
-        var uuid: uuid_t = (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
-        return self.viewBytes(at: index, length: MemoryLayout.size(ofValue: uuid)).map { bufferBytes in
-            withUnsafeMutableBytes(of: &uuid) { target in
-                precondition(target.count <= bufferBytes.count)
-                target.copyBytes(from: bufferBytes)
-            }
-            return UUID(uuid: uuid)
-        }
-    }
-}


### PR DESCRIPTION
### Motivation

`NIOFoundationCompat` has added methods to read and write UUID from/to ByteBuffers. We like to maintain less code.

### Changes

- Use methods from `NIOFoundationCompat` to read and write UUID from/to ByteBuffers
- Require `NIO 2.44.0`

### Result 

Less code to maintain.