### PR TITLE
Fixes crash in queries that timeout

### DIFF
--- a/Sources/PostgresNIO/New/PostgresChannelHandler.swift
+++ b/Sources/PostgresNIO/New/PostgresChannelHandler.swift
@@ -273,8 +273,9 @@ final class PostgresChannelHandler: ChannelDuplexHandler {
             
             
         case .forwardStreamError(let error, let read, let cleanupContext):
-            self.rowStream!.receive(completion: .failure(error))
+            let rowStream = self.rowStream!
             self.rowStream = nil
+            rowStream.receive(completion: .failure(error))
             if let cleanupContext = cleanupContext {
                 self.closeConnectionAndCleanup(cleanupContext, context: context)
             } else if read {


### PR DESCRIPTION
Fixes #347.

In an ideal case I add a unit test for this as well, but sadly this is rather involved.

cc @trasch.