### PR TITLE
Make PSQLError public

### DIFF
--- a/Sources/PostgresNIO/New/Connection State Machine/AuthenticationStateMachine.swift
+++ b/Sources/PostgresNIO/New/Connection State Machine/AuthenticationStateMachine.swift
@@ -51,7 +51,7 @@ struct AuthenticationStateMachine {
                 return .authenticated
             case .md5(let salt):
                 guard self.authContext.password != nil else {
-                    return self.setAndFireError(.authMechanismRequiresPassword)
+                    return self.setAndFireError(PSQLError(code: .authMechanismRequiresPassword))
                 }
                 self.state = .passwordAuthenticationSent
                 return .sendPassword(.md5(salt: salt), self.authContext)

--- a/Sources/PostgresNIO/New/PSQLError.swift
+++ b/Sources/PostgresNIO/New/PSQLError.swift
@@ -1,92 +1,419 @@
 import NIOCore
 
-struct PSQLError: Error {
+public struct PSQLError: Error {
 
-    enum Base {
-        case sslUnsupported
-        case failedToAddSSLHandler(underlying: Error)
-        case server(PostgresBackendMessage.ErrorResponse)
-        case decoding(PSQLDecodingError)
-        case unexpectedBackendMessage(PostgresBackendMessage)
-        case unsupportedAuthMechanism(PSQLAuthScheme)
-        case authMechanismRequiresPassword
-        case saslError(underlyingError: Error)
-        case invalidCommandTag(String)
+    public struct Code: Sendable, Hashable, CustomStringConvertible {
+        enum Base: Sendable, Hashable {
+            case sslUnsupported
+            case failedToAddSSLHandler
+            case server
+            case messageDecodingFailure
+            case unexpectedBackendMessage
+            case unsupportedAuthMechanism
+            case authMechanismRequiresPassword
+            case saslError
+            case invalidCommandTag
 
-        case queryCancelled
-        case tooManyParameters
-        case connectionQuiescing
-        case connectionClosed
-        case connectionError(underlying: Error)
-        case uncleanShutdown
+            case queryCancelled
+            case tooManyParameters
+            case connectionQuiescing
+            case connectionClosed
+            case connectionError
+            case uncleanShutdown
+        }
 
-        case casting(PostgresDecodingError)
+        internal var base: Base
+
+        private init(_ base: Base) {
+            self.base = base
+        }
+
+        public static let sslUnsupported = Self.init(.sslUnsupported)
+        public static let failedToAddSSLHandler = Self(.failedToAddSSLHandler)
+        public static let server = Self(.server)
+        public static let messageDecodingFailure = Self(.messageDecodingFailure)
+        public static let unexpectedBackendMessage = Self(.unexpectedBackendMessage)
+        public static let unsupportedAuthMechanism = Self(.unsupportedAuthMechanism)
+        public static let authMechanismRequiresPassword = Self(.authMechanismRequiresPassword)
+        public static let saslError = Self.init(.saslError)
+        public static let invalidCommandTag = Self(.invalidCommandTag)
+        public static let queryCancelled = Self(.queryCancelled)
+        public static let tooManyParameters = Self(.tooManyParameters)
+        public static let connectionQuiescing = Self(.connectionQuiescing)
+        public static let connectionClosed = Self(.connectionClosed)
+        public static let connectionError = Self(.connectionError)
+        public static let uncleanShutdown = Self.init(.uncleanShutdown)
+
+        public var description: String {
+            switch self.base {
+            case .sslUnsupported:
+                return "sslUnsupported"
+            case .failedToAddSSLHandler:
+                return "failedToAddSSLHandler"
+            case .server:
+                return "server"
+            case .messageDecodingFailure:
+                return "messageDecodingFailure"
+            case .unexpectedBackendMessage:
+                return "unexpectedBackendMessage"
+            case .unsupportedAuthMechanism:
+                return "unsupportedAuthMechanism"
+            case .authMechanismRequiresPassword:
+                return "authMechanismRequiresPassword"
+            case .saslError:
+                return "saslError"
+            case .invalidCommandTag:
+                return "invalidCommandTag"
+            case .queryCancelled:
+                return "queryCancelled"
+            case .tooManyParameters:
+                return "tooManyParameters"
+            case .connectionQuiescing:
+                return "connectionQuiescing"
+            case .connectionClosed:
+                return "connectionClosed"
+            case .connectionError:
+                return "connectionError"
+            case .uncleanShutdown:
+                return "uncleanShutdown"
+            }
+        }
     }
 
-    internal var base: Base
+    private var backing: Backing
 
-    private init(_ base: Base) {
-        self.base = base
+    public internal(set) var code: Code {
+        get { self.backing.code }
+        set {
+            if isKnownUniquelyReferenced(&self.backing) {
+                self.backing.code = newValue
+            } else {
+                self.backing = self.backing.copy()
+                self.backing.code = newValue
+            }
+        }
     }
 
-    static var sslUnsupported: PSQLError {
-        Self.init(.sslUnsupported)
+    // The info that was received from the server
+    public internal(set) var serverInfo: ServerInfo? {
+        get { self.backing.serverInfo }
+        set {
+            if isKnownUniquelyReferenced(&self.backing) {
+                self.backing.serverInfo = newValue
+            } else {
+                self.backing = self.backing.copy()
+                self.backing.serverInfo = newValue
+            }
+        }
     }
 
-    static func failedToAddSSLHandler(underlying error: Error) -> PSQLError {
-        Self.init(.failedToAddSSLHandler(underlying: error))
+    // The underlying error
+    public internal(set) var underlying: Error? {
+        get { self.backing.underlying }
+        set {
+            if isKnownUniquelyReferenced(&self.backing) {
+                self.backing.underlying = newValue
+            } else {
+                self.backing = self.backing.copy()
+                self.backing.underlying = newValue
+            }
+        }
     }
 
-    static func server(_ message: PostgresBackendMessage.ErrorResponse) -> PSQLError {
-        Self.init(.server(message))
+    // The file in which the Postgres operation was triggered that failed
+    public internal(set) var file: String? {
+        get { self.backing.file }
+        set {
+            if isKnownUniquelyReferenced(&self.backing) {
+                self.backing.file = newValue
+            } else {
+                self.backing = self.backing.copy()
+                self.backing.file = newValue
+            }
+        }
     }
 
-    static func decoding(_ error: PSQLDecodingError) -> PSQLError {
-        Self.init(.decoding(error))
+    // The line in which the Postgres operation was triggered that failed
+    public internal(set) var line: Int? {
+        get { self.backing.line }
+        set {
+            if isKnownUniquelyReferenced(&self.backing) {
+                self.backing.line = newValue
+            } else {
+                self.backing = self.backing.copy()
+                self.backing.line = newValue
+            }
+        }
     }
 
-    static func unexpectedBackendMessage(_ message: PostgresBackendMessage) -> PSQLError {
-        Self.init(.unexpectedBackendMessage(message))
+    // The query that failed
+    public internal(set) var query: PostgresQuery? {
+        get { self.backing.query }
+        set {
+            if isKnownUniquelyReferenced(&self.backing) {
+                self.backing.query = newValue
+            } else {
+                self.backing = self.backing.copy()
+                self.backing.query = newValue
+            }
+        }
     }
 
-    static func unsupportedAuthMechanism(_ authScheme: PSQLAuthScheme) -> PSQLError {
-        Self.init(.unsupportedAuthMechanism(authScheme))
+    // the backend message... we should keep this internal but we can use it to print more
+    // advanced debug reasons.
+    internal var backendMessage: PostgresBackendMessage? {
+        get { self.backing.backendMessage }
+        set {
+            if isKnownUniquelyReferenced(&self.backing) {
+                self.backing.backendMessage = newValue
+            } else {
+                self.backing = self.backing.copy()
+                self.backing.backendMessage = newValue
+            }
+        }
     }
 
-    static var authMechanismRequiresPassword: PSQLError {
-        Self.init(.authMechanismRequiresPassword)
+    /// the unsupported auth scheme... we should keep this internal but we can use it to print more
+    /// advanced debug reasons.
+    internal var unsupportedAuthScheme: UnsupportedAuthScheme? {
+        get { self.backing.unsupportedAuthScheme }
+        set {
+            if isKnownUniquelyReferenced(&self.backing) {
+                self.backing.unsupportedAuthScheme = newValue
+            } else {
+                self.backing = self.backing.copy()
+                self.backing.unsupportedAuthScheme = newValue
+            }
+        }
+    }
+
+    /// the invalid command tag... we should keep this internal but we can use it to print more
+    /// advanced debug reasons.
+    internal var invalidCommandTag: String? {
+        get { self.backing.invalidCommandTag }
+        set {
+            if isKnownUniquelyReferenced(&self.backing) {
+                self.backing.invalidCommandTag = newValue
+            } else {
+                self.backing = self.backing.copy()
+                self.backing.invalidCommandTag = newValue
+            }
+        }
+    }
+
+    init(code: Code, query: PostgresQuery, file: String? = nil, line: Int? = nil) {
+        self.backing = .init(code: code)
+        self.query = query
+        self.file = file
+        self.line = line
+    }
+
+    init(code: Code) {
+        self.backing = .init(code: code)
+    }
+
+    private final class Backing {
+        fileprivate var code: Code
+
+        fileprivate var serverInfo: ServerInfo?
+
+        fileprivate var underlying: Error?
+
+        fileprivate var file: String?
+
+        fileprivate var line: Int?
+
+        fileprivate var query: PostgresQuery?
+
+        fileprivate var backendMessage: PostgresBackendMessage?
+
+        fileprivate var unsupportedAuthScheme: UnsupportedAuthScheme?
+
+        fileprivate var invalidCommandTag: String?
+
+        init(code: Code) {
+            self.code = code
+        }
+
+        func copy() -> Self {
+            let new = Self.init(code: self.code)
+            new.serverInfo = self.serverInfo
+            new.underlying = self.underlying
+            new.file = self.file
+            new.line = self.line
+            new.query = self.query
+            new.backendMessage = self.backendMessage
+            return new
+        }
+    }
+
+    public struct ServerInfo {
+        public struct Field: Hashable, Sendable {
+            fileprivate let backing: PostgresBackendMessage.Field
+
+            private init(_ backing: PostgresBackendMessage.Field) {
+                self.backing = backing
+            }
+
+            /// Severity: the field contents are ERROR, FATAL, or PANIC (in an error message),
+            /// or WARNING, NOTICE, DEBUG, INFO, or LOG (in a notice message), or a
+            /// localized translation of one of these. Always present.
+            public static let localizedSeverity = Self(.localizedSeverity)
+
+            /// Severity: the field contents are ERROR, FATAL, or PANIC (in an error message),
+            /// or WARNING, NOTICE, DEBUG, INFO, or LOG (in a notice message).
+            /// This is identical to the S field except that the contents are never localized.
+            /// This is present only in messages generated by PostgreSQL versions 9.6 and later.
+            public static let severity = Self(.severity)
+
+            /// Code: the SQLSTATE code for the error (see Appendix A). Not localizable. Always present.
+            public static let sqlState = Self(.sqlState)
+
+            /// Message: the primary human-readable error message. This should be accurate but terse (typically one line).
+            /// Always present.
+            public static let message = Self(.message)
+
+            /// Detail: an optional secondary error message carrying more detail about the problem.
+            /// Might run to multiple lines.
+            public static let detail = Self(.detail)
+
+            /// Hint: an optional suggestion what to do about the problem.
+            /// This is intended to differ from Detail in that it offers advice (potentially inappropriate)
+            /// rather than hard facts. Might run to multiple lines.
+            public static let hint = Self(.hint)
+
+            /// Position: the field value is a decimal ASCII integer, indicating an error cursor
+            /// position as an index into the original query string. The first character has index 1,
+            /// and positions are measured in characters not bytes.
+            public static let position = Self(.position)
+
+            /// Internal position: this is defined the same as the P field, but it is used when the
+            /// cursor position refers to an internally generated command rather than the one submitted by the client.
+            /// The q field will always appear when this field appears.
+            public static let internalPosition = Self(.internalPosition)
+
+            /// Internal query: the text of a failed internally-generated command.
+            /// This could be, for example, a SQL query issued by a PL/pgSQL function.
+            public static let internalQuery = Self(.internalQuery)
+
+            /// Where: an indication of the context in which the error occurred.
+            /// Presently this includes a call stack traceback of active procedural language functions and
+            /// internally-generated queries. The trace is one entry per line, most recent first.
+            public static let locationContext = Self(.locationContext)
+
+            /// Schema name: if the error was associated with a specific database object, the name of
+            /// the schema containing that object, if any.
+            public static let schemaName = Self(.schemaName)
+
+            /// Table name: if the error was associated with a specific table, the name of the table.
+            /// (Refer to the schema name field for the name of the table's schema.)
+            public static let tableName = Self(.tableName)
+
+            /// Column name: if the error was associated with a specific table column, the name of the column.
+            /// (Refer to the schema and table name fields to identify the table.)
+            public static let columnName = Self(.columnName)
+
+            /// Data type name: if the error was associated with a specific data type, the name of the data type.
+            /// (Refer to the schema name field for the name of the data type's schema.)
+            public static let dataTypeName = Self(.dataTypeName)
+
+            /// Constraint name: if the error was associated with a specific constraint, the name of the constraint.
+            /// Refer to fields listed above for the associated table or domain. (For this purpose, indexes are
+            /// treated as constraints, even if they weren't created with constraint syntax.)
+            public static let constraintName = Self(.constraintName)
+
+            /// File: the file name of the source-code location where the error was reported.
+            public static let file = Self(.file)
+
+            /// Line: the line number of the source-code location where the error was reported.
+            public static let line = Self(.line)
+
+            /// Routine: the name of the source-code routine reporting the error.
+            public static let routine = Self(.routine)
+        }
+
+        let underlying: PostgresBackendMessage.ErrorResponse
+
+        init(_ underlying: PostgresBackendMessage.ErrorResponse) {
+            self.underlying = underlying
+        }
+
+        subscript(field: Field) -> String? {
+            self.underlying.fields[field.backing]
+        }
+    }
+
+    // MARK: - Internal convenience factory methods -
+
+    static func unexpectedBackendMessage(_ message: PostgresBackendMessage) -> Self {
+        var new = Self(code: .unexpectedBackendMessage)
+        new.backendMessage = message
+        return new
+    }
+
+    static func messageDecodingFailure(_ error: PostgresMessageDecodingError) -> Self {
+        var new = Self(code: .messageDecodingFailure)
+        new.underlying = error
+        return new
+    }
+
+    static var connectionQuiescing: PSQLError { PSQLError(code: .connectionQuiescing) }
+
+    static var connectionClosed: PSQLError { PSQLError(code: .connectionClosed) }
+
+    static var authMechanismRequiresPassword: PSQLError { PSQLError(code: .authMechanismRequiresPassword) }
+
+    static var sslUnsupported: PSQLError { PSQLError(code: .sslUnsupported) }
+
+    static var queryCancelled: PSQLError { PSQLError(code: .queryCancelled) }
+
+    static var uncleanShutdown: PSQLError { PSQLError(code: .uncleanShutdown) }
+
+    static func server(_ response: PostgresBackendMessage.ErrorResponse) -> PSQLError {
+        var error = PSQLError(code: .server)
+        error.serverInfo = .init(response)
+        return error
     }
 
     static func sasl(underlying: Error) -> PSQLError {
-        Self.init(.saslError(underlyingError: underlying))
+        var error = PSQLError(code: .saslError)
+        error.underlying = underlying
+        return error
+    }
+
+    static func failedToAddSSLHandler(underlying: Error) -> PSQLError {
+        var error = PSQLError(code: .failedToAddSSLHandler)
+        error.underlying = underlying
+        return error
+    }
+
+    static func connectionError(underlying: Error) -> PSQLError {
+        var error = PSQLError(code: .connectionError)
+        error.underlying = underlying
+        return error
+    }
+
+    static func unsupportedAuthMechanism(_ authScheme: UnsupportedAuthScheme) -> PSQLError {
+        var error = PSQLError(code: .unsupportedAuthMechanism)
+        error.unsupportedAuthScheme = authScheme
+        return error
     }
 
     static func invalidCommandTag(_ value: String) -> PSQLError {
-        Self.init(.invalidCommandTag(value))
+        var error = PSQLError(code: .invalidCommandTag)
+        error.invalidCommandTag = value
+        return error
     }
 
-    static var queryCancelled: PSQLError {
-        Self.init(.queryCancelled)
-    }
-
-    static var tooManyParameters: PSQLError {
-        Self.init(.tooManyParameters)
-    }
-
-    static var connectionQuiescing: PSQLError {
-        Self.init(.connectionQuiescing)
-    }
-
-    static var connectionClosed: PSQLError {
-        Self.init(.connectionClosed)
-    }
-
-    static func channel(underlying: Error) -> PSQLError {
-        Self.init(.connectionError(underlying: underlying))
-    }
-
-    static var uncleanShutdown: PSQLError {
-        Self.init(.uncleanShutdown)
+    enum UnsupportedAuthScheme {
+        case none
+        case kerberosV5
+        case md5
+        case plaintext
+        case scmCredential
+        case gss
+        case sspi
+        case sasl(mechanisms: [String])
     }
 }
 
@@ -110,25 +437,25 @@ public struct PostgresDecodingError: Error, Equatable {
         public static let failure = Self.init(.failure)
     }
 
-    /// The casting error code
+    /// The decoding error code
     public let code: Code
 
-    /// The cell's column name for which the casting failed
+    /// The cell's column name for which the decoding failed
     public let columnName: String
-    /// The cell's column index for which the casting failed
+    /// The cell's column index for which the decoding failed
     public let columnIndex: Int
-    /// The swift type the cell should have been casted into
+    /// The swift type the cell should have been decoded into
     public let targetType: Any.Type
-    /// The cell's postgres data type for which the casting failed
+    /// The cell's postgres data type for which the decoding failed
     public let postgresType: PostgresDataType
-    /// The cell's postgres format for which the casting failed
+    /// The cell's postgres format for which the decoding failed
     public let postgresFormat: PostgresFormat
-    /// A copy of the cell data which was attempted to be casted
+    /// A copy of the cell data which was attempted to be decoded
     public let postgresData: ByteBuffer?
 
-    /// The file the casting/decoding was attempted in
+    /// The file the decoding was attempted in
     public let file: String
-    /// The line the casting/decoding was attempted in
+    /// The line the decoding was attempted in
     public let line: Int
 
     @usableFromInline
@@ -174,14 +501,4 @@ extension PostgresDecodingError: CustomStringConvertible {
         // reason we overwrite the error description by default to this generic "Database error"
         "Database error"
     }
-}
-enum PSQLAuthScheme {
-    case none
-    case kerberosV5
-    case md5
-    case plaintext
-    case scmCredential
-    case gss
-    case sspi
-    case sasl(mechanisms: [String])
 }

--- a/Sources/PostgresNIO/New/PSQLError.swift
+++ b/Sources/PostgresNIO/New/PSQLError.swift
@@ -1,5 +1,6 @@
 import NIOCore
 
+/// An error that is thrown from the PostgresClient.
 public struct PSQLError: Error {
 
     public struct Code: Sendable, Hashable, CustomStringConvertible {
@@ -82,122 +83,93 @@ public struct PSQLError: Error {
 
     private var backing: Backing
 
+    private mutating func copyBackingStoriageIfNecessary() {
+        if !isKnownUniquelyReferenced(&self.backing) {
+            self.backing = self.backing.copy()
+        }
+    }
+
+    /// The ``PSQLError/Code-swift.struct`` code
     public internal(set) var code: Code {
         get { self.backing.code }
         set {
-            if isKnownUniquelyReferenced(&self.backing) {
-                self.backing.code = newValue
-            } else {
-                self.backing = self.backing.copy()
-                self.backing.code = newValue
-            }
+            self.copyBackingStoriageIfNecessary()
+            self.backing.code = newValue
         }
     }
 
-    // The info that was received from the server
+    /// The info that was received from the server
     public internal(set) var serverInfo: ServerInfo? {
         get { self.backing.serverInfo }
         set {
-            if isKnownUniquelyReferenced(&self.backing) {
-                self.backing.serverInfo = newValue
-            } else {
-                self.backing = self.backing.copy()
-                self.backing.serverInfo = newValue
-            }
+            self.copyBackingStoriageIfNecessary()
+            self.backing.serverInfo = newValue
         }
     }
 
-    // The underlying error
+    /// The underlying error
     public internal(set) var underlying: Error? {
         get { self.backing.underlying }
         set {
-            if isKnownUniquelyReferenced(&self.backing) {
-                self.backing.underlying = newValue
-            } else {
-                self.backing = self.backing.copy()
-                self.backing.underlying = newValue
-            }
+            self.copyBackingStoriageIfNecessary()
+            self.backing.underlying = newValue
         }
     }
 
-    // The file in which the Postgres operation was triggered that failed
+    /// The file in which the Postgres operation was triggered that failed
     public internal(set) var file: String? {
         get { self.backing.file }
         set {
-            if isKnownUniquelyReferenced(&self.backing) {
-                self.backing.file = newValue
-            } else {
-                self.backing = self.backing.copy()
-                self.backing.file = newValue
-            }
+            self.copyBackingStoriageIfNecessary()
+            self.backing.file = newValue
         }
     }
 
-    // The line in which the Postgres operation was triggered that failed
+    /// The line in which the Postgres operation was triggered that failed
     public internal(set) var line: Int? {
         get { self.backing.line }
         set {
-            if isKnownUniquelyReferenced(&self.backing) {
-                self.backing.line = newValue
-            } else {
-                self.backing = self.backing.copy()
-                self.backing.line = newValue
-            }
+            self.copyBackingStoriageIfNecessary()
+            self.backing.line = newValue
         }
     }
 
-    // The query that failed
+    /// The query that failed
     public internal(set) var query: PostgresQuery? {
         get { self.backing.query }
         set {
-            if isKnownUniquelyReferenced(&self.backing) {
-                self.backing.query = newValue
-            } else {
-                self.backing = self.backing.copy()
-                self.backing.query = newValue
-            }
+            self.copyBackingStoriageIfNecessary()
+            self.backing.query = newValue
         }
     }
 
-    // the backend message... we should keep this internal but we can use it to print more
-    // advanced debug reasons.
-    internal var backendMessage: PostgresBackendMessage? {
+    /// the backend message... we should keep this internal but we can use it to print more
+    /// advanced debug reasons.
+    var backendMessage: PostgresBackendMessage? {
         get { self.backing.backendMessage }
         set {
-            if isKnownUniquelyReferenced(&self.backing) {
-                self.backing.backendMessage = newValue
-            } else {
-                self.backing = self.backing.copy()
-                self.backing.backendMessage = newValue
-            }
+            self.copyBackingStoriageIfNecessary()
+            self.backing.backendMessage = newValue
         }
     }
 
     /// the unsupported auth scheme... we should keep this internal but we can use it to print more
     /// advanced debug reasons.
-    internal var unsupportedAuthScheme: UnsupportedAuthScheme? {
+    var unsupportedAuthScheme: UnsupportedAuthScheme? {
         get { self.backing.unsupportedAuthScheme }
         set {
-            if isKnownUniquelyReferenced(&self.backing) {
-                self.backing.unsupportedAuthScheme = newValue
-            } else {
-                self.backing = self.backing.copy()
-                self.backing.unsupportedAuthScheme = newValue
-            }
+            self.copyBackingStoriageIfNecessary()
+            self.backing.unsupportedAuthScheme = newValue
         }
     }
 
     /// the invalid command tag... we should keep this internal but we can use it to print more
     /// advanced debug reasons.
-    internal var invalidCommandTag: String? {
+    var invalidCommandTag: String? {
         get { self.backing.invalidCommandTag }
         set {
-            if isKnownUniquelyReferenced(&self.backing) {
-                self.backing.invalidCommandTag = newValue
-            } else {
-                self.backing = self.backing.copy()
-                self.backing.invalidCommandTag = newValue
-            }
+            self.copyBackingStoriageIfNecessary()
+            self.backing.invalidCommandTag = newValue
         }
     }
 
@@ -334,11 +306,13 @@ public struct PSQLError: Error {
 
         let underlying: PostgresBackendMessage.ErrorResponse
 
-        init(_ underlying: PostgresBackendMessage.ErrorResponse) {
+        fileprivate init(_ underlying: PostgresBackendMessage.ErrorResponse) {
             self.underlying = underlying
         }
 
-        subscript(field: Field) -> String? {
+        /// The detailed server error information. This field is set if the ``PSQLError/code-swift.property`` is
+        /// ``PSQLError/Code-swift.struct/server``.
+        public subscript(field: Field) -> String? {
             self.underlying.fields[field.backing]
         }
     }

--- a/Sources/PostgresNIO/New/PostgresChannelHandler.swift
+++ b/Sources/PostgresNIO/New/PostgresChannelHandler.swift
@@ -91,7 +91,7 @@ final class PostgresChannelHandler: ChannelDuplexHandler {
     
     func errorCaught(context: ChannelHandlerContext, error: Error) {
         self.logger.debug("Channel error caught.", metadata: [.error: "\(error)"])
-        let action = self.state.errorHappened(.channel(underlying: error))
+        let action = self.state.errorHappened(.connectionError(underlying: error))
         self.run(action, with: context)
     }
     
@@ -146,8 +146,8 @@ final class PostgresChannelHandler: ChannelDuplexHandler {
                 
                 self.run(action, with: context)
             }
-        } catch let error as PSQLDecodingError {
-            let action = self.state.errorHappened(.decoding(error))
+        } catch let error as PostgresMessageDecodingError {
+            let action = self.state.errorHappened(.messageDecodingFailure(error))
             self.run(action, with: context)
         } catch {
             preconditionFailure("Expected to only get PSQLDecodingErrors from the PSQLBackendMessageDecoder.")

--- a/Sources/PostgresNIO/Postgres+PSQLCompat.swift
+++ b/Sources/PostgresNIO/Postgres+PSQLCompat.swift
@@ -21,11 +21,14 @@ extension PSQLError {
         case .failedToAddSSLHandler:
             return self.underlying ?? self
         case .messageDecodingFailure:
-            return PostgresError.protocol("Error decoding message: \(String(describing: self.underlying))")
+            let message = self.underlying != nil ? String(describing: self.underlying!) : "no message"
+            return PostgresError.protocol("Error decoding message: \(message)")
         case .unexpectedBackendMessage:
-            return PostgresError.protocol("Unexpected message: \(String(describing: self.backendMessage))")
+            let message = self.backendMessage != nil ? String(describing: self.backendMessage!) : "no message"
+            return PostgresError.protocol("Unexpected message: \(message)")
         case .unsupportedAuthMechanism:
-            return PostgresError.protocol("Unsupported auth scheme: \(String(describing: self.unsupportedAuthScheme))")
+            let message = self.unsupportedAuthScheme != nil ? String(describing: self.unsupportedAuthScheme!) : "no scheme"
+            return PostgresError.protocol("Unsupported auth scheme: \(message)")
         case .authMechanismRequiresPassword:
             return PostgresError.protocol("Unable to authenticate without password")
         case .saslError:

--- a/Sources/PostgresNIO/Postgres+PSQLCompat.swift
+++ b/Sources/PostgresNIO/Postgres+PSQLCompat.swift
@@ -2,40 +2,42 @@ import NIOCore
 
 extension PSQLError {
     func toPostgresError() -> Error {
-        switch self.base {
+        switch self.code.base {
         case .queryCancelled:
             return self
-        case .server(let errorMessage):
+        case .server:
+            guard let serverInfo = self.serverInfo else {
+                return self
+            }
+
             var fields = [PostgresMessage.Error.Field: String]()
-            fields.reserveCapacity(errorMessage.fields.count)
-            errorMessage.fields.forEach { (key, value) in
+            fields.reserveCapacity(serverInfo.underlying.fields.count)
+            serverInfo.underlying.fields.forEach { (key, value) in
                 fields[PostgresMessage.Error.Field(rawValue: key.rawValue)!] = value
             }
             return PostgresError.server(PostgresMessage.Error(fields: fields))
         case .sslUnsupported:
             return PostgresError.protocol("Server does not support TLS")
-        case .failedToAddSSLHandler(underlying: let underlying):
-            return underlying
-        case .decoding(let decodingError):
-            return PostgresError.protocol("Error decoding message: \(decodingError)")
-        case .unexpectedBackendMessage(let message):
-            return PostgresError.protocol("Unexpected message: \(message)")
-        case .unsupportedAuthMechanism(let authScheme):
-            return PostgresError.protocol("Unsupported auth scheme: \(authScheme)")
+        case .failedToAddSSLHandler:
+            return self.underlying ?? self
+        case .messageDecodingFailure:
+            return PostgresError.protocol("Error decoding message: \(String(describing: self.underlying))")
+        case .unexpectedBackendMessage:
+            return PostgresError.protocol("Unexpected message: \(String(describing: self.backendMessage))")
+        case .unsupportedAuthMechanism:
+            return PostgresError.protocol("Unsupported auth scheme: \(String(describing: self.unsupportedAuthScheme))")
         case .authMechanismRequiresPassword:
             return PostgresError.protocol("Unable to authenticate without password")
-        case .saslError(underlyingError: let underlying):
-            return underlying
+        case .saslError:
+            return self.underlying ?? self
         case .tooManyParameters, .invalidCommandTag:
             return self
         case .connectionQuiescing:
             return PostgresError.connectionClosed
         case .connectionClosed:
             return PostgresError.connectionClosed
-        case .connectionError(underlying: let underlying):
-            return underlying
-        case .casting(let castingError):
-            return castingError
+        case .connectionError:
+            return self.underlying ?? self
         case .uncleanShutdown:
             return PostgresError.protocol("Unexpected connection close")
         }

--- a/Tests/IntegrationTests/PostgresNIOTests.swift
+++ b/Tests/IntegrationTests/PostgresNIOTests.swift
@@ -1093,7 +1093,7 @@ final class PostgresNIOTests: XCTestCase {
         defer { XCTAssertNoThrow( try conn?.close().wait() ) }
         let binds = [PostgresData].init(repeating: .null, count: Int(UInt16.max) + 1)
         XCTAssertThrowsError(try conn?.query("SELECT version()", binds).wait()) { error in
-            guard case .tooManyParameters = (error as? PSQLError)?.base else {
+            guard case .tooManyParameters = (error as? PSQLError)?.code.base else {
                 return XCTFail("Unexpected error: \(error)")
             }
         }

--- a/Tests/PostgresNIOTests/New/Connection State Machine/AuthenticationStateMachineTests.swift
+++ b/Tests/PostgresNIOTests/New/Connection State Machine/AuthenticationStateMachineTests.swift
@@ -69,7 +69,7 @@ class AuthenticationStateMachineTests: XCTestCase {
     // MARK: Test unsupported messages
     
     func testUnsupportedAuthMechanism() {
-        let unsupported: [(PostgresBackendMessage.Authentication, PSQLAuthScheme)] = [
+        let unsupported: [(PostgresBackendMessage.Authentication, PSQLError.UnsupportedAuthScheme)] = [
             (.kerberosV5, .kerberosV5),
             (.scmCredential, .scmCredential),
             (.gss, .gss),

--- a/Tests/PostgresNIOTests/New/Connection State Machine/ConnectionStateMachineTests.swift
+++ b/Tests/PostgresNIOTests/New/Connection State Machine/ConnectionStateMachineTests.swift
@@ -132,7 +132,7 @@ class ConnectionStateMachineTests: XCTestCase {
         // test ignore unclean shutdown when closing connection
         var stateIgnoreChannelError = ConnectionStateMachine(.closing)
         
-        XCTAssertEqual(stateIgnoreChannelError.errorHappened(PSQLError.channel(underlying: NIOSSLError.uncleanShutdown)), .wait)
+        XCTAssertEqual(stateIgnoreChannelError.errorHappened(.connectionError(underlying: NIOSSLError.uncleanShutdown)), .wait)
         XCTAssertEqual(stateIgnoreChannelError.closed(), .fireChannelInactive)
         
         // test ignore any other error when closing connection

--- a/Tests/PostgresNIOTests/New/Messages/BackendKeyDataTests.swift
+++ b/Tests/PostgresNIOTests/New/Messages/BackendKeyDataTests.swift
@@ -33,7 +33,7 @@ class BackendKeyDataTests: XCTestCase {
         XCTAssertThrowsError(try ByteToMessageDecoderVerifier.verifyDecoder(
             inputOutputPairs: expected,
             decoderFactory: { PostgresBackendMessageDecoder(hasAlreadyReceivedBytes: false) })) {
-            XCTAssert($0 is PSQLDecodingError)
+            XCTAssert($0 is PostgresMessageDecodingError)
         }
     }
 }

--- a/Tests/PostgresNIOTests/New/Messages/NotificationResponseTests.swift
+++ b/Tests/PostgresNIOTests/New/Messages/NotificationResponseTests.swift
@@ -41,7 +41,7 @@ class NotificationResponseTests: XCTestCase {
         XCTAssertThrowsError(try ByteToMessageDecoderVerifier.verifyDecoder(
             inputOutputPairs: [(buffer, [])],
             decoderFactory: { PostgresBackendMessageDecoder(hasAlreadyReceivedBytes: true) })) {
-            XCTAssert($0 is PSQLDecodingError)
+            XCTAssert($0 is PostgresMessageDecodingError)
         }
     }
     
@@ -56,7 +56,7 @@ class NotificationResponseTests: XCTestCase {
         XCTAssertThrowsError(try ByteToMessageDecoderVerifier.verifyDecoder(
             inputOutputPairs: [(buffer, [])],
             decoderFactory: { PostgresBackendMessageDecoder(hasAlreadyReceivedBytes: true) })) {
-            XCTAssert($0 is PSQLDecodingError)
+            XCTAssert($0 is PostgresMessageDecodingError)
         }
     }
 }

--- a/Tests/PostgresNIOTests/New/Messages/ParameterDescriptionTests.swift
+++ b/Tests/PostgresNIOTests/New/Messages/ParameterDescriptionTests.swift
@@ -44,7 +44,7 @@ class ParameterDescriptionTests: XCTestCase {
         XCTAssertThrowsError(try ByteToMessageDecoderVerifier.verifyDecoder(
             inputOutputPairs: [(buffer, [])],
             decoderFactory: { PostgresBackendMessageDecoder(hasAlreadyReceivedBytes: true) })) {
-            XCTAssert($0 is PSQLDecodingError)
+            XCTAssert($0 is PostgresMessageDecodingError)
         }
     }
     
@@ -63,7 +63,7 @@ class ParameterDescriptionTests: XCTestCase {
         XCTAssertThrowsError(try ByteToMessageDecoderVerifier.verifyDecoder(
             inputOutputPairs: [(buffer, [])],
             decoderFactory: { PostgresBackendMessageDecoder(hasAlreadyReceivedBytes: true) })) {
-            XCTAssert($0 is PSQLDecodingError)
+            XCTAssert($0 is PostgresMessageDecodingError)
         }
     }
 }

--- a/Tests/PostgresNIOTests/New/Messages/ParameterStatusTests.swift
+++ b/Tests/PostgresNIOTests/New/Messages/ParameterStatusTests.swift
@@ -55,7 +55,7 @@ class ParameterStatusTests: XCTestCase {
         XCTAssertThrowsError(try ByteToMessageDecoderVerifier.verifyDecoder(
             inputOutputPairs: [(buffer, [])],
             decoderFactory: { PostgresBackendMessageDecoder(hasAlreadyReceivedBytes: true) })) {
-            XCTAssert($0 is PSQLDecodingError)
+            XCTAssert($0 is PostgresMessageDecodingError)
         }
     }
     
@@ -69,7 +69,7 @@ class ParameterStatusTests: XCTestCase {
         XCTAssertThrowsError(try ByteToMessageDecoderVerifier.verifyDecoder(
             inputOutputPairs: [(buffer, [])],
             decoderFactory: { PostgresBackendMessageDecoder(hasAlreadyReceivedBytes: true) })) {
-            XCTAssert($0 is PSQLDecodingError)
+            XCTAssert($0 is PostgresMessageDecodingError)
         }
     }
 }

--- a/Tests/PostgresNIOTests/New/Messages/ReadyForQueryTests.swift
+++ b/Tests/PostgresNIOTests/New/Messages/ReadyForQueryTests.swift
@@ -48,7 +48,7 @@ class ReadyForQueryTests: XCTestCase {
         XCTAssertThrowsError(try ByteToMessageDecoderVerifier.verifyDecoder(
             inputOutputPairs: [(buffer, [])],
             decoderFactory: { PostgresBackendMessageDecoder(hasAlreadyReceivedBytes: true) })) {
-            XCTAssert($0 is PSQLDecodingError)
+            XCTAssert($0 is PostgresMessageDecodingError)
         }
     }
     
@@ -62,7 +62,7 @@ class ReadyForQueryTests: XCTestCase {
         XCTAssertThrowsError(try ByteToMessageDecoderVerifier.verifyDecoder(
             inputOutputPairs: [(buffer, [])],
             decoderFactory: { PostgresBackendMessageDecoder(hasAlreadyReceivedBytes: true) })) {
-            XCTAssert($0 is PSQLDecodingError)
+            XCTAssert($0 is PostgresMessageDecodingError)
         }
     }
     

--- a/Tests/PostgresNIOTests/New/Messages/RowDescriptionTests.swift
+++ b/Tests/PostgresNIOTests/New/Messages/RowDescriptionTests.swift
@@ -60,7 +60,7 @@ class RowDescriptionTests: XCTestCase {
         XCTAssertThrowsError(try ByteToMessageDecoderVerifier.verifyDecoder(
             inputOutputPairs: [(buffer, [])],
             decoderFactory: { PostgresBackendMessageDecoder(hasAlreadyReceivedBytes: true) })) {
-            XCTAssert($0 is PSQLDecodingError)
+            XCTAssert($0 is PostgresMessageDecodingError)
         }
     }
     
@@ -82,7 +82,7 @@ class RowDescriptionTests: XCTestCase {
         XCTAssertThrowsError(try ByteToMessageDecoderVerifier.verifyDecoder(
             inputOutputPairs: [(buffer, [])],
             decoderFactory: { PostgresBackendMessageDecoder(hasAlreadyReceivedBytes: true) })) {
-            XCTAssert($0 is PSQLDecodingError)
+            XCTAssert($0 is PostgresMessageDecodingError)
         }
     }
     
@@ -105,7 +105,7 @@ class RowDescriptionTests: XCTestCase {
         XCTAssertThrowsError(try ByteToMessageDecoderVerifier.verifyDecoder(
             inputOutputPairs: [(buffer, [])],
             decoderFactory: { PostgresBackendMessageDecoder(hasAlreadyReceivedBytes: true) })) {
-            XCTAssert($0 is PSQLDecodingError)
+            XCTAssert($0 is PostgresMessageDecodingError)
         }
     }
     
@@ -128,7 +128,7 @@ class RowDescriptionTests: XCTestCase {
         XCTAssertThrowsError(try ByteToMessageDecoderVerifier.verifyDecoder(
             inputOutputPairs: [(buffer, [])],
             decoderFactory: { PostgresBackendMessageDecoder(hasAlreadyReceivedBytes: true) })) {
-            XCTAssert($0 is PSQLDecodingError)
+            XCTAssert($0 is PostgresMessageDecodingError)
         }
     }
 

--- a/Tests/PostgresNIOTests/New/PSQLBackendMessageTests.swift
+++ b/Tests/PostgresNIOTests/New/PSQLBackendMessageTests.swift
@@ -196,7 +196,7 @@ class PSQLBackendMessageTests: XCTestCase {
             XCTAssertThrowsError(try ByteToMessageDecoderVerifier.verifyDecoder(
                 inputOutputPairs: [(buffer, [])],
                 decoderFactory: { PostgresBackendMessageDecoder(hasAlreadyReceivedBytes: false) })) {
-                XCTAssert($0 is PSQLDecodingError)
+                XCTAssert($0 is PostgresMessageDecodingError)
             }
         }
     }
@@ -238,7 +238,7 @@ class PSQLBackendMessageTests: XCTestCase {
             XCTAssertThrowsError(try ByteToMessageDecoderVerifier.verifyDecoder(
                 inputOutputPairs: [(failBuffer, [])],
                 decoderFactory: { PostgresBackendMessageDecoder(hasAlreadyReceivedBytes: false) })) {
-                XCTAssert($0 is PSQLDecodingError)
+                XCTAssert($0 is PostgresMessageDecodingError)
             }
         }
     }
@@ -251,7 +251,7 @@ class PSQLBackendMessageTests: XCTestCase {
         XCTAssertThrowsError(try ByteToMessageDecoderVerifier.verifyDecoder(
             inputOutputPairs: [(buffer, [])],
             decoderFactory: { PostgresBackendMessageDecoder(hasAlreadyReceivedBytes: false) })) {
-            XCTAssert($0 is PSQLDecodingError)
+            XCTAssert($0 is PostgresMessageDecodingError)
         }
     }
     


### PR DESCRIPTION
### Motivation

Users want to inspect what has gone wrong. For this they need access to the error type that we throw.

### Changes

- Rewrite `PSQLError` to ensure it is a type that we can evolve in public
  - For this to work we shouldn't use associated types on the code enum
- Merge `channel` and `connectionError` code into one
- Rename `PSQLDecodingError` to `PostgresMessageDecodingError` to ensure a clear distinction to `PostgresDecodingError`
- `PSQLError` is now a CoW type
- Attach the query, if we have one to the PSQLError to make debugging easier

### Result

- Better debuggable errors.