### PR TITLE
Make PostgresCodable typealias public

### DIFF
--- a/Sources/PostgresNIO/New/PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/PostgresCodable.swift
@@ -81,7 +81,7 @@ extension PostgresDecodable {
 }
 
 /// A type that can be encoded into and decoded from a postgres binary format
-typealias PostgresCodable = PostgresEncodable & PostgresDecodable
+public typealias PostgresCodable = PostgresEncodable & PostgresDecodable
 
 extension PostgresEncodable {
     @inlinable


### PR DESCRIPTION
If only for the sake of symmetry with `any Codable` (aka `any (Encodable & Decodable)`), `PostgresCodable` should be public alongside `PostgresEncodable` and `PostgresDecodable`.