### PR TITLE
Various cleanups to CI

### DIFF
--- a/.github/workflows/projectboard.yml
+++ b/.github/workflows/projectboard.yml
@@ -5,27 +5,8 @@ on:
     types: [reopened, closed, labeled, unlabeled, assigned, unassigned]
 
 jobs:
-  setup_matrix_input:
-    runs-on: ubuntu-latest
-
-    steps:
-      - id: set-matrix 
-        run: |
-          output=$(curl ${{ github.event.issue.url }}/labels | jq '.[] | .name')
-
-          echo '======================'
-          echo 'Process incoming data'
-          echo '======================'
-          json=$(echo $output | sed 's/"\s"/","/g')
-          echo $json
-          echo "::set-output name=matrix::$(echo $json)"
-    outputs:
-      issueTags: ${{ steps.set-matrix.outputs.matrix }}
-      
-  Manage_project_issues:
-    needs: setup_matrix_input
-    uses: vapor/ci/.github/workflows/issues-to-project-board.yml@main
+  manage_project_issues:
+    uses: vapor/ci/.github/workflows/issues-to-project-board.yml@reusable-workflows
     with:
-      labelsJson: ${{ needs.setup_matrix_input.outputs.issueTags }}
-    secrets: 
-      PROJECT_BOARD_AUTOMATION_PAT: "${{ secrets.PROJECT_BOARD_AUTOMATION_PAT }}"
+      labelsJson: ${{ toJSON(github.event.issue.labels.*.name || []) }}
+    secrets: inherit

--- a/.github/workflows/projectboard.yml
+++ b/.github/workflows/projectboard.yml
@@ -5,8 +5,7 @@ on:
     types: [reopened, closed, labeled, unlabeled, assigned, unassigned]
 
 jobs:
-  manage_project_issues:
-    uses: vapor/ci/.github/workflows/issues-to-project-board.yml@reusable-workflows
-    with:
-      labelsJson: ${{ toJSON(github.event.issue.labels.*.name || []) }}
+  update_project_boards:
+    name: Update project boards
+    uses: vapor/ci/.github/workflows/update-project-boards-for-issue.yml@reusable-workflows
     secrets: inherit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,9 +26,6 @@ jobs:
           # https://github.com/apple/swift-package-manager/issues/5853
           - container: swift:5.8-jammy
             coverage: false
-          # https://github.com/apple/swift/issues/65064
-          - container: swiftlang/swift:nightly-main-jammy
-            coverage: false
     container: ${{ matrix.container }}
     runs-on: ubuntu-latest
     env:
@@ -181,15 +178,3 @@ jobs:
       run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
     - name: API breaking changes
       run: swift package diagnose-api-breaking-changes origin/main
-
-  test-exports:
-    name: Test exports
-    runs-on: ubuntu-latest
-    container: swift:5.8-jammy
-    steps:
-      - name: Check out package
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - name: Build
-        run: swift build -Xswiftc -DBUILDING_DOCC

--- a/Sources/PostgresNIO/Utilities/Exports.swift
+++ b/Sources/PostgresNIO/Utilities/Exports.swift
@@ -4,7 +4,7 @@
 @_documentation(visibility: internal) @_exported import NIOSSL
 @_documentation(visibility: internal) @_exported import struct Logging.Logger
 
-#elseif !BUILDING_DOCC
+#else
 
 // TODO: Remove this with the next major release!
 @_exported import NIO


### PR DESCRIPTION
- Don't need the BUILDING_DOCC hack (and thus the extra exports check CI job) anymore.
- MASSIVELY simplify the `projectboard` workflow.
- Reenable CI coverage for the main nightly snapshot since the bug that was crashing the compiler's been fixed.
