### PR TITLE
Update API Docs Workflow

### DIFF
--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -6,8 +6,9 @@ on:
 
 jobs:
   build-and-deploy:
-     uses: vapor/api-docs/.github/workflows/build-and-deploy-docs-workflow.yml@8d28281fe89fd836116d59c7fe217df651ebf41a
+     uses: vapor/api-docs/.github/workflows/build-and-deploy-docs-workflow.yml@main
      secrets: inherit
      with:
        package_name: postgres-nio
        modules: PostgresNIO
+       pathsToInvalidate: /postgresnio

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -164,3 +164,13 @@ jobs:
     - name: API breaking changes
       run: |
         swift package diagnose-api-breaking-changes origin/main
+  test-exports:
+    name: Test exports
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out package
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Build
+        run: swift build -Xswiftc -DBUILDING_DOCC

--- a/.spi.yml
+++ b/.spi.yml
@@ -1,4 +1,4 @@
 version: 1
 external_links:
-  documentation: "https://api.vapor.codes/postgres-nio/documentation/postgresnio/"
+  documentation: "https://api.vapor.codes/postgresnio/documentation/postgresnio/"
 

--- a/Sources/PostgresNIO/New/PSQLFrontendMessageEncoder.swift
+++ b/Sources/PostgresNIO/New/PSQLFrontendMessageEncoder.swift
@@ -1,3 +1,4 @@
+import NIOCore
 
 struct PSQLFrontendMessageEncoder: MessageToByteEncoder {
     typealias OutboundIn = PostgresFrontendMessage

--- a/Sources/PostgresNIO/New/PostgresBackendMessageDecoder.swift
+++ b/Sources/PostgresNIO/New/PostgresBackendMessageDecoder.swift
@@ -1,3 +1,5 @@
+import NIOCore
+
 struct PostgresBackendMessageDecoder: NIOSingleStepByteToMessageDecoder {
     typealias InboundOut = PostgresBackendMessage
     

--- a/Sources/PostgresNIO/New/PostgresQuery.swift
+++ b/Sources/PostgresNIO/New/PostgresQuery.swift
@@ -1,3 +1,5 @@
+import NIOCore
+
 /// A Postgres SQL query, that can be executed on a Postgres server. Contains the raw sql string and bindings.
 public struct PostgresQuery: Hashable {
     /// The query string

--- a/Sources/PostgresNIO/Utilities/Exports.swift
+++ b/Sources/PostgresNIO/Utilities/Exports.swift
@@ -1,4 +1,8 @@
+#if !BUILDING_DOCC
+
 // TODO: Remove this with the next major release!
 @_exported import NIO
 @_exported import NIOSSL
 @_exported import struct Logging.Logger
+
+#endif

--- a/Sources/PostgresNIO/Utilities/PostgresJSONDecoder.swift
+++ b/Sources/PostgresNIO/Utilities/PostgresJSONDecoder.swift
@@ -1,6 +1,7 @@
 import class Foundation.JSONDecoder
 import struct Foundation.Data
 import NIOFoundationCompat
+import NIOCore
 
 /// A protocol that mimicks the Foundation `JSONDecoder.decode(_:from:)` function.
 /// Conform a non-Foundation JSON decoder to this protocol if you want PostgresNIO to be

--- a/Sources/PostgresNIO/Utilities/PostgresJSONEncoder.swift
+++ b/Sources/PostgresNIO/Utilities/PostgresJSONEncoder.swift
@@ -1,5 +1,6 @@
 import Foundation
 import NIOFoundationCompat
+import NIOCore
 
 /// A protocol that mimicks the Foundation `JSONEncoder.encode(_:)` function.
 /// Conform a non-Foundation JSON encoder to this protocol if you want PostgresNIO to be

--- a/Tests/IntegrationTests/AsyncTests.swift
+++ b/Tests/IntegrationTests/AsyncTests.swift
@@ -4,6 +4,8 @@ import PostgresNIO
 #if canImport(Network)
 import NIOTransportServices
 #endif
+import NIOPosix
+import NIOCore
 
 #if canImport(_Concurrency)
 final class AsyncPostgresConnectionTests: XCTestCase {

--- a/Tests/IntegrationTests/PostgresNIOTests.swift
+++ b/Tests/IntegrationTests/PostgresNIOTests.swift
@@ -4,6 +4,7 @@ import XCTest
 import NIOCore
 import NIOPosix
 import NIOTestUtils
+import NIOSSL
 
 final class PostgresNIOTests: XCTestCase {
     

--- a/Tests/PostgresNIOTests/Message/PostgresMessageDecoderTests.swift
+++ b/Tests/PostgresNIOTests/Message/PostgresMessageDecoderTests.swift
@@ -1,6 +1,7 @@
 import PostgresNIO
 import XCTest
 import NIOTestUtils
+import NIOCore
 
 class PostgresMessageDecoderTests: XCTestCase {
     @available(*, deprecated, message: "Tests deprecated API")

--- a/Tests/PostgresNIOTests/New/Extensions/PSQLFrontendMessageDecoder.swift
+++ b/Tests/PostgresNIOTests/New/Extensions/PSQLFrontendMessageDecoder.swift
@@ -1,4 +1,5 @@
 @testable import PostgresNIO
+import NIOCore
 
 struct PSQLFrontendMessageDecoder: NIOSingleStepByteToMessageDecoder {
     typealias InboundOut = PostgresFrontendMessage

--- a/Tests/PostgresNIOTests/New/PSQLRowStreamTests.swift
+++ b/Tests/PostgresNIOTests/New/PSQLRowStreamTests.swift
@@ -2,6 +2,8 @@ import NIOCore
 import Logging
 import XCTest
 @testable import PostgresNIO
+import NIOCore
+import NIOEmbedded
 
 class PSQLRowStreamTests: XCTestCase {
     func testEmptyStream() {

--- a/Tests/PostgresNIOTests/New/PostgresCellTests.swift
+++ b/Tests/PostgresNIOTests/New/PostgresCellTests.swift
@@ -1,5 +1,6 @@
 @testable import PostgresNIO
 import XCTest
+import NIOCore
 
 final class PostgresCellTests: XCTestCase {
     func testDecodingANonOptionalString() {

--- a/Tests/PostgresNIOTests/New/PostgresCodableTests.swift
+++ b/Tests/PostgresNIOTests/New/PostgresCodableTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 @testable import PostgresNIO
+import NIOCore
 
 final class PostgresCodableTests: XCTestCase {
 

--- a/Tests/PostgresNIOTests/New/PostgresErrorTests.swift
+++ b/Tests/PostgresNIOTests/New/PostgresErrorTests.swift
@@ -1,5 +1,6 @@
 @testable import PostgresNIO
 import XCTest
+import NIOCore
 
 final class PostgresDecodingErrorTests: XCTestCase {
     func testPostgresDecodingErrorEquality() {

--- a/Tests/PostgresNIOTests/New/PostgresQueryTests.swift
+++ b/Tests/PostgresNIOTests/New/PostgresQueryTests.swift
@@ -1,5 +1,6 @@
 @testable import PostgresNIO
 import XCTest
+import NIOCore
 
 final class PostgresQueryTests: XCTestCase {
 

--- a/Tests/PostgresNIOTests/New/PostgresRowSequenceTests.swift
+++ b/Tests/PostgresNIOTests/New/PostgresRowSequenceTests.swift
@@ -3,6 +3,8 @@ import NIOEmbedded
 import Dispatch
 import XCTest
 @testable import PostgresNIO
+import NIOCore
+import Logging
 
 #if canImport(_Concurrency)
 final class PostgresRowSequenceTests: XCTestCase {

--- a/Tests/PostgresNIOTests/New/PostgresRowTests.swift
+++ b/Tests/PostgresNIOTests/New/PostgresRowTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 @testable import PostgresNIO
+import NIOCore
 
 final class PostgresRowTests: XCTestCase {
 


### PR DESCRIPTION
The API docs workflow is now working so we can roll this out.

Because of the way exporting works on Linux and how DocC consumes it, I've ensured everything compiles when nothing is exported and wrapped the exports in our DocC flag