### PR TITLE
Add new protocol PostgresNonThrowingEncodable

### DIFF
--- a/Sources/PostgresNIO/New/Data/Bool+PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/Data/Bool+PostgresCodable.swift
@@ -43,7 +43,7 @@ extension Bool: PostgresDecodable {
     }
 }
 
-extension Bool: PostgresEncodable {
+extension Bool: PostgresNonThrowingEncodable {
     public static var psqlType: PostgresDataType {
         .bool
     }

--- a/Sources/PostgresNIO/New/Data/Bytes+PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/Data/Bytes+PostgresCodable.swift
@@ -6,7 +6,7 @@ extension PostgresEncodable where Self: Sequence, Self.Element == UInt8 {
     public static var psqlType: PostgresDataType {
         .bytea
     }
-    
+
     public static var psqlFormat: PostgresFormat {
         .binary
     }
@@ -20,7 +20,9 @@ extension PostgresEncodable where Self: Sequence, Self.Element == UInt8 {
     }
 }
 
-extension ByteBuffer: PostgresEncodable {
+extension PostgresNonThrowingEncodable where Self: Sequence, Self.Element == UInt8 {}
+
+extension ByteBuffer: PostgresNonThrowingEncodable {
     public static var psqlType: PostgresDataType {
         .bytea
     }

--- a/Sources/PostgresNIO/New/Data/Date+PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/Data/Date+PostgresCodable.swift
@@ -1,7 +1,7 @@
 import NIOCore
 import struct Foundation.Date
 
-extension Date: PostgresEncodable {
+extension Date: PostgresNonThrowingEncodable {
     public static var psqlType: PostgresDataType {
         .timestamptz
     }

--- a/Sources/PostgresNIO/New/Data/Float+PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/Data/Float+PostgresCodable.swift
@@ -1,6 +1,6 @@
 import NIOCore
 
-extension Float: PostgresEncodable {
+extension Float: PostgresNonThrowingEncodable {
     public static var psqlType: PostgresDataType {
         .float4
     }
@@ -48,7 +48,7 @@ extension Float: PostgresDecodable {
     }
 }
 
-extension Double: PostgresEncodable {
+extension Double: PostgresNonThrowingEncodable {
     public static var psqlType: PostgresDataType {
         .float8
     }

--- a/Sources/PostgresNIO/New/Data/Int+PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/Data/Int+PostgresCodable.swift
@@ -2,7 +2,7 @@ import NIOCore
 
 // MARK: UInt8
 
-extension UInt8: PostgresEncodable {
+extension UInt8: PostgresNonThrowingEncodable {
     public static var psqlType: PostgresDataType {
         .char
     }
@@ -43,7 +43,7 @@ extension UInt8: PostgresDecodable {
 
 // MARK: Int16
 
-extension Int16: PostgresEncodable {
+extension Int16: PostgresNonThrowingEncodable {
     public static var psqlType: PostgresDataType {
         .int2
     }
@@ -88,7 +88,7 @@ extension Int16: PostgresDecodable {
 
 // MARK: Int32
 
-extension Int32: PostgresEncodable {
+extension Int32: PostgresNonThrowingEncodable {
     public static var psqlType: PostgresDataType {
         .int4
     }
@@ -138,7 +138,7 @@ extension Int32: PostgresDecodable {
 
 // MARK: Int64
 
-extension Int64: PostgresEncodable {
+extension Int64: PostgresNonThrowingEncodable {
     public static var psqlType: PostgresDataType {
         .int8
     }
@@ -193,7 +193,7 @@ extension Int64: PostgresDecodable {
 
 // MARK: Int
 
-extension Int: PostgresEncodable {
+extension Int: PostgresNonThrowingEncodable {
     public static var psqlType: PostgresDataType {
         switch MemoryLayout<Int>.size {
         case 4:

--- a/Sources/PostgresNIO/New/Data/String+PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/Data/String+PostgresCodable.swift
@@ -1,7 +1,7 @@
 import NIOCore
 import struct Foundation.UUID
 
-extension String: PostgresEncodable {
+extension String: PostgresNonThrowingEncodable {
     public static var psqlType: PostgresDataType {
         .text
     }

--- a/Sources/PostgresNIO/New/Data/UUID+PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/Data/UUID+PostgresCodable.swift
@@ -2,7 +2,7 @@ import NIOCore
 import struct Foundation.UUID
 import typealias Foundation.uuid_t
 
-extension UUID: PostgresEncodable {
+extension UUID: PostgresNonThrowingEncodable {
     public static var psqlType: PostgresDataType {
         .uuid
     }

--- a/Sources/PostgresNIO/New/PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/PostgresCodable.swift
@@ -3,6 +3,8 @@ import Foundation
 
 /// A type that can encode itself to a postgres wire binary representation.
 public protocol PostgresEncodable {
+    // TODO: Rename to `PostgresThrowingEncodable` with next major release
+
     /// identifies the data type that we will encode into `byteBuffer` in `encode`
     static var psqlType: PostgresDataType { get }
 
@@ -19,6 +21,8 @@ public protocol PostgresEncodable {
 /// to create ``PostgresQuery``s using the `ExpressibleByStringInterpolation` without
 /// having to spell `try`.
 public protocol PostgresNonThrowingEncodable: PostgresEncodable {
+    // TODO: Rename to `PostgresEncodable` with next major release
+
     func encode<JSONEncoder: PostgresJSONEncoder>(into byteBuffer: inout ByteBuffer, context: PostgresEncodingContext<JSONEncoder>)
 }
 

--- a/Tests/IntegrationTests/AsyncTests.swift
+++ b/Tests/IntegrationTests/AsyncTests.swift
@@ -90,7 +90,7 @@ final class AsyncPostgresConnectionTests: XCTestCase {
             var binds = PostgresBindings(capacity: Int(UInt16.max))
             for _ in (0..<rowsCount) {
                 for num in (0..<columnsCount) {
-                    try binds.append(num, context: .default)
+                    binds.append(num, context: .default)
                 }
             }
             XCTAssertEqual(binds.count, Int(UInt16.max))

--- a/Tests/PostgresNIOTests/New/Connection State Machine/ExtendedQueryStateMachineTests.swift
+++ b/Tests/PostgresNIOTests/New/Connection State Machine/ExtendedQueryStateMachineTests.swift
@@ -12,7 +12,7 @@ class ExtendedQueryStateMachineTests: XCTestCase {
         let logger = Logger.psqlTest
         let promise = EmbeddedEventLoop().makePromise(of: PSQLRowStream.self)
         promise.fail(PSQLError.uncleanShutdown) // we don't care about the error at all.
-        let query: PostgresQuery = try! "DELETE FROM table WHERE id=\(1)"
+        let query: PostgresQuery = "DELETE FROM table WHERE id=\(1)"
         let queryContext = ExtendedQueryContext(query: query, logger: logger, promise: promise)
         
         XCTAssertEqual(state.enqueue(task: .extendedQuery(queryContext)), .sendParseDescribeBindExecuteSync(query))
@@ -84,7 +84,7 @@ class ExtendedQueryStateMachineTests: XCTestCase {
         let logger = Logger.psqlTest
         let promise = EmbeddedEventLoop().makePromise(of: PSQLRowStream.self)
         promise.fail(PSQLError.uncleanShutdown) // we don't care about the error at all.
-        let query: PostgresQuery = try! "DELETE FROM table WHERE id=\(1)"
+        let query: PostgresQuery = "DELETE FROM table WHERE id=\(1)"
         let queryContext = ExtendedQueryContext(query: query, logger: logger, promise: promise)
         
         XCTAssertEqual(state.enqueue(task: .extendedQuery(queryContext)), .sendParseDescribeBindExecuteSync(query))

--- a/Tests/PostgresNIOTests/New/Data/Array+PSQLCodableTests.swift
+++ b/Tests/PostgresNIOTests/New/Data/Array+PSQLCodableTests.swift
@@ -61,7 +61,7 @@ class Array_PSQLCodableTests: XCTestCase {
         let values = ["foo", "bar", "hello", "world"]
 
         var buffer = ByteBuffer()
-        XCTAssertNoThrow(try values.encode(into: &buffer, context: .default))
+        values.encode(into: &buffer, context: .default)
 
         var result: [String]?
         XCTAssertNoThrow(result = try [String](from: &buffer, type: .textArray, format: .binary, context: .default))
@@ -72,7 +72,7 @@ class Array_PSQLCodableTests: XCTestCase {
         let values: [String] = []
 
         var buffer = ByteBuffer()
-        XCTAssertNoThrow(try values.encode(into: &buffer, context: .default))
+        values.encode(into: &buffer, context: .default)
 
         var result: [String]?
         XCTAssertNoThrow(result = try [String](from: &buffer, type: .textArray, format: .binary, context: .default))

--- a/Tests/PostgresNIOTests/New/Messages/BindTests.swift
+++ b/Tests/PostgresNIOTests/New/Messages/BindTests.swift
@@ -7,8 +7,8 @@ class BindTests: XCTestCase {
     func testEncodeBind() {
         let encoder = PSQLFrontendMessageEncoder()
         var bindings = PostgresBindings()
-        XCTAssertNoThrow(try bindings.append("Hello", context: .default))
-        XCTAssertNoThrow(try bindings.append("World", context: .default))
+        bindings.append("Hello", context: .default)
+        bindings.append("World", context: .default)
         var byteBuffer = ByteBuffer()
         let bind = PostgresFrontendMessage.Bind(portalName: "", preparedStatementName: "", bind: bindings)
         let message = PostgresFrontendMessage.bind(bind)

--- a/Tests/PostgresNIOTests/New/PostgresQueryTests.swift
+++ b/Tests/PostgresNIOTests/New/PostgresQueryTests.swift
@@ -8,13 +8,11 @@ final class PostgresQueryTests: XCTestCase {
         let null: UUID? = nil
         let uuid: UUID? = UUID()
 
-        var query: PostgresQuery?
-        XCTAssertNoThrow(query = try """
+        var query: PostgresQuery = """
             INSERT INTO foo (id, title, something) SET (\(uuid), \(string), \(null));
             """
-        )
 
-        XCTAssertEqual(query?.sql, "INSERT INTO foo (id, title, something) SET ($1, $2, $3);")
+        XCTAssertEqual(query.sql, "INSERT INTO foo (id, title, something) SET ($1, $2, $3);")
 
         var expected = ByteBuffer()
         expected.writeInteger(Int32(16))
@@ -29,7 +27,7 @@ final class PostgresQueryTests: XCTestCase {
         expected.writeString(string)
         expected.writeInteger(Int32(-1))
 
-        XCTAssertEqual(query?.binds.bytes, expected)
+        XCTAssertEqual(query.binds.bytes, expected)
     }
 
     func testStringInterpolationWithCustomJSONEncoder() {
@@ -63,7 +61,7 @@ final class PostgresQueryTests: XCTestCase {
 
         var query = PostgresQuery(unsafeSQL: sql, binds: .init(capacity: 5))
         for value in 1...5 {
-            XCTAssertNoThrow(try query.binds.append(Int(value), context: .default))
+            query.binds.append(Int(value), context: .default)
         }
 
         XCTAssertEqual(query.sql, "INSERT INTO test (id) SET ($1, $2, $3, $4, $5);")
@@ -81,14 +79,12 @@ final class PostgresQueryTests: XCTestCase {
         let tableName = UUID().uuidString.uppercased()
         let value = 1
 
-        var query: PostgresQuery?
-        XCTAssertNoThrow(query = try "INSERT INTO \(unescaped: tableName) (id) SET (\(value));")
-        XCTAssertEqual(query?.sql, "INSERT INTO \(tableName) (id) SET ($1);")
+        let query: PostgresQuery = "INSERT INTO \(unescaped: tableName) (id) SET (\(value));"
 
         var expected = ByteBuffer()
         expected.writeInteger(UInt32(8))
         expected.writeInteger(value)
 
-        XCTAssertEqual(query?.binds.bytes, expected)
+        XCTAssertEqual(query.binds.bytes, expected)
     }
 }


### PR DESCRIPTION
### Motivation

Currently creating a `PostgresQuery` through String interpolation always throws. The reason to support throwing in `PostgresEncodable` is, that the `Encodable` protocol enforces throwing (and we do want to support JSON). But for most of the primary types throwing is totally useless.

### Changes

- We introduce the protocol `PostgresNonThrowingEncodable`, which inherits from `PostgresEncodable` but enforces that the `encode` method does not `throw`
- We add a separate entry points for `PostgresNonThrowingEncodable` in `PostgresQuery` and `PostgresBinding` to reduce the number of places where we throw

### Result

- way less throwing in places where we don't actually `throw`