### PR TITLE
Add PostgresRow decoding tests, reformat Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,27 +22,36 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-log.git", from: "1.5.2"),
     ],
     targets: [
-        .target(name: "PostgresNIO", dependencies: [
-            .product(name: "Atomics", package: "swift-atomics"),
-            .product(name: "Crypto", package: "swift-crypto"),
-            .product(name: "Logging", package: "swift-log"),
-            .product(name: "Metrics", package: "swift-metrics"),
-            .product(name: "NIO", package: "swift-nio"),
-            .product(name: "NIOCore", package: "swift-nio"),
-            .product(name: "NIOPosix", package: "swift-nio"),
-            .product(name: "NIOTransportServices", package: "swift-nio-transport-services"),
-            .product(name: "NIOTLS", package: "swift-nio"),
-            .product(name: "NIOSSL", package: "swift-nio-ssl"),
-            .product(name: "NIOFoundationCompat", package: "swift-nio"),
-        ]),
-        .testTarget(name: "PostgresNIOTests", dependencies: [
-            .target(name: "PostgresNIO"),
-            .product(name: "NIOEmbedded", package: "swift-nio"),
-            .product(name: "NIOTestUtils", package: "swift-nio"),
-        ]),
-        .testTarget(name: "IntegrationTests", dependencies: [
-            .target(name: "PostgresNIO"),
-            .product(name: "NIOTestUtils", package: "swift-nio"),
-        ]),
+        .target(
+            name: "PostgresNIO",
+            dependencies: [
+                .product(name: "Atomics", package: "swift-atomics"),
+                .product(name: "Crypto", package: "swift-crypto"),
+                .product(name: "Logging", package: "swift-log"),
+                .product(name: "Metrics", package: "swift-metrics"),
+                .product(name: "NIO", package: "swift-nio"),
+                .product(name: "NIOCore", package: "swift-nio"),
+                .product(name: "NIOPosix", package: "swift-nio"),
+                .product(name: "NIOTransportServices", package: "swift-nio-transport-services"),
+                .product(name: "NIOTLS", package: "swift-nio"),
+                .product(name: "NIOSSL", package: "swift-nio-ssl"),
+                .product(name: "NIOFoundationCompat", package: "swift-nio"),
+            ]
+        ),
+        .testTarget(
+            name: "PostgresNIOTests",
+            dependencies: [
+                .target(name: "PostgresNIO"),
+                .product(name: "NIOEmbedded", package: "swift-nio"),
+                .product(name: "NIOTestUtils", package: "swift-nio"),
+            ]
+        ),
+        .testTarget(
+            name: "IntegrationTests",
+            dependencies: [
+                .target(name: "PostgresNIO"),
+                .product(name: "NIOTestUtils", package: "swift-nio"),
+            ]
+        ),
     ]
 )

--- a/Tests/PostgresNIOTests/New/PostgresRowTests.swift
+++ b/Tests/PostgresNIOTests/New/PostgresRowTests.swift
@@ -122,4 +122,80 @@ final class PostgresRowTests: XCTestCase {
         XCTAssertEqual(randomAccessRow["id"], PostgresCell(bytes: nil, dataType: .uuid, format: .binary, columnName: "id", columnIndex: 0))
         XCTAssertEqual(randomAccessRow["name"], PostgresCell(bytes: ByteBuffer(string: "Hello world!"), dataType: .text, format: .binary, columnName: "name", columnIndex: 1))
     }
+
+    func testDecoding() {
+        let rowDescription = [
+            RowDescription.Column(
+                name: "id",
+                tableOID: 1,
+                columnAttributeNumber: 1,
+                dataType: .uuid,
+                dataTypeSize: 0,
+                dataTypeModifier: 0,
+                format: .binary
+            ),
+            RowDescription.Column(
+                name: "name",
+                tableOID: 1,
+                columnAttributeNumber: 1,
+                dataType: .text,
+                dataTypeSize: 0,
+                dataTypeModifier: 0,
+                format: .binary
+            )
+        ]
+
+        let row = PostgresRow(
+            data: .makeTestDataRow(nil, ByteBuffer(string: "Hello world!")),
+            lookupTable: ["id": 0, "name": 1],
+            columns: rowDescription
+        )
+
+        var result: (UUID?, String)?
+        XCTAssertNoThrow(result = try row.decode((UUID?, String).self))
+        XCTAssertEqual(result?.0, .some(.none))
+        XCTAssertEqual(result?.1, "Hello world!")
+    }
+
+    func testDecodingTypeMismatch() {
+        let rowDescription = [
+            RowDescription.Column(
+                name: "id",
+                tableOID: 1,
+                columnAttributeNumber: 1,
+                dataType: .uuid,
+                dataTypeSize: 0,
+                dataTypeModifier: 0,
+                format: .binary
+            ),
+            RowDescription.Column(
+                name: "name",
+                tableOID: 1,
+                columnAttributeNumber: 1,
+                dataType: .int8,
+                dataTypeSize: 0,
+                dataTypeModifier: 0,
+                format: .binary
+            )
+        ]
+
+        let row = PostgresRow(
+            data: .makeTestDataRow(nil, ByteBuffer(integer: 123)),
+            lookupTable: ["id": 0, "name": 1],
+            columns: rowDescription
+        )
+
+        XCTAssertThrowsError(try row.decode((UUID?, String).self)) { error in
+            guard let psqlError = error as? PostgresDecodingError else { return XCTFail("Unexpected error type") }
+
+            XCTAssertEqual(psqlError.columnName, "name")
+            XCTAssertEqual(psqlError.columnIndex, 1)
+            XCTAssertEqual(psqlError.line, #line - 5)
+            XCTAssertEqual(psqlError.file, #file)
+            XCTAssertEqual(psqlError.postgresData, ByteBuffer(integer: 123))
+            XCTAssertEqual(psqlError.postgresFormat, .binary)
+            XCTAssertEqual(psqlError.postgresType, .int8)
+            XCTAssert(psqlError.targetType == String.self)
+        }
+    }
 }


### PR DESCRIPTION
- Reformat Package.swift so that it is easier to add further properties on the targets
- Cherry pick two `PostgresRow` decoding tests from #341 