### PR TITLE
Add support for int8range and int8range[]

### DIFF
--- a/Sources/PostgresNIO/Data/PostgresData+Range.swift
+++ b/Sources/PostgresNIO/Data/PostgresData+Range.swift
@@ -17,7 +17,7 @@ extension PostgresData {
         switch self.formatCode {
         case .binary:
             switch self.type {
-            case PostgresDataType(3926):
+            case .int8Range:
                 guard value.readInteger(as: Int8.self) == 2 else {
                     return nil
                 }

--- a/Sources/PostgresNIO/Data/PostgresData+Range.swift
+++ b/Sources/PostgresNIO/Data/PostgresData+Range.swift
@@ -1,0 +1,66 @@
+extension PostgresData {
+    public init(int8Range: Range<Int64>) {
+        var buffer = ByteBufferAllocator().buffer(capacity: 25)
+        buffer.writeInteger(2, as: Int8.self)
+        buffer.writeInteger(8, as: Int32.self)
+        buffer.writeInteger(int8Range.lowerBound)
+        buffer.writeInteger(8, as: Int32.self)
+        buffer.writeInteger(int8Range.upperBound)
+        self.init(type: .int8Range, formatCode: .binary, value: buffer)
+    }
+    
+    public var int8Range: Range<Int64>? {
+        guard var value = self.value else {
+            return nil
+        }
+        
+        switch self.formatCode {
+        case .binary:
+            switch self.type {
+            case PostgresDataType(3926):
+                guard value.readInteger(as: Int8.self) == 2 else {
+                    return nil
+                }
+
+                guard value.readInteger(as: Int32.self) == 8 else {
+                    return nil
+                }
+
+                guard let lowerBound: Int64 = value.readInteger() else {
+                    return nil
+                }
+
+                guard value.readInteger(as: Int32.self) == 8 else {
+                    return nil
+                }
+
+                guard let upperBound: Int64 = value.readInteger() else {
+                    return nil
+                }
+                
+                return lowerBound..<upperBound
+            default:
+                return nil
+            }
+        case .text:
+            return nil
+        }
+    }
+}
+
+extension Range: PostgresDataConvertible where Element == Int64 {
+    public static var postgresDataType: PostgresDataType {
+        return .int8Range
+    }
+    
+    public init?(postgresData: PostgresData) {
+        guard let range: Range<Int64> = postgresData.int8Range else {
+            return nil
+        }
+        self = range
+    }
+
+    public var postgresData: PostgresData? {
+        return .init(int8Range: self)
+    }
+}

--- a/Sources/PostgresNIO/Data/PostgresData.swift
+++ b/Sources/PostgresNIO/Data/PostgresData.swift
@@ -70,6 +70,10 @@ public struct PostgresData: CustomStringConvertible, CustomDebugStringConvertibl
             description = self.array(of: String.self)?.description
         case .jsonbArray:
             description = self.array?.description
+        case .int8Range:
+            description = self.int8Range?.description
+        case .int8RangeArray:
+            description = self.array(of: Range<Int64>.self)?.description
         default:
             if self.type.isUserDefined {
                 // custom type

--- a/Sources/PostgresNIO/Data/PostgresDataType.swift
+++ b/Sources/PostgresNIO/Data/PostgresDataType.swift
@@ -122,6 +122,8 @@ public struct PostgresDataType: RawRepresentable, Hashable, CustomStringConverti
     public static let jsonbArray = PostgresDataType(3807)
     /// `3926`
     public static let int8Range = PostgresDataType(3926)
+    /// `3927` _int8range
+    public static let int8RangeArray = PostgresDataType(3927)
 
     /// The raw data type code recognized by PostgreSQL.
     public var rawValue: UInt32
@@ -187,6 +189,8 @@ public struct PostgresDataType: RawRepresentable, Hashable, CustomStringConverti
         case .uuidArray: return "UUID[]"
         case .jsonb: return "JSONB"
         case .jsonbArray: return "JSONB[]"
+        case .int8Range: return "INT8RANGE"
+        case .int8RangeArray: return "INT8RANGE[]"
         default: return nil
         }
     }
@@ -208,6 +212,7 @@ public struct PostgresDataType: RawRepresentable, Hashable, CustomStringConverti
         case .jsonb: return .jsonbArray
         case .text: return .textArray
         case .varchar: return .varcharArray
+        case .int8Range: return .int8RangeArray
         default: return nil
         }
     }
@@ -230,6 +235,7 @@ public struct PostgresDataType: RawRepresentable, Hashable, CustomStringConverti
         case .jsonbArray: return .jsonb
         case .textArray: return .text
         case .varcharArray: return .varchar
+        case .int8RangeArray: return .int8Range
         default: return nil
         }
     }

--- a/Sources/PostgresNIO/Data/PostgresDataType.swift
+++ b/Sources/PostgresNIO/Data/PostgresDataType.swift
@@ -120,6 +120,8 @@ public struct PostgresDataType: RawRepresentable, Hashable, CustomStringConverti
     public static let jsonb = PostgresDataType(3802)
     /// `3807` _jsonb
     public static let jsonbArray = PostgresDataType(3807)
+    /// `3926`
+    public static let int8Range = PostgresDataType(3926)
 
     /// The raw data type code recognized by PostgreSQL.
     public var rawValue: UInt32

--- a/Tests/IntegrationTests/PostgresNIOTests.swift
+++ b/Tests/IntegrationTests/PostgresNIOTests.swift
@@ -341,6 +341,23 @@ final class PostgresNIOTests: XCTestCase {
         XCTAssertEqual(UUID(uuidString: row?[data: "id"].string ?? ""), UUID(uuidString: "123E4567-E89B-12D3-A456-426655440000"))
     }
 
+    func testInt8Range() {
+        var conn: PostgresConnection?
+        XCTAssertNoThrow(conn = try PostgresConnection.test(on: eventLoop).wait())
+        defer { XCTAssertNoThrow( try conn?.close().wait() ) }
+        struct Model: Decodable {
+            let range: Range<Int64>
+        }
+        var results: PostgresQueryResult?
+        XCTAssertNoThrow(results = try conn?.query("""
+        SELECT
+            '[-9223372036854775808, 9223372036854775807)'::int8range AS range
+        """).wait())
+        XCTAssertEqual(results?.count, 1)
+        let row = results?.first?.makeRandomAccess()
+        XCTAssertEqual(row?[data: "range"].int8Range, -9223372036854775808..<9223372036854775807)
+    }
+
     func testDates() {
         var conn: PostgresConnection?
         XCTAssertNoThrow(conn = try PostgresConnection.test(on: eventLoop).wait())

--- a/Tests/IntegrationTests/PostgresNIOTests.swift
+++ b/Tests/IntegrationTests/PostgresNIOTests.swift
@@ -354,8 +354,19 @@ final class PostgresNIOTests: XCTestCase {
             '[-9223372036854775808, 9223372036854775807)'::int8range AS range
         """).wait())
         XCTAssertEqual(results?.count, 1)
-        let row = results?.first?.makeRandomAccess()
+        var row = results?.first?.makeRandomAccess()
         XCTAssertEqual(row?[data: "range"].int8Range, -9223372036854775808..<9223372036854775807)
+
+        XCTAssertNoThrow(results = try conn?.query("""
+        SELECT
+            ARRAY[
+                '[0, 1)'::int8range,
+                '[10, 11)'::int8range
+            ] AS ranges
+        """).wait())
+        XCTAssertEqual(results?.count, 1)
+        row = results?.first?.makeRandomAccess()
+        XCTAssertEqual(row?[data: "ranges"].array(of: Range<Int64>.self), [0..<1, 10..<11])
     }
 
     func testDates() {


### PR DESCRIPTION
This PR adds support for the `int8range` Postgres type and the corresponding Swift type `Range<Int64>`. Postgres comes with built-in support for `int8range` and five other range types: https://www.postgresql.org/docs/current/rangetypes.html.

The test case I created in this PR demonstrates the new functionality. In short, the range `'[-9223372036854775808, 9223372036854775807)'::int8range` gets decoded to `-9223372036854775808..<9223372036854775807` and the range array `ARRAY['[0, 1)'::int8range, '[10, 11)'::int8range]` gets decoded to `[0..<1, 10..<11]`.

For now, I only wrote code for `int8range` and `int8range[]` because that's what I personally had a need for, but I'd be happy to add support for the other range types (and `ClosedRange` too), once I get confirmation that there is interest in adding this stuff to PostgresNIO.

Since these types are standard in Postgres, I think they belong in PostgresNIO.