### PR TITLE
Make PostgresBindings.append(PostgresData) public

### DIFF
--- a/Sources/PostgresNIO/New/PostgresQuery.swift
+++ b/Sources/PostgresNIO/New/PostgresQuery.swift
@@ -168,7 +168,7 @@ public struct PostgresBindings: Hashable {
         self.metadata.append(.init(value: value))
     }
 
-    mutating func append(_ postgresData: PostgresData) {
+    public mutating func append(_ postgresData: PostgresData) {
         switch postgresData.value {
         case .none:
             self.bytes.writeInteger(-1, as: Int32.self)


### PR DESCRIPTION
### Motivation

We need convenience methods to adopt PostgresQuery and PostgresBinding in downstream libs (PostgresKit and Fluent). For this we should make appending PostgresData to PostgresBindings public.

### Changes

- Make `PostgresBindings.append(PostgresData)` public