### PR TITLE
Add support for UDS and existing Channels

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
         shell: bash
         run: |
           coverage=$( [[ '${{ matrix.coverage }}' == 'true' ]] && echo -n '--enable-code-coverage' || true )
-          swift test --enable-test-discovery --filter=^PostgresNIOTests --sanitize=thread ${coverage}
+          swift test --filter=^PostgresNIOTests --sanitize=thread ${coverage}
       - name: Submit coverage report to Codecov.io
         if: ${{ matrix.coverage }}
         uses: vapor/swift-codecov-action@v0.2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,6 +58,7 @@ jobs:
             dbauth: trust
     container:
       image: swift:5.8-jammy
+      volumes: [ 'pgrunshare:/var/run/postgresql' ]
     runs-on: ubuntu-latest
     env:
       LOG_LEVEL: debug
@@ -74,10 +75,12 @@ jobs:
       POSTGRES_HOSTNAME: 'psql-a'
       POSTGRES_HOSTNAME_A: 'psql-a'
       POSTGRES_HOSTNAME_B: 'psql-b'
+      POSTGRES_SOCKET: '/var/run/postgresql/.s.PGSQL.5432'
       POSTGRES_HOST_AUTH_METHOD: ${{ matrix.dbauth }}
     services:
       psql-a:
         image: ${{ matrix.dbimage }}
+        volumes: [ 'pgrunshare:/var/run/postgresql' ]
         env:
           POSTGRES_USER: 'test_username'
           POSTGRES_DB: 'test_database'
@@ -86,6 +89,7 @@ jobs:
           POSTGRES_INITDB_ARGS: --auth-host=${{ matrix.dbauth }}
       psql-b:
         image: ${{ matrix.dbimage }}
+        volumes: [ 'pgrunshare:/var/run/postgresql' ]
         env:
           POSTGRES_USER: 'test_username'
           POSTGRES_DB: 'test_database'
@@ -134,6 +138,7 @@ jobs:
       POSTGRES_PASSWORD: 'test_password'
       POSTGRES_DB: 'postgres'
       POSTGRES_HOST_AUTH_METHOD: ${{ matrix.dbauth }}
+      POSTGRES_SOCKET: '/tmp/.s.PGSQL.5432'
     steps:
       - name: Select latest available Xcode
         uses: maxim-lobanov/setup-xcode@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,14 @@ jobs:
           - swift:5.8-jammy
           - swiftlang/swift:nightly-5.9-jammy
           - swiftlang/swift:nightly-main-jammy
+        include:
+          - coverage: true
+          # https://github.com/apple/swift-package-manager/issues/5853
+          - container: swift:5.8-jammy
+            coverage: false
+          # https://github.com/apple/swift/issues/65064
+          - container: swiftlang/swift:nightly-main-jammy
+            coverage: false
     container: ${{ matrix.container }}
     runs-on: ubuntu-latest
     env:
@@ -29,9 +37,12 @@ jobs:
       - name: Check out package
         uses: actions/checkout@v3
       - name: Run unit tests with code coverage and Thread Sanitizer
-        run: swift test --enable-test-discovery --filter=^PostgresNIOTests --sanitize=thread --enable-code-coverage
+        shell: bash
+        run: |
+          coverage=$( [[ '${{ matrix.coverage }}' == 'true' ]] && echo -n '--enable-code-coverage' || true )
+          swift test --enable-test-discovery --filter=^PostgresNIOTests --sanitize=thread ${coverage}
       - name: Submit coverage report to Codecov.io
-        if: ${{ !contains(matrix.container, '5.8') }}
+        if: ${{ matrix.coverage }}
         uses: vapor/swift-codecov-action@v0.2
         with:
           cc_flags: 'unittests'

--- a/Sources/PostgresNIO/Connection/PostgresConnection+Configuration.swift
+++ b/Sources/PostgresNIO/Connection/PostgresConnection+Configuration.swift
@@ -45,7 +45,7 @@ extension PostgresConnection {
                     else { return false }
                 }
                 
-                /// The ``NIOSSLContext`` that will be used. `nil` when TLS is disabled.
+                /// The `NIOSSLContext` that will be used. `nil` when TLS is disabled.
                 public var sslContext: NIOSSLContext? {
                     switch self.base {
                     case .prefer(let context), .require(let context): return context

--- a/Sources/PostgresNIO/Connection/PostgresConnection+Configuration.swift
+++ b/Sources/PostgresNIO/Connection/PostgresConnection+Configuration.swift
@@ -1,0 +1,318 @@
+import NIOCore
+@_implementationOnly import NIOPosix // inet_pton() et al.
+import NIOSSL
+
+extension PostgresConnection {
+    /// A configuration object for a connection
+    public struct Configuration {
+
+        // MARK: - Communication channel
+
+        /// Contains the information necessary to establish the underlying communication channel for a connection.
+        public struct Server {
+            // MARK: TLS
+            
+            /// The possible modes of operation for TLS encapsulation of a connection.
+            public struct TLS {
+                // MARK: Initializers
+                
+                /// Do not try to create a TLS connection to the server.
+                public static var disable: Self = .init(base: .disable)
+
+                /// Try to create a TLS connection to the server. If the server supports TLS, create a TLS connection.
+                /// If the server does not support TLS, create an insecure connection.
+                public static func prefer(_ sslContext: NIOSSLContext) -> Self {
+                    self.init(base: .prefer(sslContext))
+                }
+
+                /// Try to create a TLS connection to the server. If the server supports TLS, create a TLS connection.
+                /// If the server does not support TLS, fail the connection creation.
+                public static func require(_ sslContext: NIOSSLContext) -> Self {
+                    self.init(base: .require(sslContext))
+                }
+                
+                // MARK: Accessors
+                
+                /// Whether TLS will be attempted on the connection (`false` only when mode is ``disable``).
+                public var isAllowed: Bool {
+                    if case .disable = self.base { return false }
+                    else { return true }
+                }
+                
+                /// Whether TLS will be enforced on the connection (`true` only when mode is ``require(_:)``).
+                public var isEnforced: Bool {
+                    if case .require(_) = self.base { return true }
+                    else { return false }
+                }
+                
+                /// The ``NIOSSLContext`` that will be used. `nil` when TLS is disabled.
+                public var sslContext: NIOSSLContext? {
+                    switch self.base {
+                    case .prefer(let context), .require(let context): return context
+                    case .disable: return nil
+                    }
+                }
+
+                // MARK: Implementation details
+                
+                fileprivate enum Base {
+                    case disable
+                    case prefer(NIOSSLContext)
+                    case require(NIOSSLContext)
+                }
+                fileprivate let base: Base
+                private init(base: Base) { self.base = base }
+
+            }
+            
+            // MARK: Initializers
+            
+            /// Create a configuration for connecting to a server with a hostname and optional port.
+            ///
+            /// This specifies a TCP connection. If you're unsure which kind of connection you want, you almost
+            /// definitely want this one.
+            ///
+            /// - Parameters:
+            ///   - host: The hostname to connect to.
+            ///   - port: The TCP port to connect to (defaults to 5432).
+            ///   - tls: The TLS mode to use.
+            public init(host: String, port: Int = 5432, tls: TLS) {
+                self.init(base: .connectTCP(host: host, port: port), tls: tls)
+            }
+            
+            /// Create a configuration for connecting to a server through a UNIX domain socket.
+            ///
+            /// - Parameters:
+            ///   - path: The filesystem path of the socket to connect to.
+            ///   - tls: The TLS mode to use. Defaults to ``TLS-swift.struct/disable``.
+            public static func unixDomainSocket(path: String, tls: TLS = .disable) -> Self {
+                .init(base: .bindUnixDomainSocket(path: path), tls: tls)
+            }
+            
+            /// Create a configuration for establishing a connection to a Postgres server over a preestablished
+            /// `NIOCore/Channel`.
+            ///
+            /// This is provided for calling code which wants to manage the underlying connection transport on its
+            /// own, such as when tunneling a connection through SSH.
+            ///
+            /// - Parameters:
+            ///   - channel: The `NIOCore/Channel` to use. The channel must already be active and connected to an
+            ///     endpoint (i.e. `NIOCore/Channel/isActive` must be `true`).
+            ///   - tls: The TLS mode to use. Defaults to ``TLS-swift.struct/disable``.
+            public static func establishedChannel(_ channel: Channel, tls: TLS = .disable) -> Self {
+                .init(base: .configureChannel(channel), tls: tls)
+            }
+            
+            // MARK: Accessors
+            
+            /// The hostname to connect to for TCP configurations.
+            ///
+            /// Always `nil` for other configurations.
+            public var host: String? {
+                if case let .connectTCP(host, _) = self.base { return host }
+                else { return nil }
+            }
+            
+            /// The port to connect to for TCP configurations.
+            ///
+            /// Always `nil` for other configurations.
+            public var port: Int? {
+                if case let .connectTCP(_, port) = self.base { return port }
+                else { return nil }
+            }
+            
+            /// The socket path to connect to for Unix domain socket connections.
+            ///
+            /// Always `nil` for other configurations.
+            public var socketPath: String? {
+                if case let .bindUnixDomainSocket(path) = self.base { return path }
+                else { return nil }
+            }
+            
+            /// The `NIOCore/Channel` to use in existing-channel configurations.
+            ///
+            /// Always `nil` for other configurations.
+            public var channel: Channel? {
+                if case let .configureChannel(channel) = self.base { return channel }
+                else { return nil }
+            }
+            
+            /// The TLS mode to use for the connection. Valid for all configurations.
+            public let tls: TLS
+            
+            // MARK: Implementation details
+            
+            // TODO: Make all of these `fileprivate` once the deprecated stuff is removed
+            enum Base {
+                case configureChannel(Channel)
+                case bindUnixDomainSocket(path: String)
+                case connectTCP(host: String, port: Int)
+            }
+            let base: Base
+            init(base: Base, tls: TLS) { (self.base, self.tls) = (base, tls) }
+        }
+        
+        // MARK: - Authentication
+
+        /// Contains authentication information for a connection.
+        public struct Authentication {
+            // TODO: Make the properties of this structure immutable (removing setters breaks public API).
+    
+            /// The username to connect with.
+            public var username: String
+
+            /// The password, if any, for the user specified by ``username``.
+            ///
+            /// - Warning: `nil` means "no password provided", whereas `""` (the empty string) is a password of zero
+            ///   length; these are not the same thing.
+            public var password: String?
+
+            /// The name of the database to open.
+            ///
+            /// - Note: If set to `nil` or an empty string, the provided ``username`` is used.
+            public var database: String?
+
+            public init(username: String, password: String?, database: String?) {
+                self.username = username
+                self.password = password
+                self.database = database
+            }
+        }
+        
+        // MARK: - Connection options
+        
+        /// Describes options affecting how the underlying connection is made.
+        public struct Options {
+            /// A timeout for connection attempts.
+            ///
+            /// Ignored when using a preexisting communcation channel. (See
+            /// ``PostgresConnection/Configuration/Server-swift.struct/establishedChannel(_:tls:)``.)
+            public let connectTimeout: TimeAmount
+            
+            /// The name to use for SNI (Server Name Indication) when TLS is enabled.
+            ///
+            /// > When set to `nil`:
+            /// If the connection is made to a server over TCP using
+            /// ``PostgresConnection/Configuration/Server-swift.struct/init(host:port:tls:)``, the given `host` is used,
+            /// unless it was an IP address string. If it _was_ an IP, or the connection is made by any other method,
+            /// SNI is disabled.
+            ///
+            /// - Warning: This name is not validated in any way; in particular, there is no attempt to check that it
+            ///   matches the server's TLS certificate, nor is it in any way impacted by the validation setting in the
+            ///   TLS configuration (see ``PostgresConnection/Configuration/Server-swift.struct/TLS-swift.struct``).
+            public let tlsServerName: String?
+            
+            /// Whether the connection is required to provide backend key data (internal Postgres stuff).
+            ///
+            /// This property is provided for compatibility with Amazon RDS Proxy, which requires it to be `false`.
+            /// If you are not using Amazon RDS Proxy, you should probably leave this set to `true` (the default).
+            public let requireBackendKeyData: Bool
+            
+            /// Configure various options for a connection.
+            ///
+            /// Most users should not need to adjust the defaults.
+            ///
+            /// - Parameters:
+            ///   - connectTimeout: See ``connectTimeout``. Defaults to 10 seconds.
+            ///   - tlsServerName: See ``tlsServerName``. Default is `nil`.
+            ///   - requireBackendKeyData: See ``requireBackendKeyData``. Default is `true`.
+            public init(
+                connectTimeout: TimeAmount = .seconds(10),
+                tlsServerName: String? = nil,
+                requireBackendKeyData: Bool = true
+            ) {
+                self.connectTimeout = connectTimeout
+                self.tlsServerName = tlsServerName
+                self.requireBackendKeyData = requireBackendKeyData
+            }
+        }
+
+        /// Endpoint information for establishing a communication channel.
+        ///
+        /// See ``Server-swift.struct``.
+        public let server: Server
+        
+        /// Authentication properties to send during the startup auth handshake.
+        ///
+        /// See ``Authentication-swift.struct``.
+        public var authentication: Authentication // TODO: Make this immutable
+        
+        /// Options for handling the communication channel. Most users don't need to change these.
+        ///
+        /// See ``Options-swift.struct``.
+        public let options: Options
+        
+        /// Create a complete connection configuration.
+        ///
+        /// - Parameters:
+        ///   - server: See ``Server-swift.struct``.
+        ///   - authentication: See ``Authentication-swift.struct``.
+        ///   - options: See ``Options-swift.struct``. Most users do not need to adjust any of these.
+        public init(
+            server: Server,
+            authentication: Authentication,
+            options: Options = .init()
+        ) {
+            self.server = server
+            self.authentication = authentication
+            self.options = options
+        }
+    }
+}
+
+extension PostgresConnection {
+    /// A configuration object to bring the new ``PostgresConnection.Configuration`` together with
+    /// the deprecated configuration.
+    ///
+    /// TODO: Drop with next major release
+    struct InternalConfiguration {
+        enum Connection {
+            case unresolvedTCP(host: String, port: Int)
+            case unresolvedUDS(path: String)
+            case resolved(address: SocketAddress)
+            case bootstrapped(channel: Channel)
+        }
+
+        let connection: InternalConfiguration.Connection
+        let authentication: Configuration.Authentication?
+        let tls: Configuration.Server.TLS
+        let options: Configuration.Options
+    }
+}
+
+extension PostgresConnection.InternalConfiguration {
+    init(_ config: PostgresConnection.Configuration) {
+        switch config.server.base {
+        case .connectTCP(let host, let port): self.connection = .unresolvedTCP(host: host, port: port)
+        case .bindUnixDomainSocket(let path): self.connection = .unresolvedUDS(path: path)
+        case .configureChannel(let channel): self.connection = .bootstrapped(channel: channel)
+        }
+        self.authentication = config.authentication
+        self.tls = config.server.tls
+        self.options = config.options
+    }
+    
+    var serverNameForSNI: String? {
+        // If a name was explicitly configured, always use it.
+        if let tlsServerName = self.options.tlsServerName { return tlsServerName }
+        
+        // Otherwise, if the connection is TCP and the hostname wasn't an IP (not valid in SNI), use that.
+        if case .unresolvedTCP(let host, _) = self.connection, !host.isIPAddress() { return host }
+        
+        // Otherwise, disable SNI
+        return nil
+    }
+}
+
+// originally taken from NIOSSL
+private extension String {
+    func isIPAddress() -> Bool {
+        // We need some scratch space to let inet_pton write into.
+        var ipv4Addr = in_addr(), ipv6Addr = in6_addr() // inet_pton() assumes the provided address buffer is non-NULL
+        
+        /// N.B.: ``String/withCString(_:)`` is much more efficient than directly passing `self`, especially twice.
+        return self.withCString { ptr in
+            inet_pton(AF_INET, ptr, &ipv4Addr) == 1 || inet_pton(AF_INET6, ptr, &ipv6Addr) == 1
+        }
+    }
+}

--- a/Sources/PostgresNIO/Connection/PostgresConnection+Configuration.swift
+++ b/Sources/PostgresNIO/Connection/PostgresConnection+Configuration.swift
@@ -5,260 +5,218 @@ import NIOSSL
 extension PostgresConnection {
     /// A configuration object for a connection
     public struct Configuration {
-
-        // MARK: - Communication channel
-
-        /// Contains the information necessary to establish the underlying communication channel for a connection.
-        public struct Server {
-            // MARK: TLS
-            
-            /// The possible modes of operation for TLS encapsulation of a connection.
-            public struct TLS {
-                // MARK: Initializers
-                
-                /// Do not try to create a TLS connection to the server.
-                public static var disable: Self = .init(base: .disable)
-
-                /// Try to create a TLS connection to the server. If the server supports TLS, create a TLS connection.
-                /// If the server does not support TLS, create an insecure connection.
-                public static func prefer(_ sslContext: NIOSSLContext) -> Self {
-                    self.init(base: .prefer(sslContext))
-                }
-
-                /// Try to create a TLS connection to the server. If the server supports TLS, create a TLS connection.
-                /// If the server does not support TLS, fail the connection creation.
-                public static func require(_ sslContext: NIOSSLContext) -> Self {
-                    self.init(base: .require(sslContext))
-                }
-                
-                // MARK: Accessors
-                
-                /// Whether TLS will be attempted on the connection (`false` only when mode is ``disable``).
-                public var isAllowed: Bool {
-                    if case .disable = self.base { return false }
-                    else { return true }
-                }
-                
-                /// Whether TLS will be enforced on the connection (`true` only when mode is ``require(_:)``).
-                public var isEnforced: Bool {
-                    if case .require(_) = self.base { return true }
-                    else { return false }
-                }
-                
-                /// The `NIOSSLContext` that will be used. `nil` when TLS is disabled.
-                public var sslContext: NIOSSLContext? {
-                    switch self.base {
-                    case .prefer(let context), .require(let context): return context
-                    case .disable: return nil
-                    }
-                }
-
-                // MARK: Implementation details
-                
-                fileprivate enum Base {
-                    case disable
-                    case prefer(NIOSSLContext)
-                    case require(NIOSSLContext)
-                }
-                fileprivate let base: Base
-                private init(base: Base) { self.base = base }
-
-            }
-            
+    
+        // MARK: - TLS
+        
+        /// The possible modes of operation for TLS encapsulation of a connection.
+        public struct TLS {
             // MARK: Initializers
             
-            /// Create a configuration for connecting to a server with a hostname and optional port.
-            ///
-            /// This specifies a TCP connection. If you're unsure which kind of connection you want, you almost
-            /// definitely want this one.
-            ///
-            /// - Parameters:
-            ///   - host: The hostname to connect to.
-            ///   - port: The TCP port to connect to (defaults to 5432).
-            ///   - tls: The TLS mode to use.
-            public init(host: String, port: Int = 5432, tls: TLS) {
-                self.init(base: .connectTCP(host: host, port: port), tls: tls)
+            /// Do not try to create a TLS connection to the server.
+            public static var disable: Self = .init(base: .disable)
+
+            /// Try to create a TLS connection to the server. If the server supports TLS, create a TLS connection.
+            /// If the server does not support TLS, create an insecure connection.
+            public static func prefer(_ sslContext: NIOSSLContext) -> Self {
+                self.init(base: .prefer(sslContext))
             }
-            
-            /// Create a configuration for connecting to a server through a UNIX domain socket.
-            ///
-            /// - Parameters:
-            ///   - path: The filesystem path of the socket to connect to.
-            ///   - tls: The TLS mode to use. Defaults to ``TLS-swift.struct/disable``.
-            public static func unixDomainSocket(path: String, tls: TLS = .disable) -> Self {
-                .init(base: .bindUnixDomainSocket(path: path), tls: tls)
-            }
-            
-            /// Create a configuration for establishing a connection to a Postgres server over a preestablished
-            /// `NIOCore/Channel`.
-            ///
-            /// This is provided for calling code which wants to manage the underlying connection transport on its
-            /// own, such as when tunneling a connection through SSH.
-            ///
-            /// - Parameters:
-            ///   - channel: The `NIOCore/Channel` to use. The channel must already be active and connected to an
-            ///     endpoint (i.e. `NIOCore/Channel/isActive` must be `true`).
-            ///   - tls: The TLS mode to use. Defaults to ``TLS-swift.struct/disable``.
-            public static func establishedChannel(_ channel: Channel, tls: TLS = .disable) -> Self {
-                .init(base: .configureChannel(channel), tls: tls)
+
+            /// Try to create a TLS connection to the server. If the server supports TLS, create a TLS connection.
+            /// If the server does not support TLS, fail the connection creation.
+            public static func require(_ sslContext: NIOSSLContext) -> Self {
+                self.init(base: .require(sslContext))
             }
             
             // MARK: Accessors
             
-            /// The hostname to connect to for TCP configurations.
-            ///
-            /// Always `nil` for other configurations.
-            public var host: String? {
-                if case let .connectTCP(host, _) = self.base { return host }
-                else { return nil }
+            /// Whether TLS will be attempted on the connection (`false` only when mode is ``disable``).
+            public var isAllowed: Bool {
+                if case .disable = self.base { return false }
+                else { return true }
             }
             
-            /// The port to connect to for TCP configurations.
-            ///
-            /// Always `nil` for other configurations.
-            public var port: Int? {
-                if case let .connectTCP(_, port) = self.base { return port }
-                else { return nil }
+            /// Whether TLS will be enforced on the connection (`true` only when mode is ``require(_:)``).
+            public var isEnforced: Bool {
+                if case .require(_) = self.base { return true }
+                else { return false }
             }
             
-            /// The socket path to connect to for Unix domain socket connections.
-            ///
-            /// Always `nil` for other configurations.
-            public var socketPath: String? {
-                if case let .bindUnixDomainSocket(path) = self.base { return path }
-                else { return nil }
+            /// The `NIOSSLContext` that will be used. `nil` when TLS is disabled.
+            public var sslContext: NIOSSLContext? {
+                switch self.base {
+                case .prefer(let context), .require(let context): return context
+                case .disable: return nil
+                }
             }
-            
-            /// The `NIOCore/Channel` to use in existing-channel configurations.
-            ///
-            /// Always `nil` for other configurations.
-            public var channel: Channel? {
-                if case let .configureChannel(channel) = self.base { return channel }
-                else { return nil }
-            }
-            
-            /// The TLS mode to use for the connection. Valid for all configurations.
-            public let tls: TLS
-            
+
             // MARK: Implementation details
             
-            // TODO: Make all of these `fileprivate` once the deprecated stuff is removed
-            enum Base {
-                case configureChannel(Channel)
-                case bindUnixDomainSocket(path: String)
-                case connectTCP(host: String, port: Int)
+            fileprivate enum Base {
+                case disable
+                case prefer(NIOSSLContext)
+                case require(NIOSSLContext)
             }
-            let base: Base
-            init(base: Base, tls: TLS) { (self.base, self.tls) = (base, tls) }
-        }
-        
-        // MARK: - Authentication
-
-        /// Contains authentication information for a connection.
-        public struct Authentication {
-            // TODO: Make the properties of this structure immutable (removing setters breaks public API).
-    
-            /// The username to connect with.
-            public var username: String
-
-            /// The password, if any, for the user specified by ``username``.
-            ///
-            /// - Warning: `nil` means "no password provided", whereas `""` (the empty string) is a password of zero
-            ///   length; these are not the same thing.
-            public var password: String?
-
-            /// The name of the database to open.
-            ///
-            /// - Note: If set to `nil` or an empty string, the provided ``username`` is used.
-            public var database: String?
-
-            public init(username: String, password: String?, database: String?) {
-                self.username = username
-                self.password = password
-                self.database = database
-            }
+            fileprivate let base: Base
+            private init(base: Base) { self.base = base }
         }
         
         // MARK: - Connection options
         
         /// Describes options affecting how the underlying connection is made.
         public struct Options {
-            /// A timeout for connection attempts.
+            /// A timeout for connection attempts. Defaults to ten seconds.
             ///
             /// Ignored when using a preexisting communcation channel. (See
-            /// ``PostgresConnection/Configuration/Server-swift.struct/establishedChannel(_:tls:)``.)
-            public let connectTimeout: TimeAmount
+            /// ``PostgresConnection/Configuration/init(establishedChannel:username:password:database:)``.)
+            public var connectTimeout: TimeAmount
             
-            /// The name to use for SNI (Server Name Indication) when TLS is enabled.
+            /// The name to use for SNI (Server Name Indication) when TLS is enabled. Defaults to none (but see below).
             ///
             /// > When set to `nil`:
             /// If the connection is made to a server over TCP using
-            /// ``PostgresConnection/Configuration/Server-swift.struct/init(host:port:tls:)``, the given `host` is used,
-            /// unless it was an IP address string. If it _was_ an IP, or the connection is made by any other method,
-            /// SNI is disabled.
+            /// ``PostgresConnection/Configuration/init(host:port:username:password:database:tls:)``, the given `host`
+            /// is used, unless it was an IP address string. If it _was_ an IP, or the connection is made by any other
+            /// method, SNI is disabled.
             ///
             /// - Warning: This name is not validated in any way; in particular, there is no attempt to check that it
             ///   matches the server's TLS certificate, nor is it in any way impacted by the validation setting in the
-            ///   TLS configuration (see ``PostgresConnection/Configuration/Server-swift.struct/TLS-swift.struct``).
-            public let tlsServerName: String?
+            ///   TLS configuration (see ``PostgresConnection/Configuration/TLS-swift.struct``).
+            public var tlsServerName: String?
             
             /// Whether the connection is required to provide backend key data (internal Postgres stuff).
             ///
             /// This property is provided for compatibility with Amazon RDS Proxy, which requires it to be `false`.
             /// If you are not using Amazon RDS Proxy, you should probably leave this set to `true` (the default).
-            public let requireBackendKeyData: Bool
+            public var requireBackendKeyData: Bool
             
-            /// Configure various options for a connection.
+            /// Create an options structure with default values.
             ///
             /// Most users should not need to adjust the defaults.
-            ///
-            /// - Parameters:
-            ///   - connectTimeout: See ``connectTimeout``. Defaults to 10 seconds.
-            ///   - tlsServerName: See ``tlsServerName``. Default is `nil`.
-            ///   - requireBackendKeyData: See ``requireBackendKeyData``. Default is `true`.
-            public init(
-                connectTimeout: TimeAmount = .seconds(10),
-                tlsServerName: String? = nil,
-                requireBackendKeyData: Bool = true
-            ) {
-                self.connectTimeout = connectTimeout
-                self.tlsServerName = tlsServerName
-                self.requireBackendKeyData = requireBackendKeyData
+            public init() {
+                self.connectTimeout = .seconds(10)
+                self.tlsServerName = nil
+                self.requireBackendKeyData = true
             }
         }
-
-        /// Endpoint information for establishing a communication channel.
-        ///
-        /// See ``Server-swift.struct``.
-        public let server: Server
         
-        /// Authentication properties to send during the startup auth handshake.
+        // MARK: - Accessors
+
+        /// The hostname to connect to for TCP configurations.
         ///
-        /// See ``Authentication-swift.struct``.
-        public var authentication: Authentication // TODO: Make this immutable
+        /// Always `nil` for other configurations.
+        public var host: String? {
+            if case let .connectTCP(host, _) = self.endpointInfo { return host }
+            else { return nil }
+        }
+        
+        /// The port to connect to for TCP configurations.
+        ///
+        /// Always `nil` for other configurations.
+        public var port: Int? {
+            if case let .connectTCP(_, port) = self.endpointInfo { return port }
+            else { return nil }
+        }
+        
+        /// The socket path to connect to for Unix domain socket connections.
+        ///
+        /// Always `nil` for other configurations.
+        public var unixSocketPath: String? {
+            if case let .bindUnixDomainSocket(path) = self.endpointInfo { return path }
+            else { return nil }
+        }
+        
+        /// The `Channel` to use in existing-channel configurations.
+        ///
+        /// Always `nil` for other configurations.
+        public var establishedChannel: Channel? {
+            if case let .configureChannel(channel) = self.endpointInfo { return channel }
+            else { return nil }
+        }
+        
+        /// The TLS mode to use for the connection. Valid for all configurations.
+        ///
+        /// See ``TLS-swift.struct``.
+        public var tls: TLS
         
         /// Options for handling the communication channel. Most users don't need to change these.
         ///
         /// See ``Options-swift.struct``.
-        public let options: Options
+        public var options: Options = .init()
         
-        /// Create a complete connection configuration.
+        /// The username to connect with.
+        public var username: String
+
+        /// The password, if any, for the user specified by ``username``.
+        ///
+        /// - Warning: `nil` means "no password provided", whereas `""` (the empty string) is a password of zero
+        ///   length; these are not the same thing.
+        public var password: String?
+
+        /// The name of the database to open.
+        ///
+        /// - Note: If set to `nil` or an empty string, the provided ``username`` is used.
+        public var database: String?
+
+        // MARK: - Initializers
+
+        /// Create a configuration for connecting to a server with a hostname and optional port.
+        ///
+        /// This specifies a TCP connection. If you're unsure which kind of connection you want, you almost
+        /// definitely want this one.
         ///
         /// - Parameters:
-        ///   - server: See ``Server-swift.struct``.
-        ///   - authentication: See ``Authentication-swift.struct``.
-        ///   - options: See ``Options-swift.struct``. Most users do not need to adjust any of these.
-        public init(
-            server: Server,
-            authentication: Authentication,
-            options: Options = .init()
-        ) {
-            self.server = server
-            self.authentication = authentication
-            self.options = options
+        ///   - host: The hostname to connect to.
+        ///   - port: The TCP port to connect to (defaults to 5432).
+        ///   - tls: The TLS mode to use.
+        public init(host: String, port: Int = 5432, username: String, password: String?, database: String?, tls: TLS) {
+            self.init(endpointInfo: .connectTCP(host: host, port: port), tls: tls, username: username, password: password, database: database)
+        }
+            
+        /// Create a configuration for connecting to a server through a UNIX domain socket.
+        ///
+        /// - Parameters:
+        ///   - path: The filesystem path of the socket to connect to.
+        ///   - tls: The TLS mode to use. Defaults to ``TLS-swift.struct/disable``.
+        public init(unixSocketPath: String, username: String, password: String?, database: String?) {
+            self.init(endpointInfo: .bindUnixDomainSocket(path: unixSocketPath), tls: .disable, username: username, password: password, database: database)
+        }
+            
+        /// Create a configuration for establishing a connection to a Postgres server over a preestablished
+        /// `NIOCore/Channel`.
+        ///
+        /// This is provided for calling code which wants to manage the underlying connection transport on its
+        /// own, such as when tunneling a connection through SSH.
+        ///
+        /// - Parameters:
+        ///   - channel: The `NIOCore/Channel` to use. The channel must already be active and connected to an
+        ///     endpoint (i.e. `NIOCore/Channel/isActive` must be `true`).
+        ///   - tls: The TLS mode to use. Defaults to ``TLS-swift.struct/disable``.
+        public init(establishedChannel channel: Channel, username: String, password: String?, database: String?) {
+            self.init(endpointInfo: .configureChannel(channel), tls: .disable, username: username, password: password, database: database)
+        }
+
+        // MARK: - Implementation details
+        // TODO: Make these `private` once the deprecated ``Connection`` struct is gone.
+
+        /*private*/ enum EndpointInfo {
+            case configureChannel(Channel)
+            case bindUnixDomainSocket(path: String)
+            case connectTCP(host: String, port: Int)
+        }
+
+        /*private*/ var endpointInfo: EndpointInfo
+
+        /*private*/ init(endpointInfo: EndpointInfo, tls: TLS, username: String, password: String?, database: String?) {
+            self.endpointInfo = endpointInfo
+            self.tls = tls
+            self.username = username
+            self.password = password
+            self.database = database
         }
     }
 }
+
+// MARK: - Internal config details
 
 extension PostgresConnection {
     /// A configuration object to bring the new ``PostgresConnection.Configuration`` together with
@@ -274,21 +232,25 @@ extension PostgresConnection {
         }
 
         let connection: InternalConfiguration.Connection
-        let authentication: Configuration.Authentication?
-        let tls: Configuration.Server.TLS
+        let username: String?
+        let password: String?
+        let database: String?
+        let tls: Configuration.TLS
         let options: Configuration.Options
     }
 }
 
 extension PostgresConnection.InternalConfiguration {
     init(_ config: PostgresConnection.Configuration) {
-        switch config.server.base {
+        switch config.endpointInfo {
         case .connectTCP(let host, let port): self.connection = .unresolvedTCP(host: host, port: port)
         case .bindUnixDomainSocket(let path): self.connection = .unresolvedUDS(path: path)
         case .configureChannel(let channel): self.connection = .bootstrapped(channel: channel)
         }
-        self.authentication = config.authentication
-        self.tls = config.server.tls
+        self.username = config.username
+        self.password = config.password
+        self.database = config.database
+        self.tls = config.tls
         self.options = config.options
     }
     

--- a/Sources/PostgresNIO/Connection/PostgresConnection.swift
+++ b/Sources/PostgresNIO/Connection/PostgresConnection.swift
@@ -169,7 +169,6 @@ public final class PostgresConnection: @unchecked Sendable {
                 guard channel.isActive else {
                     return eventLoop.makeFailedFuture(PSQLError.channel(underlying: ChannelError.alreadyClosed))
                 }
-                // TODO: Are there drawbacks to creating a bootstrap we don't end up using?
                 connectFuture = eventLoop.makeSucceededFuture(channel)
             }
 

--- a/Sources/PostgresNIO/Connection/PostgresConnection.swift
+++ b/Sources/PostgresNIO/Connection/PostgresConnection.swift
@@ -1,5 +1,6 @@
 import Atomics
 import NIOCore
+@_implementationOnly import NIOPosix
 #if canImport(Network)
 import NIOTransportServices
 #endif

--- a/Sources/PostgresNIO/Connection/PostgresConnection.swift
+++ b/Sources/PostgresNIO/Connection/PostgresConnection.swift
@@ -175,7 +175,7 @@ public final class PostgresConnection: @unchecked Sendable {
                 connectFuture = bootstrap.connect(unixDomainSocketPath: path)
             case .bootstrapped(let channel):
                 guard channel.isActive else {
-                    return eventLoop.makeFailedFuture(PSQLError.channel(underlying: ChannelError.alreadyClosed))
+                    return eventLoop.makeFailedFuture(PSQLError.connectionError(underlying: ChannelError.alreadyClosed))
                 }
                 connectFuture = eventLoop.makeSucceededFuture(channel)
             }

--- a/Sources/PostgresNIO/Connection/PostgresConnection.swift
+++ b/Sources/PostgresNIO/Connection/PostgresConnection.swift
@@ -70,31 +70,209 @@ public final class PostgresConnection: @unchecked Sendable {
         }
 
         public struct Connection {
-            /// The server to connect to
+            // MARK: Guts
+            
+            enum Base {
+                case configureChannel(Channel, serverName: String?)
+                case bindUnixDomainSocket(path: String, serverName: String?)
+                case connectTCP(host: String, port: Int)
+            }
+            
+            var base: Base // TODO: Make this immutable once the deprecated properties are removed
+            var realConnectTimeout: TimeAmount = .seconds(10) // need a separate property so we can deprecate the public one's setter
+            var realRequireBackendKeyData: Bool = true // need a separate property so we can deprecate the public one's setter
+            
+            private init(base: Base, connectTimeout: TimeAmount, requireBackendKeyData: Bool) {
+                self.base = base
+                self.realConnectTimeout = connectTimeout
+                self.realRequireBackendKeyData = requireBackendKeyData
+            }
+
+            // MARK: Initializers
+
+            /// Create a configuration for connecting to a server over TCP.
             ///
-            /// - Default: localhost
-            public var host: String
+            /// - Parameters:
+            ///   - host: The hostname to connect to.
+            ///   - port: The TCP port to connect to (defaults to 5432).
+            ///   - connectTimeout: See ``connectTimeout``.
+            ///   - requireBackendKeyData: See ``requireBackendKeyData``.
+            public static func tcp(
+                host: String,
+                port: Int = 5432,
+                connectTimeout: TimeAmount = .seconds(10),
+                requireBackendKeyData: Bool = true
+            ) -> Self {
+                .init(
+                    base: .connectTCP(host: host, port: port),
+                    connectTimeout: connectTimeout,
+                    requireBackendKeyData: true
+                )
+            }
+            
+            /// Create a configuration for connecting to a server through a UNIX domain socket.
+            ///
+            /// - Parameters:
+            ///   - path: The filesystem path of the socket to connect to.
+            ///   - connectTimeout: See ``connectTimeout``.
+            ///   - tlsHostname: See ``tlsHostname``.
+            ///   - requireBackendKeyData: See ``requireBackendKeyData``.
+            public static func unixDomainSocket(
+                path: String,
+                connectTimeout: TimeAmount = .seconds(10),
+                tlsHostname: String? = nil,
+                requireBackendKeyData: Bool = true
+            ) -> Self {
+                .init(
+                    base: .bindUnixDomainSocket(path: path, serverName: tlsHostname),
+                    connectTimeout: connectTimeout,
+                    requireBackendKeyData: requireBackendKeyData
+                )
+            }
+            
+            /// Create a configuration for establishing a connection to a Postgres server over a
+            /// preestablished ``NIOCore/Channel``.
+            ///
+            /// This is provided for calling code which wants to manage the underlying connection
+            /// transport on its own, such as when tunneling a connection through SSH.
+            ///
+            /// - Parameters:
+            ///   - channel: The ``NIOCore/Channel`` to use. The channel must already be active and
+            ///     connected to an endpoint.
+            ///   - tlsHostname: See ``tlsHostname``.
+            ///   - requireBackendKeyData: See ``requireBackendKeyData``.
+            public static func establishedChannel(
+                channel: Channel,
+                tlsHostname: String? = nil,
+                requireBackendKeyData: Bool = true
+            ) -> Self {
+                .init(
+                    base: .configureChannel(channel, serverName: tlsHostname),
+                    connectTimeout: .seconds(10),
+                    requireBackendKeyData: requireBackendKeyData
+                )
+            }
+            
+            // MARK: Getters
+            
+            /// The hostname to connect to for TCP configurations. Always `nil` for other configurations.
+            public var hostname: String? {
+                switch self.base {
+                case .connectTCP(let host, _): return host
+                default: return nil
+                }
+            }
+            
+            /// The port to connect to for TCP configurations. Always `nil` for other configurations.
+            public var tcpPort: Int? {
+                switch self.base {
+                case .connectTCP(_, let port): return port
+                default: return nil
+                }
+            }
+            
+            /// The socket path to connect to for Unix domain socket connections. Always `nil` for other configurations.
+            public var unixSocketPath: String? {
+                switch self.base {
+                case .bindUnixDomainSocket(let path, _): return path
+                default: return nil
+                }
+            }
+            
+            /// The ``NIOCore/Channel`` to use in existing-channel configurations. Always `nil` for other configurations.
+            public var establishedChannel: Channel? {
+                switch self.base {
+                case .configureChannel(let channel, _): return channel
+                default: return nil
+                }
+            }
+            
+            /// Specifies a timeout for connection attempts.
+            ///
+            /// > Default: 10 seconds
+            ///
+            /// - Note: This setting has no effect for existing-channel configurations.
+            ///
+            /// - Warning: Mutating this property on an existing configuration is no longer supported. Provide the
+            ///    timeout when calling one of the `static` configuration creation methods instead.
+            public var connectTimeout: TimeAmount {
+                get { self.realConnectTimeout }
+                @available(*, deprecated, message: "Provide connection timeout as a parameter when creating the configuration.")
+                set { self.realConnectTimeout = newValue }
+            }
+
+            /// Whether the connection is required to provide ``BackendKeyData``.
+            ///
+            /// This property is provided for compatibility with Amazon RDS Proxy, which requires it to be `false`.
+            /// If you are not using Amazon RDS Proxy, you probably don't need this.
+            ///
+            /// - Warning: Mutating this property on an existing configuration is no longer supported. Provide this
+            ///   flag when calling one of the `static` configuration creation methods instead.
+            public var requireBackendKeyData: Bool {
+                get { self.realRequireBackendKeyData }
+                @available(*, deprecated, message: "Provide the backend key data flag as a parameter when creating the configuration.")
+                set { self.realRequireBackendKeyData = newValue }
+            }
+
+            /// The server name to use for SNI when a connection initiates TLS, if one was provided.
+            ///
+            /// For TCP configurations, this is always the same as ``hostname``.
+            ///
+            /// - Note: This presence or absence of this value neither indicates nor affects whether
+            ///   TLS is disabled, requested, or required for a connection, regardless of type.
+            public var tlsHostname: String? {
+                switch self.base {
+                case .connectTCP(let host, _): return host
+                case .bindUnixDomainSocket(_, let serverName): return serverName
+                case .configureChannel(_, let serverName): return serverName
+                }
+            }
+            
+            // MARK: Deprecated
+
+            /// Create a configuration for connecting to a server over TCP.
+            ///
+            /// - Warning: This is a legacy initializer provided for compatibility. Use the
+            ///   ``tcp(host:port:connectTimeout:requireBackendKeyData:)`` method instead.
+            ///
+            /// - Parameters:
+            ///   - host: The hostname to connect to.
+            ///   - port: The TCP port to connect to (defaults to 5432).
+            @available(*, deprecated, message: "Use `.tcp(host:port:connectTimeout:requireBackendKeyData:)` instead.")
+            public init(host: String, port: Int = 5432) {
+                self = .tcp(host: host, port: port)
+            }
+
+            /// The server to connect to.
+            ///
+            /// - Warning: This is a legacy property. To avoid unexpected crashes, the getter will return an
+            ///   empty string and the setter will have no effect when used with non-TCP configurations. Use
+            ///   the ``hostname`` property instead. (There is no replacement for the setter.)
+            public var host: String {
+                @available(*, deprecated, message: "Use `hostname` instead.")
+                get { self.hostname ?? "" }
+                @available(*, deprecated, message: "This structure should be treated as immutable.")
+                set {
+                    if case .connectTCP(_, let port) = self.base {
+                        self.base = .connectTCP(host: newValue, port: port)
+                    }
+                }
+            }
 
             /// The server port to connect to.
             ///
-            /// - Default: 5432
-            public var port: Int
-
-            /// Require connection to provide `BackendKeyData`.
-            /// For use with Amazon RDS Proxy, this must be set to false.
-            ///
-            /// - Default: true
-            public var requireBackendKeyData: Bool = true
-
-            /// Specifies a timeout to apply to a connection attempt.
-            ///
-            /// - Default: 10 seconds
-            public var connectTimeout: TimeAmount
-
-            public init(host: String, port: Int = 5432) {
-                self.host = host
-                self.port = port
-                self.connectTimeout = .seconds(10)
+            /// - Warning: This is a legacy property. To avoid unexpected crashes, the getter will return zero
+            ///   and the setter will have no effect when used with non-TCP configurations. Use the ``tcpPort``
+            ///   property instead. (There is no replacement for the setter.)
+            public var port: Int {
+                @available(*, deprecated, message: "Use `tcpPort` instead.")
+                get { self.tcpPort ?? 0 }
+                @available(*, deprecated, message: "This structure should be treated as immutable.")
+                set {
+                    if case .connectTCP(let host, _) = self.base {
+                        self.base = .connectTCP(host: host, port: newValue)
+                    }
+                }
             }
         }
 
@@ -271,8 +449,16 @@ public final class PostgresConnection: @unchecked Sendable {
             switch configuration.connection {
             case .resolved(let address, _):
                 connectFuture = bootstrap.connect(to: address)
-            case .unresolved(let host, let port):
+            case .unresolvedTCP(let host, let port):
                 connectFuture = bootstrap.connect(host: host, port: port)
+            case .unresolvedUDS(let path, _):
+                connectFuture = bootstrap.connect(unixDomainSocketPath: path)
+            case .bootstrapped(let channel, _):
+                guard channel.isActive else {
+                    return eventLoop.makeFailedFuture(PSQLError.channel(underlying: ChannelError.alreadyClosed))
+                }
+                // TODO: Are there drawbacks to creating a bootstrap we don't end up using?
+                connectFuture = eventLoop.makeSucceededFuture(channel)
             }
 
             return connectFuture.flatMap { channel -> EventLoopFuture<PostgresConnection> in
@@ -736,12 +922,13 @@ enum CloseTarget {
 extension PostgresConnection.InternalConfiguration {
     var sslServerHostname: String? {
         switch self.connection {
-        case .unresolved(let host, _):
+        case .unresolvedTCP(let host, _):
             guard !host.isIPAddress() else {
+                // Providing an IP address to SNI is not valid; disable SNI instead.
                 return nil
             }
             return host
-        case .resolved(_, let serverName):
+        case .unresolvedUDS(_, let serverName), .resolved(_, let serverName), .bootstrapped(_, let serverName):
             return serverName
         }
     }
@@ -768,8 +955,10 @@ extension PostgresConnection {
     /// TODO: Drop with next major release
     struct InternalConfiguration {
         enum Connection {
-            case unresolved(host: String, port: Int)
+            case unresolvedTCP(host: String, port: Int)
+            case unresolvedUDS(path: String, serverName: String?)
             case resolved(address: SocketAddress, serverName: String?)
+            case bootstrapped(channel: Channel, serverName: String?)
         }
 
         var connection: Connection
@@ -786,7 +975,11 @@ extension PostgresConnection {
 extension PostgresConnection.InternalConfiguration {
     init(_ config: PostgresConnection.Configuration) {
         self.authentication = config.authentication
-        self.connection = .unresolved(host: config.connection.host, port: config.connection.port)
+        switch config.connection.base {
+        case .connectTCP(let host, let port): self.connection = .unresolvedTCP(host: host, port: port)
+        case .bindUnixDomainSocket(let path, let serverName): self.connection = .unresolvedUDS(path: path, serverName: serverName)
+        case .configureChannel(let channel, let serverName): self.connection = .bootstrapped(channel: channel, serverName: serverName)
+        }
         self.connectTimeout = config.connection.connectTimeout
         self.tls = config.tls
         self.requireBackendKeyData = config.connection.requireBackendKeyData

--- a/Sources/PostgresNIO/Deprecated/PostgresConnection+Configuration+Deprecated.swift
+++ b/Sources/PostgresNIO/Deprecated/PostgresConnection+Configuration+Deprecated.swift
@@ -1,0 +1,91 @@
+import NIOCore
+
+extension PostgresConnection.Configuration {
+    /// Legacy connection parameters structure. Replaced by ``PostgresConnection/Configuration/Server-swift.struct``.
+    @available(*, deprecated, message: "Use `Configuration.Server` instead.")
+    public struct Connection {
+        /// See ``PostgresConnection/Configuration/Server-swift.struct/host``.
+        public var host: String
+
+        /// See ``PostgresConnection/Configuration/Server-swift.struct/port``.
+        public var port: Int
+
+        /// See ``PostgresConnection/Configuration/Options-swift.struct/requireBackendKeyData``.
+        public var requireBackendKeyData: Bool = true
+
+        /// See ``PostgresConnection/Configuration/Options-swift.struct/connectTimeout``.
+        public var connectTimeout: TimeAmount = .seconds(10)
+
+        /// Create a configuration for connecting to a server.
+        ///
+        /// - Parameters:
+        ///   - host: The hostname to connect to.
+        ///   - port: The TCP port to connect to (defaults to 5432).
+        public init(host: String, port: Int = 5432) {
+            self.host = host
+            self.port = port
+        }
+    }
+    
+    /// Legacy location of ``PostgresConnection/Configuration/Server-swift.struct/TLS-swift.struct``.
+    @available(*, deprecated, message: "Use `Configuration.Server.TLS` instead.")
+    public typealias TLS = PostgresConnection.Configuration.Server.TLS
+    
+    /// Accessor for legacy connection parameters. Replaced by ``PostgresConnection/Configuration/server-swift.property``.
+    @available(*, deprecated, message: "Use `Configuration.server` instead.")
+    public var connection: Connection {
+        get {
+            switch self.server.base {
+            case .connectTCP(let host, let port):
+                var conn = Connection(host: host, port: port)
+                conn.requireBackendKeyData = self.options.requireBackendKeyData
+                conn.connectTimeout = self.options.connectTimeout
+                return conn
+            case .bindUnixDomainSocket(_), .configureChannel(_):
+                return .init(host: "!invalid!", port: 0) // best we can do, really
+            }
+        }
+        set {
+            self = .init(
+                server: .init(host: newValue.host, port: newValue.port, tls: self.server.tls),
+                authentication: self.authentication,
+                options: .init(
+                    connectTimeout: newValue.connectTimeout,
+                    tlsServerName: self.options.tlsServerName,
+                    requireBackendKeyData: newValue.requireBackendKeyData
+                )
+            )
+        }
+    }
+    
+    /// Accessor for legacy TLS mode. Replaced by ``PostgresConnection/Configuration/Server-swift.struct/tls-swift.property``.
+    @available(*, deprecated, message: "Use `Configuration.server.tls` instead.")
+    public var tls: TLS {
+        get { self.server.tls }
+        set {
+            self = .init(
+                server: .init(base: self.server.base, tls: newValue),
+                authentication: self.authentication, options: self.options
+            )
+        }
+    }
+
+    /// Legacy initializer. Replaced by ``PostgresConnection/Configuration/init(server:authentication:options:)``.
+    @available(*, deprecated, message: "Use `init(server:authentication:options:)` instead.")
+    public init(connection: Connection, authentication: Authentication, tls: TLS) {
+        self.init(
+            server: .init(host: connection.host, port: connection.port, tls: tls),
+            authentication: authentication,
+            options: .init(connectTimeout: connection.connectTimeout, requireBackendKeyData: connection.requireBackendKeyData)
+        )
+    }
+}
+
+extension PostgresConnection.Configuration.Authentication {
+    /// Old initializer for the original, less intitive, order of parameters (database and password switched places).
+    /// Replaced by ``init(username:password:database:)``.
+    @available(*, deprecated, message: "Use ``init(username:password:database:)`` instead.")
+    public init(username: String, database: String?, password: String?) {
+        self.init(username: username, password: password, database: database)
+    }
+}

--- a/Sources/PostgresNIO/New/Data/UUID+PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/Data/UUID+PostgresCodable.swift
@@ -1,4 +1,5 @@
 import NIOCore
+import NIOFoundationCompat
 import struct Foundation.UUID
 import typealias Foundation.uuid_t
 import NIOFoundationCompat

--- a/Sources/PostgresNIO/New/PostgresChannelHandler.swift
+++ b/Sources/PostgresNIO/New/PostgresChannelHandler.swift
@@ -32,7 +32,7 @@ final class PostgresChannelHandler: ChannelDuplexHandler {
          logger: Logger,
          configureSSLCallback: ((Channel) throws -> Void)?)
     {
-        self.state = ConnectionStateMachine(requireBackendKeyData: configuration.requireBackendKeyData)
+        self.state = ConnectionStateMachine(requireBackendKeyData: configuration.options.requireBackendKeyData)
         self.configuration = configuration
         self.configureSSLCallback = configureSSLCallback
         self.logger = logger
@@ -576,13 +576,13 @@ private extension Insecure.MD5.Digest {
 }
 
 extension ConnectionStateMachine.TLSConfiguration {
-    fileprivate init(_ tls: PostgresConnection.Configuration.TLS) {
-        switch tls.base {
-        case .disable:
+    fileprivate init(_ tls: PostgresConnection.Configuration.Server.TLS) {
+        switch (tls.isAllowed, tls.isEnforced) {
+        case (false, _):
             self = .disable
-        case .require:
+        case (true, true):
             self = .require
-        case .prefer:
+        case (true, false):
             self = .prefer
         }
     }

--- a/Sources/PostgresNIO/New/PostgresChannelHandler.swift
+++ b/Sources/PostgresNIO/New/PostgresChannelHandler.swift
@@ -284,11 +284,11 @@ final class PostgresChannelHandler: ChannelDuplexHandler {
         case .provideAuthenticationContext:
             context.fireUserInboundEventTriggered(PSQLEvent.readyForStartup)
             
-            if let authentication = self.configuration.authentication {
+            if let username = self.configuration.username {
                 let authContext = AuthContext(
-                    username: authentication.username,
-                    password: authentication.password,
-                    database: authentication.database
+                    username: username,
+                    password: self.configuration.password,
+                    database: self.configuration.database
                 )
                 let action = self.state.provideAuthenticationContext(authContext)
                 return self.run(action, with: context)
@@ -517,16 +517,6 @@ extension PostgresChannelHandler: PSQLRowsDataSource {
     }
 }
 
-extension PostgresConnection.Configuration.Authentication {
-    func toAuthContext() -> AuthContext {
-        AuthContext(
-            username: self.username,
-            password: self.password,
-            database: self.database
-        )
-    }
-}
-
 extension AuthContext {
     func toStartupParameters() -> PostgresFrontendMessage.Startup.Parameters {
         PostgresFrontendMessage.Startup.Parameters(
@@ -576,7 +566,7 @@ private extension Insecure.MD5.Digest {
 }
 
 extension ConnectionStateMachine.TLSConfiguration {
-    fileprivate init(_ tls: PostgresConnection.Configuration.Server.TLS) {
+    fileprivate init(_ tls: PostgresConnection.Configuration.TLS) {
         switch (tls.isAllowed, tls.isEnforced) {
         case (false, _):
             self = .disable

--- a/Sources/PostgresNIO/New/PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/PostgresCodable.swift
@@ -18,7 +18,7 @@ public protocol PostgresEncodable {
 }
 
 /// A type that can encode itself to a postgres wire binary representation. It enforces that the
-/// ``PostgresEncodable/encode(into:context:)`` does not throw. This allows users
+/// ``PostgresEncodable/encode(into:context:)-1jkcp`` does not throw. This allows users
 /// to create ``PostgresQuery``s using the `ExpressibleByStringInterpolation` without
 /// having to spell `try`.
 public protocol PostgresNonThrowingEncodable: PostgresEncodable {

--- a/Sources/PostgresNIO/Utilities/Exports.swift
+++ b/Sources/PostgresNIO/Utilities/Exports.swift
@@ -1,4 +1,10 @@
-#if !BUILDING_DOCC
+#if compiler(>=5.8)
+
+@_documentation(visibility: internal) @_exported import NIO
+@_documentation(visibility: internal) @_exported import NIOSSL
+@_documentation(visibility: internal) @_exported import struct Logging.Logger
+
+#elseif !BUILDING_DOCC
 
 // TODO: Remove this with the next major release!
 @_exported import NIO

--- a/Tests/IntegrationTests/PSQLIntegrationTests.swift
+++ b/Tests/IntegrationTests/PSQLIntegrationTests.swift
@@ -23,16 +23,16 @@ final class IntegrationTests: XCTestCase {
         try XCTSkipIf(env("POSTGRES_HOST_AUTH_METHOD") == "trust")
 
         let config = PostgresConnection.Configuration(
-            connection: .tcp(
+            server: .init(
                 host: env("POSTGRES_HOSTNAME") ?? "localhost",
-                port: env("POSTGRES_PORT").flatMap(Int.init(_:)) ?? 5432
+                port: env("POSTGRES_PORT").flatMap(Int.init(_:)) ?? 5432,
+                tls: .disable
             ),
             authentication: .init(
                 username: env("POSTGRES_USER") ?? "test_username",
-                database: env("POSTGRES_DB") ?? "test_database",
-                password: "wrong_password"
-            ),
-            tls: .disable
+                password: "wrong_password",
+                database: env("POSTGRES_DB") ?? "test_database"
+            )
         )
 
         let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)

--- a/Tests/IntegrationTests/PSQLIntegrationTests.swift
+++ b/Tests/IntegrationTests/PSQLIntegrationTests.swift
@@ -23,7 +23,7 @@ final class IntegrationTests: XCTestCase {
         try XCTSkipIf(env("POSTGRES_HOST_AUTH_METHOD") == "trust")
 
         let config = PostgresConnection.Configuration(
-            connection: .init(
+            connection: .tcp(
                 host: env("POSTGRES_HOSTNAME") ?? "localhost",
                 port: 5432
             ),

--- a/Tests/IntegrationTests/PSQLIntegrationTests.swift
+++ b/Tests/IntegrationTests/PSQLIntegrationTests.swift
@@ -25,7 +25,7 @@ final class IntegrationTests: XCTestCase {
         let config = PostgresConnection.Configuration(
             connection: .tcp(
                 host: env("POSTGRES_HOSTNAME") ?? "localhost",
-                port: 5432
+                port: env("POSTGRES_PORT").flatMap(Int.init(_:)) ?? 5432
             ),
             authentication: .init(
                 username: env("POSTGRES_USER") ?? "test_username",

--- a/Tests/IntegrationTests/PSQLIntegrationTests.swift
+++ b/Tests/IntegrationTests/PSQLIntegrationTests.swift
@@ -23,16 +23,12 @@ final class IntegrationTests: XCTestCase {
         try XCTSkipIf(env("POSTGRES_HOST_AUTH_METHOD") == "trust")
 
         let config = PostgresConnection.Configuration(
-            server: .init(
-                host: env("POSTGRES_HOSTNAME") ?? "localhost",
-                port: env("POSTGRES_PORT").flatMap(Int.init(_:)) ?? 5432,
-                tls: .disable
-            ),
-            authentication: .init(
-                username: env("POSTGRES_USER") ?? "test_username",
-                password: "wrong_password",
-                database: env("POSTGRES_DB") ?? "test_database"
-            )
+            host: env("POSTGRES_HOSTNAME") ?? "localhost",
+            port: env("POSTGRES_PORT").flatMap(Int.init(_:)) ?? 5432,
+            username: env("POSTGRES_USER") ?? "test_username",
+            password: "wrong_password",
+            database: env("POSTGRES_DB") ?? "test_database",
+            tls: .disable
         )
 
         let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)

--- a/Tests/IntegrationTests/PostgresNIOTests.swift
+++ b/Tests/IntegrationTests/PostgresNIOTests.swift
@@ -42,9 +42,8 @@ final class PostgresNIOTests: XCTestCase {
     func testConnectEstablishedChannelAndClose() throws {
         let channel = try ClientBootstrap(group: self.group).connect(to: PostgresConnection.address()).wait()
         let config = PostgresConnection.Configuration.init(
-            connection: .establishedChannel(channel: channel),
-            authentication: PostgresConnection.authConfig(),
-            tls: .disable
+            server: .establishedChannel(channel),
+            authentication: PostgresConnection.authConfig()
         )
         let logger = Logger(label: "postgres.connection.test")
         let conn = try PostgresConnection.connect(on: self.eventLoop, configuration: config, id: 0, logger: logger).wait()
@@ -75,9 +74,8 @@ final class PostgresNIOTests: XCTestCase {
     func testSimpleQueryVersionUsingEstablishedChannel() throws {
         let channel = try ClientBootstrap(group: self.group).connect(to: PostgresConnection.address()).wait()
         let config = PostgresConnection.Configuration.init(
-            connection: .establishedChannel(channel: channel),
-            authentication: PostgresConnection.authConfig(),
-            tls: .disable
+            server: .establishedChannel(channel),
+            authentication: PostgresConnection.authConfig()
         )
         let logger = Logger(label: "postgres.connection.test")
         let conn = try PostgresConnection.connect(on: self.eventLoop, configuration: config, id: 0, logger: logger).wait()
@@ -790,16 +788,16 @@ final class PostgresNIOTests: XCTestCase {
         let logger = Logger(label: "test")
         let sslContext = try! NIOSSLContext(configuration: .makeClientConfiguration())
         let config = PostgresConnection.Configuration(
-            connection: .tcp(
+            server: .init(
                 host: "elmer.db.elephantsql.com",
-                port: 5432
+                port: 5432,
+                tls: .require(sslContext)
             ),
             authentication: .init(
                 username: "uymgphwj",
-                database: "uymgphwj",
-                password: "7_tHbREdRwkqAdu4KoIS7hQnNxr8J1LA"
-            ),
-            tls: .require(sslContext)
+                password: "7_tHbREdRwkqAdu4KoIS7hQnNxr8J1LA",
+                database: "uymgphwj"
+            )
         )
 
 

--- a/Tests/IntegrationTests/Utilities.swift
+++ b/Tests/IntegrationTests/Utilities.swift
@@ -16,8 +16,8 @@ extension PostgresConnection {
     static func authConfig() -> PostgresConnection.Configuration.Authentication {
         .init(
             username: env("POSTGRES_USER") ?? "test_username",
-            database: env("POSTGRES_DB") ?? "test_database",
-            password: env("POSTGRES_PASSWORD") ?? "test_password"
+            password: env("POSTGRES_PASSWORD") ?? "test_password",
+            database: env("POSTGRES_DB") ?? "test_database"
         )
     }
 
@@ -37,12 +37,12 @@ extension PostgresConnection {
         logger.logLevel = logLevel
 
         let config = PostgresConnection.Configuration(
-            connection: .tcp(
+            server: .init(
                 host: env("POSTGRES_HOSTNAME") ?? "localhost",
-                port: env("POSTGRES_PORT").flatMap(Int.init(_:)) ?? 5432
+                port: env("POSTGRES_PORT").flatMap(Int.init(_:)) ?? 5432,
+                tls: .disable
             ),
-            authentication: self.authConfig(),
-            tls: .disable
+            authentication: self.authConfig()
         )
 
         return PostgresConnection.connect(on: eventLoop, configuration: config, id: 0, logger: logger)
@@ -53,9 +53,8 @@ extension PostgresConnection {
         logger.logLevel = logLevel
         
         let config = PostgresConnection.Configuration(
-            connection: .unixDomainSocket(path: env("POSTGRES_SOCKET") ?? "/tmp/.s.PGSQL.\(env("POSTGRES_PORT").flatMap(Int.init(_:)) ?? 5432)"),
-            authentication: self.authConfig(),
-            tls: .disable
+            server: .unixDomainSocket(path: env("POSTGRES_SOCKET") ?? "/tmp/.s.PGSQL.\(env("POSTGRES_PORT").flatMap(Int.init(_:)) ?? 5432)"),
+            authentication: self.authConfig()
         )
         
         return PostgresConnection.connect(on: eventLoop, configuration: config, id: 0, logger: logger)

--- a/Tests/PostgresNIOTests/New/PSQLConnectionTests.swift
+++ b/Tests/PostgresNIOTests/New/PSQLConnectionTests.swift
@@ -22,8 +22,9 @@ class PSQLConnectionTests: XCTestCase {
         }
         
         let config = PostgresConnection.Configuration(
-            server: .init(host: "127.0.0.1", port: port, tls: .disable),
-            authentication: .init(username: "postgres", password: "abc123", database: "postgres")
+            host: "127.0.0.1", port: port,
+            username: "postgres", password: "abc123", database: "postgres",
+            tls: .disable
         )
         
         var logger = Logger.psqlTest

--- a/Tests/PostgresNIOTests/New/PSQLConnectionTests.swift
+++ b/Tests/PostgresNIOTests/New/PSQLConnectionTests.swift
@@ -22,9 +22,8 @@ class PSQLConnectionTests: XCTestCase {
         }
         
         let config = PostgresConnection.Configuration(
-            connection: .tcp(host: "127.0.0.1", port: port),
-            authentication: .init(username: "postgres", database: "postgres", password: "abc123"),
-            tls: .disable
+            server: .init(host: "127.0.0.1", port: port, tls: .disable),
+            authentication: .init(username: "postgres", password: "abc123", database: "postgres")
         )
         
         var logger = Logger.psqlTest

--- a/Tests/PostgresNIOTests/New/PSQLConnectionTests.swift
+++ b/Tests/PostgresNIOTests/New/PSQLConnectionTests.swift
@@ -22,7 +22,7 @@ class PSQLConnectionTests: XCTestCase {
         }
         
         let config = PostgresConnection.Configuration(
-            connection: .init(host: "127.0.0.1", port: port),
+            connection: .tcp(host: "127.0.0.1", port: port),
             authentication: .init(username: "postgres", database: "postgres", password: "abc123"),
             tls: .disable
         )

--- a/Tests/PostgresNIOTests/New/PostgresChannelHandlerTests.swift
+++ b/Tests/PostgresNIOTests/New/PostgresChannelHandlerTests.swift
@@ -184,7 +184,7 @@ class PostgresChannelHandlerTests: XCTestCase {
         )
 
         return PostgresConnection.InternalConfiguration(
-            connection: .unresolved(host: host, port: port),
+            connection: .unresolvedTCP(host: host, port: port),
             connectTimeout: connectTimeout,
             authentication: authentication,
             tls: tls,

--- a/Tests/PostgresNIOTests/New/PostgresChannelHandlerTests.swift
+++ b/Tests/PostgresNIOTests/New/PostgresChannelHandlerTests.swift
@@ -26,8 +26,8 @@ class PostgresChannelHandlerTests: XCTestCase {
             return XCTFail("Unexpected message")
         }
         
-        XCTAssertEqual(startup.parameters.user, config.authentication?.username)
-        XCTAssertEqual(startup.parameters.database, config.authentication?.database)
+        XCTAssertEqual(startup.parameters.user, config.username)
+        XCTAssertEqual(startup.parameters.database, config.database)
         XCTAssertEqual(startup.parameters.options, nil)
         XCTAssertEqual(startup.parameters.replication, .false)
         
@@ -72,8 +72,8 @@ class PostgresChannelHandlerTests: XCTestCase {
             return XCTFail("Unexpected message")
         }
         
-        XCTAssertEqual(startupMessage.parameters.user, config.authentication?.username)
-        XCTAssertEqual(startupMessage.parameters.database, config.authentication?.database)
+        XCTAssertEqual(startupMessage.parameters.user, config.username)
+        XCTAssertEqual(startupMessage.parameters.database, config.database)
         XCTAssertEqual(startupMessage.parameters.replication, .false)
     }
     
@@ -111,9 +111,9 @@ class PostgresChannelHandlerTests: XCTestCase {
     func testRunAuthenticateMD5Password() {
         let config = self.testConnectionConfiguration()
         let authContext = AuthContext(
-            username: config.authentication?.username ?? "something wrong",
-            password: config.authentication?.password,
-            database: config.authentication?.database
+            username: config.username ?? "something wrong",
+            password: config.password,
+            database: config.database
         )
         let state = ConnectionStateMachine(.waitingToStartAuthentication)
         let handler = PostgresChannelHandler(configuration: config, state: state, configureSSLCallback: nil)
@@ -138,9 +138,9 @@ class PostgresChannelHandlerTests: XCTestCase {
         let password = "postgres"
         let config = self.testConnectionConfiguration(password: password)
         let authContext = AuthContext(
-            username: config.authentication?.username ?? "something wrong",
-            password: config.authentication?.password,
-            database: config.authentication?.database
+            username: config.username ?? "something wrong",
+            password: config.password,
+            database: config.database
         )
         let state = ConnectionStateMachine(.waitingToStartAuthentication)
         let handler = PostgresChannelHandler(configuration: config, state: state, configureSSLCallback: nil)
@@ -169,21 +169,21 @@ class PostgresChannelHandlerTests: XCTestCase {
         username: String = "test",
         database: String = "postgres",
         password: String = "password",
-        tls: PostgresConnection.Configuration.Server.TLS = .disable,
+        tls: PostgresConnection.Configuration.TLS = .disable,
         connectTimeout: TimeAmount = .seconds(10),
         requireBackendKeyData: Bool = true
     ) -> PostgresConnection.InternalConfiguration {
-        let authentication = PostgresConnection.Configuration.Authentication(
-            username: username,
-            password: password,
-            database: database
-        )
+        var options = PostgresConnection.Configuration.Options()
+        options.connectTimeout = connectTimeout
+        options.requireBackendKeyData = requireBackendKeyData
 
         return PostgresConnection.InternalConfiguration(
             connection: .unresolvedTCP(host: host, port: port),
-            authentication: authentication,
+            username: username,
+            password: password,
+            database: database,
             tls: tls,
-            options: .init(connectTimeout: connectTimeout, requireBackendKeyData: requireBackendKeyData)
+            options: options
         )
     }
 }


### PR DESCRIPTION
Extends `PostgresConnection` to enable connecting to Postgres servers over UNIX domain sockets or using a preexisting `Channel`.

In the process, most of the existing structure of `PostgresConnection.Configuration` has been deprecated in favor of new APIs with more options and cleaner design. The deprecation messages provide instructions on migrating existing code. List of deprecations and their replacements (all listed APIs should be assumed to have a `PostgresConnection.` prefix):

- `Configuration.Connection` and `.connection` -> `Configuration.host`, `.port`, `.unixDomainSocket`, and `.establishedChannel` properties, and respective initializers.
- `Configuration.Authentication` and `.authentication` -> `Configuration.username`, `.password`, and `.database` properties.
- New `Configuration.Options` structure and `.options` property, containing the `connectTimeout` and `requireBackendKeyData` properties previously found on `Configuration.Connection`.

_Note:_ The integration tests for UNIX domain sockets will be skipped unless `POSTGRES_SOCKET` is set to a socket path in the test environment. See the updated `test.yml` for examples of how to do so correctly.

Closes #259
Closes #268