### PR TITLE
Mark `RowDescription.Column` as Sendable

### DIFF
--- a/Sources/PostgresNIO/New/Messages/RowDescription.swift
+++ b/Sources/PostgresNIO/New/Messages/RowDescription.swift
@@ -15,7 +15,7 @@ struct RowDescription: PostgresBackendMessage.PayloadDecodable, Sendable, Equata
     var columns: [Column]
 
     @usableFromInline
-    struct Column: Equatable {
+    struct Column: Equatable, Sendable {
         /// The field name.
         @usableFromInline
         var name: String


### PR DESCRIPTION
Result: A warning less.