### PR TITLE
Require new swift-nio versions

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,13 +13,13 @@ let package = Package(
         .library(name: "PostgresNIO", targets: ["PostgresNIO"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-atomics.git", from: "1.0.2"),
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.44.0"),
-        .package(url: "https://github.com/apple/swift-nio-transport-services.git", from: "1.13.1"),
-        .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.22.1"),
+        .package(url: "https://github.com/apple/swift-atomics.git", from: "1.1.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.50.0"),
+        .package(url: "https://github.com/apple/swift-nio-transport-services.git", from: "1.16.0"),
+        .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.23.1"),
         .package(url: "https://github.com/apple/swift-crypto.git", "1.0.0" ..< "3.0.0"),
         .package(url: "https://github.com/apple/swift-metrics.git", from: "2.0.0"),
-        .package(url: "https://github.com/apple/swift-log.git", from: "1.4.4"),
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.5.2"),
     ],
     targets: [
         .target(name: "PostgresNIO", dependencies: [

--- a/Sources/PostgresNIO/New/Data/UUID+PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/Data/UUID+PostgresCodable.swift
@@ -1,6 +1,7 @@
 import NIOCore
 import struct Foundation.UUID
 import typealias Foundation.uuid_t
+import NIOFoundationCompat
 
 extension UUID: PostgresNonThrowingEncodable {
     public static var psqlType: PostgresDataType {

--- a/Sources/PostgresNIO/New/PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/PostgresCodable.swift
@@ -1,5 +1,6 @@
 import NIOCore
-import Foundation
+import class Foundation.JSONEncoder
+import class Foundation.JSONDecoder
 
 /// A type that can encode itself to a postgres wire binary representation.
 public protocol PostgresEncodable {

--- a/Tests/PostgresNIOTests/New/PostgresQueryTests.swift
+++ b/Tests/PostgresNIOTests/New/PostgresQueryTests.swift
@@ -9,7 +9,7 @@ final class PostgresQueryTests: XCTestCase {
         let null: UUID? = nil
         let uuid: UUID? = UUID()
 
-        var query: PostgresQuery = """
+        let query: PostgresQuery = """
             INSERT INTO foo (id, title, something) SET (\(uuid), \(string), \(null));
             """
 


### PR DESCRIPTION
New NIO versions enforce Sendability. We want to always pick those up. Also this fixes another import warning.