### PR TITLE
Fix Decodable autoconformance to PostgresDecodable

### DIFF
--- a/Sources/PostgresNIO/New/Data/JSON+PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/Data/JSON+PostgresCodable.swift
@@ -26,7 +26,7 @@ extension PostgresEncodable where Self: Encodable {
 }
 
 extension PostgresDecodable where Self: Decodable {
-    init<JSONDecoder: PostgresJSONDecoder>(
+    public init<JSONDecoder: PostgresJSONDecoder>(
         from buffer: inout ByteBuffer,
         type: PostgresDataType,
         format: PostgresFormat,


### PR DESCRIPTION
The default implementation of `PostgresDecodable` on `Decodable` types does not work automatically when used in other packages because it's not public. Just a simple visibility change does fix this.
