### PR TITLE
Update SPI info to point to our hosted docs

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,6 +1,4 @@
 version: 1
-builder:
-  configs:
-  - documentation_targets:
-    - PostgresNIO
+external_links:
+  documentation: "https://api.vapor.codes/postgres-nio/documentation/postgresnio/"
 


### PR DESCRIPTION
The API docs now hosts the DocC documentation for PostgresNIO
