### PR TITLE
PostgresCodable should be a typealias

### DIFF
--- a/Sources/PostgresNIO/New/Data/Bool+PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/Data/Bool+PostgresCodable.swift
@@ -60,5 +60,3 @@ extension Bool: PostgresEncodable {
         byteBuffer.writeInteger(self ? 1 : 0, as: UInt8.self)
     }
 }
-
-extension Bool: PostgresCodable {}

--- a/Sources/PostgresNIO/New/Data/Bytes+PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/Data/Bytes+PostgresCodable.swift
@@ -51,8 +51,6 @@ extension ByteBuffer: PostgresDecodable {
     }
 }
 
-extension ByteBuffer: PostgresCodable {}
-
 extension Data: PostgresEncodable {
     public static var psqlType: PostgresDataType {
         .bytea
@@ -82,5 +80,3 @@ extension Data: PostgresDecodable {
         self = buffer.readData(length: buffer.readableBytes, byteTransferStrategy: .automatic)!
     }
 }
-
-extension Data: PostgresCodable {}

--- a/Sources/PostgresNIO/New/Data/Date+PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/Data/Date+PostgresCodable.swift
@@ -57,5 +57,3 @@ extension Date: PostgresDecodable {
         }
     }
 }
-
-extension Date: PostgresCodable {}

--- a/Sources/PostgresNIO/New/Data/Decimal+PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/Data/Decimal+PostgresCodable.swift
@@ -47,5 +47,3 @@ extension Decimal: PostgresDecodable {
         }
     }
 }
-
-extension Decimal: PostgresCodable {}

--- a/Sources/PostgresNIO/New/Data/Float+PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/Data/Float+PostgresCodable.swift
@@ -48,8 +48,6 @@ extension Float: PostgresDecodable {
     }
 }
 
-extension Float: PostgresCodable {}
-
 extension Double: PostgresEncodable {
     public static var psqlType: PostgresDataType {
         .float8
@@ -97,5 +95,3 @@ extension Double: PostgresDecodable {
         }
     }
 }
-
-extension Double: PostgresCodable {}

--- a/Sources/PostgresNIO/New/Data/Int+PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/Data/Int+PostgresCodable.swift
@@ -41,8 +41,6 @@ extension UInt8: PostgresDecodable {
     }
 }
 
-extension UInt8: PostgresCodable {}
-
 // MARK: Int16
 
 extension Int16: PostgresEncodable {
@@ -87,8 +85,6 @@ extension Int16: PostgresDecodable {
         }
     }
 }
-
-extension Int16: PostgresCodable {}
 
 // MARK: Int32
 
@@ -139,8 +135,6 @@ extension Int32: PostgresDecodable {
         }
     }
 }
-
-extension Int32: PostgresCodable {}
 
 // MARK: Int64
 
@@ -196,8 +190,6 @@ extension Int64: PostgresDecodable {
         }
     }
 }
-
-extension Int64: PostgresCodable {}
 
 // MARK: Int
 
@@ -260,5 +252,3 @@ extension Int: PostgresDecodable {
         }
     }
 }
-
-extension Int: PostgresCodable {}

--- a/Sources/PostgresNIO/New/Data/JSON+PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/Data/JSON+PostgresCodable.swift
@@ -45,5 +45,3 @@ extension PostgresDecodable where Self: Decodable {
         }
     }
 }
-
-extension PostgresCodable where Self: Codable {}

--- a/Sources/PostgresNIO/New/Data/RawRepresentable+PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/Data/RawRepresentable+PostgresCodable.swift
@@ -33,5 +33,3 @@ extension PostgresDecodable where Self: RawRepresentable, RawValue: PostgresDeco
         self = selfValue
     }
 }
-
-extension PostgresCodable where Self: RawRepresentable, RawValue: PostgresCodable, RawValue._DecodableType == RawValue {}

--- a/Sources/PostgresNIO/New/Data/String+PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/Data/String+PostgresCodable.swift
@@ -45,5 +45,3 @@ extension String: PostgresDecodable {
         }
     }
 }
-
-extension String: PostgresCodable {}

--- a/Sources/PostgresNIO/New/Data/UUID+PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/Data/UUID+PostgresCodable.swift
@@ -52,5 +52,3 @@ extension UUID: PostgresDecodable {
         }
     }
 }
-
-extension UUID: PostgresCodable {}

--- a/Sources/PostgresNIO/New/PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/PostgresCodable.swift
@@ -68,7 +68,7 @@ extension PostgresDecodable {
 }
 
 /// A type that can be encoded into and decoded from a postgres binary format
-protocol PostgresCodable: PostgresEncodable, PostgresDecodable {}
+typealias PostgresCodable = PostgresEncodable & PostgresDecodable
 
 extension PostgresEncodable {
     @inlinable


### PR DESCRIPTION
### Motivation

`PostgresCodable` only marks a type as `PostgresEncodable` and `PostgresDecodable`. For this reason this should not be an extra protocol. Instead it should be a typealias. (See same pattern in Codable – which also is just a typealias).

Lucky for us we never made `PostgresCodable` public so far.

### Changes

- `PostgresCodable` is a typealias