### PR TITLE
`PostgresQuery` and `PostgresBindings` should be Sendable

### DIFF
--- a/Sources/PostgresNIO/Data/PostgresDataType.swift
+++ b/Sources/PostgresNIO/Data/PostgresDataType.swift
@@ -3,7 +3,7 @@
 /// Currently there a two wire formats supported:
 ///  - text
 ///  - binary
-public enum PostgresFormat: Int16 {
+public enum PostgresFormat: Int16, Sendable {
     case text = 0
     case binary = 1
 }
@@ -31,7 +31,7 @@ public typealias PostgresFormatCode = PostgresFormat
 
 /// The data type's raw object ID.
 /// Use `select * from pg_type where oid = <idhere>;` to lookup more information.
-public struct PostgresDataType: RawRepresentable, Hashable, CustomStringConvertible {
+public struct PostgresDataType: RawRepresentable, Hashable, Sendable, CustomStringConvertible {
     /// `0`
     public static let null = PostgresDataType(0)
     /// `16`

--- a/Sources/PostgresNIO/Data/PostgresDataType.swift
+++ b/Sources/PostgresNIO/Data/PostgresDataType.swift
@@ -3,7 +3,7 @@
 /// Currently there a two wire formats supported:
 ///  - text
 ///  - binary
-public enum PostgresFormat: Int16, Sendable {
+public enum PostgresFormat: Int16 {
     case text = 0
     case binary = 1
 }
@@ -31,7 +31,7 @@ public typealias PostgresFormatCode = PostgresFormat
 
 /// The data type's raw object ID.
 /// Use `select * from pg_type where oid = <idhere>;` to lookup more information.
-public struct PostgresDataType: RawRepresentable, Hashable, Sendable, CustomStringConvertible {
+public struct PostgresDataType: RawRepresentable, Hashable, CustomStringConvertible {
     /// `0`
     public static let null = PostgresDataType(0)
     /// `16`

--- a/Sources/PostgresNIO/New/PostgresQuery.swift
+++ b/Sources/PostgresNIO/New/PostgresQuery.swift
@@ -1,5 +1,5 @@
 /// A Postgres SQL query, that can be executed on a Postgres server. Contains the raw sql string and bindings.
-public struct PostgresQuery: Hashable, Sendable {
+public struct PostgresQuery: Hashable {
     /// The query string
     public var sql: String
     /// The query binds
@@ -102,9 +102,9 @@ struct PSQLExecuteStatement {
     var rowDescription: RowDescription?
 }
 
-public struct PostgresBindings: Hashable, Sendable {
+public struct PostgresBindings: Hashable {
     @usableFromInline
-    struct Metadata: Hashable, Sendable {
+    struct Metadata: Hashable {
         @usableFromInline
         var dataType: PostgresDataType
         @usableFromInline
@@ -177,3 +177,9 @@ public struct PostgresBindings: Hashable, Sendable {
         self.metadata.append(.init(dataType: postgresData.type, format: .binary))
     }
 }
+
+#if swift(>=5.6)
+extension PostgresQuery: Sendable {}
+extension PostgresBindings: Sendable {}
+extension PostgresBindings.Metadata: Sendable {}
+#endif

--- a/Sources/PostgresNIO/New/PostgresQuery.swift
+++ b/Sources/PostgresNIO/New/PostgresQuery.swift
@@ -1,5 +1,5 @@
 /// A Postgres SQL query, that can be executed on a Postgres server. Contains the raw sql string and bindings.
-public struct PostgresQuery: Hashable {
+public struct PostgresQuery: Hashable, Sendable {
     /// The query string
     public var sql: String
     /// The query binds
@@ -102,9 +102,9 @@ struct PSQLExecuteStatement {
     var rowDescription: RowDescription?
 }
 
-public struct PostgresBindings: Hashable {
+public struct PostgresBindings: Hashable, Sendable {
     @usableFromInline
-    struct Metadata: Hashable {
+    struct Metadata: Hashable, Sendable {
         @usableFromInline
         var dataType: PostgresDataType
         @usableFromInline


### PR DESCRIPTION
When we added Sendable annotations previously we seem to have forgot `PostgresQuery` and `PostgresBindings`. This PR fixes that.