### PR TITLE
Add support for decimal types other than Foundation.Decimal

### DIFF
--- a/Sources/PostgresNIO/Data/PostgresData+Decimal.swift
+++ b/Sources/PostgresNIO/Data/PostgresData+Decimal.swift
@@ -30,6 +30,6 @@ extension Decimal: PostgresDataConvertible {
     }
 
     public var postgresData: PostgresData? {
-        return .init(numeric: PostgresNumeric(decimal: self))
+        return .init(numeric: PostgresNumeric(decimalString: self.description))
     }
 }

--- a/Sources/PostgresNIO/Data/PostgresData+Numeric.swift
+++ b/Sources/PostgresNIO/Data/PostgresData+Numeric.swift
@@ -1,5 +1,4 @@
 import NIOCore
-import struct Foundation.Decimal
 
 public struct PostgresNumeric: CustomStringConvertible, CustomDebugStringConvertible, ExpressibleByStringLiteral {
     /// The number of digits after this metadata
@@ -37,12 +36,10 @@ public struct PostgresNumeric: CustomStringConvertible, CustomDebugStringConvert
         return Double(self.string)
     }
     
-    public init(decimal: Decimal) {
-        self.init(decimalString: decimal.description)
-    }
-    
     public init?(string: String) {
         // validate string contents are decimal
+        // TODO: this won't work for all Big decimals
+        // TODO: how does this handle Nan and Infinity
         guard Double(string) != nil else {
             return nil
         }
@@ -116,12 +113,6 @@ public struct PostgresNumeric: CustomStringConvertible, CustomDebugStringConvert
         self.sign = isNegative ? 0x4000 : 0
         self.dscale = numericCast(dscale)
         self.value = buffer
-    }
-    
-    public var decimal: Decimal {
-        // force cast should always succeed since we know
-        // string returns a valid decimal
-        return Decimal(string: self.string)!
     }
 
     public var string: String {

--- a/Sources/PostgresNIO/Data/PostgresData+Numeric.swift
+++ b/Sources/PostgresNIO/Data/PostgresData+Numeric.swift
@@ -37,7 +37,6 @@ public struct PostgresNumeric: CustomStringConvertible, CustomDebugStringConvert
         return Double(self.string)
     }
     
-    
     public init(decimal: Decimal) {
         self.init(decimalString: decimal.description)
     }

--- a/Sources/PostgresNIO/Data/PostgresData+Numeric.swift
+++ b/Sources/PostgresNIO/Data/PostgresData+Numeric.swift
@@ -1,4 +1,5 @@
 import NIOCore
+import Foundation.Decimal
 
 public struct PostgresNumeric: CustomStringConvertible, CustomDebugStringConvertible, ExpressibleByStringLiteral {
     /// The number of digits after this metadata
@@ -36,6 +37,11 @@ public struct PostgresNumeric: CustomStringConvertible, CustomDebugStringConvert
         return Double(self.string)
     }
     
+    
+    public init(decimal: Decimal) {
+        self.init(decimalString: decimal.description)
+    }
+
     public init?(string: String) {
         // validate string contents are decimal
         // TODO: this won't work for all Big decimals
@@ -113,6 +119,13 @@ public struct PostgresNumeric: CustomStringConvertible, CustomDebugStringConvert
         self.sign = isNegative ? 0x4000 : 0
         self.dscale = numericCast(dscale)
         self.value = buffer
+    }
+
+    
+    public var decimal: Decimal {
+        // force cast should always succeed since we know
+        // string returns a valid decimal
+        return Decimal(string: self.string)!
     }
 
     public var string: String {

--- a/Sources/PostgresNIO/Data/PostgresData+Numeric.swift
+++ b/Sources/PostgresNIO/Data/PostgresData+Numeric.swift
@@ -1,5 +1,5 @@
 import NIOCore
-import Foundation.Decimal
+import struct Foundation.Decimal
 
 public struct PostgresNumeric: CustomStringConvertible, CustomDebugStringConvertible, ExpressibleByStringLiteral {
     /// The number of digits after this metadata

--- a/Sources/PostgresNIO/New/Data/Decimal+PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/Data/Decimal+PostgresCodable.swift
@@ -1,49 +1,7 @@
-import NIOCore
 import struct Foundation.Decimal
 
-extension Decimal: PostgresEncodable {
-    public static var psqlType: PostgresDataType {
-        .numeric
-    }
-
-    public static var psqlFormat: PostgresFormat {
-        .binary
-    }
-
-    public func encode<JSONEncoder: PostgresJSONEncoder>(
-        into byteBuffer: inout ByteBuffer,
-        context: PostgresEncodingContext<JSONEncoder>
-    ) {
-        let numeric = PostgresNumeric(decimal: self)
-        byteBuffer.writeInteger(numeric.ndigits)
-        byteBuffer.writeInteger(numeric.weight)
-        byteBuffer.writeInteger(numeric.sign)
-        byteBuffer.writeInteger(numeric.dscale)
-        var value = numeric.value
-        byteBuffer.writeBuffer(&value)
-    }
-}
-
-extension Decimal: PostgresDecodable {
-    public init<JSONDecoder: PostgresJSONDecoder>(
-        from buffer: inout ByteBuffer,
-        type: PostgresDataType,
-        format: PostgresFormat,
-        context: PostgresDecodingContext<JSONDecoder>
-    ) throws {
-        switch (format, type) {
-        case (.binary, .numeric):
-            guard let numeric = PostgresNumeric(buffer: &buffer) else {
-                throw PostgresDecodingError.Code.failure
-            }
-            self = numeric.decimal
-        case (.text, .numeric):
-            guard let string = buffer.readString(length: buffer.readableBytes), let value = Decimal(string: string) else {
-                throw PostgresDecodingError.Code.failure
-            }
-            self = value
-        default:
-            throw PostgresDecodingError.Code.typeMismatch
-        }
+extension Decimal: ExpressibleByPostgresFloatingPointString {
+    public init?(floatingPointString: String) {
+        self.init(string: floatingPointString)
     }
 }

--- a/Sources/PostgresNIO/New/Data/ExpressibleByPostgresFloatingPointString.swift
+++ b/Sources/PostgresNIO/New/Data/ExpressibleByPostgresFloatingPointString.swift
@@ -1,0 +1,59 @@
+import NIOCore
+
+
+/// This protocol allows using various implementations of a Decimal type for Postgres NUMERIC type
+public protocol ExpressibleByPostgresFloatingPointString: PostgresEncodable, PostgresDecodable {
+    static var psqlType: PostgresDataType { get }
+    static var psqlFormat: PostgresFormat { get }
+    
+    init?(floatingPointString: String)
+    var description: String { get }
+}
+
+extension ExpressibleByPostgresFloatingPointString {
+    public static var psqlType: PostgresDataType {
+        .numeric
+    }
+
+    public static var psqlFormat: PostgresFormat {
+        .binary
+    }
+
+    // PostgresEncodable conformance
+    public func encode<JSONEncoder: PostgresJSONEncoder>(
+        into byteBuffer: inout ByteBuffer,
+        context: PostgresEncodingContext<JSONEncoder>
+    ) {
+        let numeric = PostgresNumeric(decimalString: self.description)
+        byteBuffer.writeInteger(numeric.ndigits)
+        byteBuffer.writeInteger(numeric.weight)
+        byteBuffer.writeInteger(numeric.sign)
+        byteBuffer.writeInteger(numeric.dscale)
+        var value = numeric.value
+        byteBuffer.writeBuffer(&value)
+    }
+
+    // PostgresDecodable conformance
+    public init<JSONDecoder: PostgresJSONDecoder>(
+        from buffer: inout ByteBuffer,
+        type: PostgresDataType,
+        format: PostgresFormat,
+        context: PostgresDecodingContext<JSONDecoder>
+    ) throws {
+        switch (format, type) {
+        case (.binary, .numeric):
+            guard let numeric = PostgresNumeric(buffer: &buffer) else {
+                throw PostgresDecodingError.Code.failure
+            }
+            // numeric.string is valid decimal representation
+            self = Self(floatingPointString: numeric.string)!
+        case (.text, .numeric):
+            guard let string = buffer.readString(length: buffer.readableBytes), let value = Self(floatingPointString: string) else {
+                throw PostgresDecodingError.Code.failure
+            }
+            self = value
+        default:
+            throw PostgresDecodingError.Code.typeMismatch
+        }
+    }
+}


### PR DESCRIPTION
Currently, the only numerical option for an exact representation of the Postgres NUMERIC type is to use `Foundation.Decimal`. However, `Foundation.Decimal` is not fully implemented, and in particular is missing some useful conformances such as `LosslessStringConvertible` or `FloatingPoint`. The current implementation makes it complex to use other Decimal implementations to map to the NUMERIC type.

This PR aims to provide a new protocol `ExpressibleByFloatingPointString`, to which `Foundation.Decimal` can trivially conform, and at the same time allow to easily make other Decimal types conform to (*), and be used as mapping to the Postgres NUMERIC type.

```swift
extension Decimal: ExpressibleByPostgresFloatingPointString {
    public init?(floatingPointString: String) {
        self.init(string: floatingPointString)
    }
}
```

The change aims to make no changes to the API. It has been tested with the Test suite from postgres-nio and that of postgres-kit as well as from use in a higher level Vapor app.

--
(*) for example `BigDecimal` from https://github.com/mgriebling/BigDecimal.git

```swift
import PostgresNIO
import BigDecimal

extension BigDecimal: ExpressibleByPostgresFloatingPointString {
    public init?(floatingPointString: String) {
        self.init(floatingPointString)
    } 
}
```