### PR TITLE
Decode `.bpchar` as `String`

### DIFF
--- a/Sources/PostgresNIO/New/Data/String+PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/Data/String+PostgresCodable.swift
@@ -30,6 +30,7 @@ extension String: PostgresDecodable {
     ) throws {
         switch (format, type) {
         case (_, .varchar),
+             (_, .bpchar),
              (_, .text),
              (_, .name):
             // we can force unwrap here, since this method only fails if there are not enough

--- a/Tests/PostgresNIOTests/New/Data/String+PSQLCodableTests.swift
+++ b/Tests/PostgresNIOTests/New/Data/String+PSQLCodableTests.swift
@@ -20,7 +20,7 @@ class String_PSQLCodableTests: XCTestCase {
         buffer.writeString(expected)
 
         let dataTypes: [PostgresDataType] = [
-            .text, .varchar, .name
+            .text, .varchar, .name, .bpchar
         ]
 
         for dataType in dataTypes {
@@ -33,7 +33,7 @@ class String_PSQLCodableTests: XCTestCase {
 
     func testDecodeFailureFromInvalidType() {
         let buffer = ByteBuffer()
-        let dataTypes: [PostgresDataType] = [.bool, .float4Array, .float8Array, .bpchar]
+        let dataTypes: [PostgresDataType] = [.bool, .float4Array, .float8Array]
 
         for dataType in dataTypes {
             var loopBuffer = buffer


### PR DESCRIPTION
`bpchar` is "blank-padded char", the low-level Postgres name for `character(N)` (the auto-padded form of `character varying`). `String`'s `PostgresCodable` conformance should thus recognize it as a valid representation.