### PR TITLE
Use computed property to PostgresConnection.Configuration.TLS.disable for concurrency safe

### DIFF
--- a/Sources/PostgresNIO/Connection/PostgresConnection+Configuration.swift
+++ b/Sources/PostgresNIO/Connection/PostgresConnection+Configuration.swift
@@ -13,7 +13,7 @@ extension PostgresConnection {
             // MARK: Initializers
             
             /// Do not try to create a TLS connection to the server.
-            public static let disable: Self = .init(base: .disable)
+            public static var disable: Self { .init(base: .disable) }
 
             /// Try to create a TLS connection to the server. If the server supports TLS, create a TLS connection.
             /// If the server does not support TLS, create an insecure connection.

--- a/Sources/PostgresNIO/Connection/PostgresConnection+Configuration.swift
+++ b/Sources/PostgresNIO/Connection/PostgresConnection+Configuration.swift
@@ -13,7 +13,7 @@ extension PostgresConnection {
             // MARK: Initializers
             
             /// Do not try to create a TLS connection to the server.
-            public static var disable: Self = .init(base: .disable)
+            public static let disable: Self = .init(base: .disable)
 
             /// Try to create a TLS connection to the server. If the server supports TLS, create a TLS connection.
             /// If the server does not support TLS, create an insecure connection.


### PR DESCRIPTION
`PostgresConnection.Configuration.TLS.disable` is declared as `var` but it causes compiler warning on strict concurrency checking.

![cocurrency error](https://github.com/vapor/postgres-nio/assets/19257572/ab3b909d-7633-43ab-a019-5b2ed83e90f9)


This value seems to not to be modified in runtime.
So this should be changed to `let`.