### PR TITLE
async/await prepared statement API

### DIFF
--- a/Sources/PostgresNIO/Connection/PostgresConnection.swift
+++ b/Sources/PostgresNIO/Connection/PostgresConnection.swift
@@ -468,7 +468,7 @@ extension PostgresConnection {
         file: String = #fileID,
         line: Int = #line
     ) async throws -> AsyncThrowingMapSequence<PostgresRowSequence, Statement.Row> {
-        let bindings = preparedStatement.makeBindings()
+        let bindings = try preparedStatement.makeBindings()
         let promise = self.channel.eventLoop.makePromise(of: PSQLRowStream.self)
         let task = HandlerTask.executePreparedStatement(.init(
             name: String(reflecting: Statement.self),
@@ -502,7 +502,7 @@ extension PostgresConnection {
         file: String = #fileID,
         line: Int = #line
     ) async throws -> String where Statement.Row == () {
-        let bindings = preparedStatement.makeBindings()
+        let bindings = try preparedStatement.makeBindings()
         let promise = self.channel.eventLoop.makePromise(of: PSQLRowStream.self)
         let task = HandlerTask.executePreparedStatement(.init(
             name: String(reflecting: Statement.self),

--- a/Sources/PostgresNIO/Connection/PostgresConnection.swift
+++ b/Sources/PostgresNIO/Connection/PostgresConnection.swift
@@ -462,12 +462,13 @@ extension PostgresConnection {
     }
 
     /// Execute a prepared statement, taking care of the preparation when necessary
-    public func execute<Statement: PostgresPreparedStatement>(
+    @inlinable
+    public func execute<Statement: PostgresPreparedStatement, Row>(
         _ preparedStatement: Statement,
         logger: Logger,
         file: String = #fileID,
         line: Int = #line
-    ) async throws -> AsyncThrowingMapSequence<PostgresRowSequence, Statement.Row> {
+    ) async throws -> AsyncThrowingMapSequence<PostgresRowSequence, Row> where Row == Statement.Row {
         let bindings = try preparedStatement.makeBindings()
         let promise = self.channel.eventLoop.makePromise(of: PSQLRowStream.self)
         let task = HandlerTask.executePreparedStatement(.init(
@@ -496,6 +497,7 @@ extension PostgresConnection {
     }
 
     /// Execute a prepared statement, taking care of the preparation when necessary
+    @inlinable
     public func execute<Statement: PostgresPreparedStatement>(
         _ preparedStatement: Statement,
         logger: Logger,
@@ -525,7 +527,6 @@ extension PostgresConnection {
             )
             throw error // rethrow with more metadata
         }
-
     }
 }
 

--- a/Sources/PostgresNIO/Connection/PostgresConnection.swift
+++ b/Sources/PostgresNIO/Connection/PostgresConnection.swift
@@ -464,9 +464,10 @@ extension PostgresConnection {
     /// Execute a prepared statement, taking care of the preparation when necessary
     public func execute<Statement: PostgresPreparedStatement>(
         _ preparedStatement: Statement,
-        logger: Logger
-    ) async throws -> AsyncThrowingMapSequence<PostgresRowSequence, Statement.Row>
-    {
+        logger: Logger,
+        file: String = #fileID,
+        line: Int = #line
+    ) async throws -> AsyncThrowingMapSequence<PostgresRowSequence, Statement.Row> {
         let promise = self.channel.eventLoop.makePromise(of: PSQLRowStream.self)
         let task = HandlerTask.executePreparedStatement(.init(
             name: String(reflecting: Statement.self),
@@ -485,10 +486,10 @@ extension PostgresConnection {
     /// Execute a prepared statement, taking care of the preparation when necessary
     public func execute<Statement: PostgresPreparedStatement>(
         _ preparedStatement: Statement,
-        logger: Logger
-    ) async throws -> String
-    where Statement.Row == ()
-    {
+        logger: Logger,
+        file: String = #fileID,
+        line: Int = #line
+    ) async throws -> String where Statement.Row == () {
         let promise = self.channel.eventLoop.makePromise(of: PSQLRowStream.self)
         let task = HandlerTask.executePreparedStatement(.init(
             name: String(reflecting: Statement.self),

--- a/Sources/PostgresNIO/Connection/PostgresConnection.swift
+++ b/Sources/PostgresNIO/Connection/PostgresConnection.swift
@@ -462,7 +462,6 @@ extension PostgresConnection {
     }
 
     /// Execute a prepared statement, taking care of the preparation when necessary
-    @inlinable
     public func execute<Statement: PostgresPreparedStatement, Row>(
         _ preparedStatement: Statement,
         logger: Logger,
@@ -497,7 +496,6 @@ extension PostgresConnection {
     }
 
     /// Execute a prepared statement, taking care of the preparation when necessary
-    @inlinable
     public func execute<Statement: PostgresPreparedStatement>(
         _ preparedStatement: Statement,
         logger: Logger,

--- a/Sources/PostgresNIO/New/Connection State Machine/PreparedStatementStateMachine.swift
+++ b/Sources/PostgresNIO/New/Connection State Machine/PreparedStatementStateMachine.swift
@@ -49,7 +49,7 @@ struct PreparedStatementStateMachine {
         switch state {
         case .preparing(let statements):
             // When sending the bindings we are going to ask for binary data.
-            if var rowDescription {
+            if var rowDescription = rowDescription {
                 for i in 0..<rowDescription.columns.count {
                     rowDescription.columns[i].format = .binary
                 }

--- a/Sources/PostgresNIO/New/Connection State Machine/PreparedStatementStateMachine.swift
+++ b/Sources/PostgresNIO/New/Connection State Machine/PreparedStatementStateMachine.swift
@@ -1,0 +1,68 @@
+import NIOCore
+
+struct PreparedStatementStateMachine {
+    enum State {
+        case preparing([PreparedStatementContext])
+        case prepared(RowDescription?)
+        case error(PSQLError)
+    }
+    
+    enum Action {
+        case prepareStatement
+        case waitForAlreadyInFlightPreparation
+        case executePendingStatements([PreparedStatementContext], RowDescription?)
+        case returnError([PreparedStatementContext], PSQLError)
+    }
+    
+    var preparedStatements: [String: State]
+    
+    init() {
+        self.preparedStatements = [:]
+    }
+    
+    mutating func lookup(name: String, context: PreparedStatementContext) -> Action {
+        if let state = self.preparedStatements[name] {
+            switch state {
+            case .preparing(var statements):
+                statements.append(context)
+                self.preparedStatements[name] = .preparing(statements)
+                return .waitForAlreadyInFlightPreparation
+            case .prepared(let rowDescription):
+                return .executePendingStatements([context], rowDescription)
+            case .error(let error):
+                return .returnError([context], error)
+            }
+        } else {
+            self.preparedStatements[name] = .preparing([context])
+            return .prepareStatement
+        }
+    }
+    
+    mutating func preparationComplete(
+        name: String,
+        rowDescription: RowDescription?
+    ) -> Action {
+        guard case .preparing(let statements) = self.preparedStatements[name] else {
+            preconditionFailure("Preparation completed for an unexpected statement")
+        }
+        // When sending the bindings we are going to ask for binary data.
+        if var rowDescription {
+            for i in 0..<rowDescription.columns.count {
+                rowDescription.columns[i].format = .binary
+            }
+            self.preparedStatements[name] = .prepared(rowDescription)
+            return .executePendingStatements(statements, rowDescription)
+        } else {
+            self.preparedStatements[name] = .prepared(nil)
+            return .executePendingStatements(statements, nil)
+        }
+    }
+
+    mutating func errorHappened(name: String, error: PSQLError) -> Action {
+        guard case .preparing(let statements) = self.preparedStatements[name] else {
+            preconditionFailure("Preparation completed for an unexpected statement")
+        }
+        self.preparedStatements[name] = .error(error)
+        return .returnError(statements, error)
+    }
+}

--- a/Sources/PostgresNIO/New/PSQLTask.swift
+++ b/Sources/PostgresNIO/New/PSQLTask.swift
@@ -6,6 +6,7 @@ enum HandlerTask {
     case closeCommand(CloseCommandContext)
     case startListening(NotificationListener)
     case cancelListening(String, Int)
+    case executePreparedStatement(PreparedStatementContext)
 }
 
 enum PSQLTask {
@@ -66,6 +67,28 @@ final class ExtendedQueryContext {
     ) {
         self.query = .prepareStatement(name: name, query: query, promise)
         self.logger = logger
+    }
+}
+
+final class PreparedStatementContext{
+    let name: String
+    let sql: String
+    let bindings: PostgresBindings
+    let logger: Logger
+    let promise: EventLoopPromise<PSQLRowStream>
+
+    init(
+        name: String,
+        sql: String,
+        bindings: PostgresBindings,
+        logger: Logger,
+        promise: EventLoopPromise<PSQLRowStream>
+    ) {
+        self.name = name
+        self.sql = sql
+        self.bindings = bindings
+        self.logger = logger
+        self.promise = promise
     }
 }
 

--- a/Sources/PostgresNIO/New/PostgresChannelHandler.swift
+++ b/Sources/PostgresNIO/New/PostgresChannelHandler.swift
@@ -50,8 +50,6 @@ final class PostgresChannelHandler: ChannelDuplexHandler {
     ) {
         self.state = state
         self.eventLoop = eventLoop
-        self.listenState = ListenStateMachine()
-        self.preparedStatementState = PreparedStatementStateMachine()
         self.configuration = configuration
         self.configureSSLCallback = configureSSLCallback
         self.logger = logger
@@ -240,7 +238,7 @@ final class PostgresChannelHandler: ChannelDuplexHandler {
             )
             switch action {
             case .prepareStatement:
-                psqlTask = self.makePrepareStatementAction(
+                psqlTask = self.makePrepareStatementTask(
                     preparedStatement: preparedStatement,
                     context: context
                 )
@@ -249,7 +247,7 @@ final class PostgresChannelHandler: ChannelDuplexHandler {
                 // and will execute the statement as soon as it's prepared
                 return
             case .executeStatement(let rowDescription):
-                psqlTask = self.makeExecutPreparedStatementAction(
+                psqlTask = self. makeExecutePreparedStatementTask(
                     preparedStatement: preparedStatement,
                     rowDescription: rowDescription
                 )
@@ -688,7 +686,7 @@ final class PostgresChannelHandler: ChannelDuplexHandler {
         }
     }
 
-    private func makePrepareStatementAction(
+    private func makePrepareStatementTask(
         preparedStatement: PreparedStatementContext,
         context: ChannelHandlerContext
     ) -> PSQLTask {
@@ -723,7 +721,7 @@ final class PostgresChannelHandler: ChannelDuplexHandler {
         ))
     }
 
-    private func makeExecutPreparedStatementAction(
+    private func makeExecutePreparedStatementTask(
         preparedStatement: PreparedStatementContext,
         rowDescription: RowDescription?
     ) -> PSQLTask {
@@ -731,7 +729,8 @@ final class PostgresChannelHandler: ChannelDuplexHandler {
             executeStatement: .init(
                 name: preparedStatement.name,
                 binds: preparedStatement.bindings,
-                rowDescription: rowDescription),
+                rowDescription: rowDescription
+            ),
             logger: preparedStatement.logger,
             promise: preparedStatement.promise
         ))

--- a/Sources/PostgresNIO/New/PostgresChannelHandler.swift
+++ b/Sources/PostgresNIO/New/PostgresChannelHandler.swift
@@ -247,7 +247,7 @@ final class PostgresChannelHandler: ChannelDuplexHandler {
                 // and will execute the statement as soon as it's prepared
                 return
             case .executeStatement(let rowDescription):
-                psqlTask = self. makeExecutePreparedStatementTask(
+                psqlTask = self.makeExecutePreparedStatementTask(
                     preparedStatement: preparedStatement,
                     rowDescription: rowDescription
                 )

--- a/Sources/PostgresNIO/New/PostgresQuery.swift
+++ b/Sources/PostgresNIO/New/PostgresQuery.swift
@@ -168,12 +168,22 @@ public struct PostgresBindings: Sendable, Hashable {
     }
 
     @inlinable
+    public mutating func append<Value: PostgresEncodable>(_ value: Value) throws {
+        try self.append(value, context: .default)
+    }
+
+    @inlinable
     public mutating func append<Value: PostgresEncodable, JSONEncoder: PostgresJSONEncoder>(
         _ value: Value,
         context: PostgresEncodingContext<JSONEncoder>
     ) throws {
         try value.encodeRaw(into: &self.bytes, context: context)
         self.metadata.append(.init(value: value, protected: true))
+    }
+
+    @inlinable
+    public mutating func append<Value: PostgresNonThrowingEncodable>(_ value: Value) {
+        self.append(value, context: .default)
     }
 
     @inlinable

--- a/Sources/PostgresNIO/New/PreparedStatement.swift
+++ b/Sources/PostgresNIO/New/PreparedStatement.swift
@@ -13,7 +13,7 @@
 ///
 ///     func makeBindings() -> PostgresBindings {
 ///         var bindings = PostgresBindings()
-///         bindings.append(.init(string: self.state))
+///         bindings.append(self.state)
 ///         return bindings
 ///     }
 ///
@@ -33,7 +33,7 @@ public protocol PostgresPreparedStatement: Sendable {
     static var sql: String { get }
 
     /// Make the bindings to provided concrete values to use when executing the prepared SQL statement
-    func makeBindings() -> PostgresBindings
+    func makeBindings() throws -> PostgresBindings
     
     /// Decode a row returned by the database into an instance of `Row`
     func decodeRow(_ row: PostgresRow) throws -> Row

--- a/Sources/PostgresNIO/New/PreparedStatement.swift
+++ b/Sources/PostgresNIO/New/PreparedStatement.swift
@@ -5,7 +5,7 @@
 ///
 /// As an example, consider this struct:
 /// ```swift
-/// struct Example: PreparedStatement {
+/// struct Example: PostgresPreparedStatement {
 ///     static var sql = "SELECT pid, datname FROM pg_stat_activity WHERE state = $1"
 ///     typealias Row = (Int, String)
 ///
@@ -25,7 +25,7 @@
 ///
 /// Structs conforming to this protocol can then be used with `PostgresConnection.execute(_ preparedStatement:, logger:)`,
 /// which will take care of preparing the statement on the server side and executing it.
-public protocol PreparedStatement {
+public protocol PostgresPreparedStatement: Sendable {
     /// The type rows returned by the statement will be decoded into
     associatedtype Row
 

--- a/Sources/PostgresNIO/New/PreparedStatement.swift
+++ b/Sources/PostgresNIO/New/PreparedStatement.swift
@@ -6,7 +6,7 @@
 /// As an example, consider this struct:
 /// ```swift
 /// struct Example: PostgresPreparedStatement {
-///     static var sql = "SELECT pid, datname FROM pg_stat_activity WHERE state = $1"
+///     static let sql = "SELECT pid, datname FROM pg_stat_activity WHERE state = $1"
 ///     typealias Row = (Int, String)
 ///
 ///     var state: String

--- a/Sources/PostgresNIO/New/PreparedStatement.swift
+++ b/Sources/PostgresNIO/New/PreparedStatement.swift
@@ -1,0 +1,40 @@
+/// A prepared statement.
+///
+/// Structs conforming to this protocol will need to provide the SQL statement to
+/// send to the server and a way of creating bindings are decoding the result.
+///
+/// As an example, consider this struct:
+/// ```swift
+/// struct Example: PreparedStatement {
+///     static var sql = "SELECT pid, datname FROM pg_stat_activity WHERE state = $1"
+///     typealias Row = (Int, String)
+///
+///     var state: String
+///
+///     func makeBindings() -> PostgresBindings {
+///         var bindings = PostgresBindings()
+///         bindings.append(.init(string: self.state))
+///         return bindings
+///     }
+///
+///     func decodeRow(_ row: PostgresNIO.PostgresRow) throws -> Row {
+///         try row.decode(Row.self)
+///     }
+/// }
+/// ```
+///
+/// Structs conforming to this protocol can then be used with `PostgresConnection.execute(_ preparedStatement:, logger:)`,
+/// which will take care of preparing the statement on the server side and executing it.
+public protocol PreparedStatement {
+    /// The type rows returned by the statement will be decoded into
+    associatedtype Row
+
+    /// The SQL statement to prepare on the database server.
+    static var sql: String { get }
+
+    /// Make the bindings to provided concrete values to use when executing the prepared SQL statement
+    func makeBindings() -> PostgresBindings
+    
+    /// Decode a row returned by the database into an instance of `Row`
+    func decodeRow(_ row: PostgresRow) throws -> Row
+}

--- a/Tests/IntegrationTests/AsyncTests.swift
+++ b/Tests/IntegrationTests/AsyncTests.swift
@@ -329,7 +329,7 @@ final class AsyncPostgresConnectionTests: XCTestCase {
 
             func makeBindings() -> PostgresBindings {
                 var bindings = PostgresBindings()
-                bindings.append(.init(string: self.state))
+                bindings.append(self.state)
                 return bindings
             }
 

--- a/Tests/IntegrationTests/AsyncTests.swift
+++ b/Tests/IntegrationTests/AsyncTests.swift
@@ -321,7 +321,7 @@ final class AsyncPostgresConnectionTests: XCTestCase {
         defer { XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully()) }
         let eventLoop = eventLoopGroup.next()
 
-        struct TestPreparedStatement: PreparedStatement {
+        struct TestPreparedStatement: PostgresPreparedStatement {
             static var sql = "SELECT pid, datname FROM pg_stat_activity WHERE state = $1"
             typealias Row = (Int, String)
 

--- a/Tests/IntegrationTests/AsyncTests.swift
+++ b/Tests/IntegrationTests/AsyncTests.swift
@@ -315,6 +315,48 @@ final class AsyncPostgresConnectionTests: XCTestCase {
             try await connection.query("SELECT 1;", logger: .psqlTest)
         }
     }
+
+    func testPreparedStatement() async throws {
+        let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully()) }
+        let eventLoop = eventLoopGroup.next()
+
+        struct TestPreparedStatement: PreparedStatement {
+            static var sql = "SELECT pid, datname FROM pg_stat_activity WHERE state = $1"
+            typealias Row = (Int, String)
+
+            var state: String
+
+            func makeBindings() -> PostgresBindings {
+                var bindings = PostgresBindings()
+                bindings.append(.init(string: self.state))
+                return bindings
+            }
+
+            func decodeRow(_ row: PostgresNIO.PostgresRow) throws -> Row {
+                try row.decode(Row.self)
+            }
+        }
+        let preparedStatement = TestPreparedStatement(state: "active")
+        try await withTestConnection(on: eventLoop) { connection in
+            var results = try await connection.execute(preparedStatement, logger: .psqlTest)
+            var counter = 0
+
+            for try await element in results {
+                XCTAssertEqual(element.1, env("POSTGRES_DB") ?? "test_database")
+                counter += 1
+            }
+
+            XCTAssertGreaterThanOrEqual(counter, 1)
+
+            // Second execution, which reuses the existing prepared statement
+            results = try await connection.execute(preparedStatement, logger: .psqlTest)
+            for try await element in results {
+                XCTAssertEqual(element.1, env("POSTGRES_DB") ?? "test_database")
+                counter += 1
+            }
+        }
+    }
 }
 
 extension XCTestCase {

--- a/Tests/PostgresNIOTests/New/Connection State Machine/PreparedStatementStateMachineTests.swift
+++ b/Tests/PostgresNIOTests/New/Connection State Machine/PreparedStatementStateMachineTests.swift
@@ -1,0 +1,159 @@
+import XCTest
+import NIOEmbedded
+@testable import PostgresNIO
+
+class PreparedStatementStateMachineTests: XCTestCase {
+    func testPrepareAndExecuteStatement() {
+        let eventLoop = EmbeddedEventLoop()
+        var stateMachine = PreparedStatementStateMachine()
+
+        let firstPreparedStatement = self.makePreparedStatementContext(eventLoop: eventLoop)
+        // Initial lookup, the statement hasn't been prepared yet
+        let lookupAction = stateMachine.lookup(preparedStatement: firstPreparedStatement)
+        guard case .preparing = stateMachine.preparedStatements["test"] else {
+            XCTFail("State machine in the wrong state")
+            return
+        }
+        guard case .prepareStatement = lookupAction else {
+            XCTFail("State machine returned the wrong action")
+            return
+        }
+
+        // Once preparation is complete we transition to a prepared state
+        let preparationCompleteAction = stateMachine.preparationComplete(name: "test", rowDescription: nil)
+        guard case .prepared(nil) = stateMachine.preparedStatements["test"] else {
+            XCTFail("State machine in the wrong state")
+            return
+        }
+        XCTAssertEqual(preparationCompleteAction.statements.count, 1)
+        XCTAssertNil(preparationCompleteAction.rowDescription)
+        firstPreparedStatement.promise.succeed(PSQLRowStream(
+            source: .noRows(.success("tag")),
+            eventLoop: eventLoop,
+            logger: .psqlTest
+        ))
+
+        // Create a new prepared statement
+        let secondPreparedStatement = self.makePreparedStatementContext(eventLoop: eventLoop)
+        // The statement is already preparead, lookups tell us to execute it
+        let secondLookupAction = stateMachine.lookup(preparedStatement: secondPreparedStatement)
+        guard case .prepared(nil) = stateMachine.preparedStatements["test"] else {
+            XCTFail("State machine in the wrong state")
+            return
+        }
+        guard case .executeStatement(nil) = secondLookupAction else {
+            XCTFail("State machine returned the wrong action")
+            return
+        }
+        secondPreparedStatement.promise.succeed(PSQLRowStream(
+            source: .noRows(.success("tag")),
+            eventLoop: eventLoop,
+            logger: .psqlTest
+        ))
+    }
+
+    func testPrepareAndExecuteStatementWithError() {
+        let eventLoop = EmbeddedEventLoop()
+        var stateMachine = PreparedStatementStateMachine()
+
+        let firstPreparedStatement = self.makePreparedStatementContext(eventLoop: eventLoop)
+        // Initial lookup, the statement hasn't been prepared yet
+        let lookupAction = stateMachine.lookup(preparedStatement: firstPreparedStatement)
+        guard case .preparing = stateMachine.preparedStatements["test"] else {
+            XCTFail("State machine in the wrong state")
+            return
+        }
+        guard case .prepareStatement = lookupAction else {
+            XCTFail("State machine returned the wrong action")
+            return
+        }
+
+        // Simulate an error occurring during preparation
+        let error = PSQLError(code: .server)
+        let preparationCompleteAction = stateMachine.errorHappened(
+            name: "test",
+            error: error
+        )
+        guard case .error = stateMachine.preparedStatements["test"] else {
+            XCTFail("State machine in the wrong state")
+            return
+        }
+        XCTAssertEqual(preparationCompleteAction.statements.count, 1)
+        firstPreparedStatement.promise.fail(error)
+
+        // Create a new prepared statement
+        let secondPreparedStatement = self.makePreparedStatementContext(eventLoop: eventLoop)
+        // Ensure that we don't try again to prepare a statement we know will fail
+        let secondLookupAction = stateMachine.lookup(preparedStatement: secondPreparedStatement)
+        guard case .error = stateMachine.preparedStatements["test"] else {
+            XCTFail("State machine in the wrong state")
+            return
+        }
+        guard case .returnError = secondLookupAction else {
+            XCTFail("State machine returned the wrong action")
+            return
+        }
+        secondPreparedStatement.promise.fail(error)
+    }
+
+    func testBatchStatementPreparation() {
+        let eventLoop = EmbeddedEventLoop()
+        var stateMachine = PreparedStatementStateMachine()
+
+        let firstPreparedStatement = self.makePreparedStatementContext(eventLoop: eventLoop)
+        // Initial lookup, the statement hasn't been prepared yet
+        let lookupAction = stateMachine.lookup(preparedStatement: firstPreparedStatement)
+        guard case .preparing = stateMachine.preparedStatements["test"] else {
+            XCTFail("State machine in the wrong state")
+            return
+        }
+        guard case .prepareStatement = lookupAction else {
+            XCTFail("State machine returned the wrong action")
+            return
+        }
+
+        // A new request comes in before the statement completes
+        let secondPreparedStatement = self.makePreparedStatementContext(eventLoop: eventLoop)
+        let secondLookupAction = stateMachine.lookup(preparedStatement: secondPreparedStatement)
+        guard case .preparing = stateMachine.preparedStatements["test"] else {
+            XCTFail("State machine in the wrong state")
+            return
+        }
+        guard case .waitForAlreadyInFlightPreparation = secondLookupAction else {
+            XCTFail("State machine returned the wrong action")
+            return
+        }
+
+        // Once preparation is complete we transition to a prepared state.
+        // The action tells us to execute both the pending statements.
+        let preparationCompleteAction = stateMachine.preparationComplete(name: "test", rowDescription: nil)
+        guard case .prepared(nil) = stateMachine.preparedStatements["test"] else {
+            XCTFail("State machine in the wrong state")
+            return
+        }
+        XCTAssertEqual(preparationCompleteAction.statements.count, 2)
+        XCTAssertNil(preparationCompleteAction.rowDescription)
+
+        firstPreparedStatement.promise.succeed(PSQLRowStream(
+            source: .noRows(.success("tag")),
+            eventLoop: eventLoop,
+            logger: .psqlTest
+        ))
+        secondPreparedStatement.promise.succeed(PSQLRowStream(
+            source: .noRows(.success("tag")),
+            eventLoop: eventLoop,
+            logger: .psqlTest
+        ))
+    }
+
+    private func makePreparedStatementContext(eventLoop: EmbeddedEventLoop) -> PreparedStatementContext {
+        let promise = eventLoop.makePromise(of: PSQLRowStream.self)
+        return PreparedStatementContext(
+            name: "test",
+            sql: "INSERT INTO test_table (column1) VALUES (1)",
+            bindings: PostgresBindings(),
+            logger: .psqlTest,
+            promise: promise
+        )
+    }
+}

--- a/Tests/PostgresNIOTests/New/Extensions/PSQLFrontendMessageDecoder.swift
+++ b/Tests/PostgresNIOTests/New/Extensions/PSQLFrontendMessageDecoder.swift
@@ -142,7 +142,7 @@ extension PostgresFrontendMessage {
             }
 
             let parameters = (0..<parameterCount).map { _ -> ByteBuffer? in
-                let length = buffer.readInteger(as: UInt16.self)
+                let length = buffer.readInteger(as: UInt32.self)
                 switch length {
                 case .some(..<0):
                     return nil

--- a/Tests/PostgresNIOTests/New/PostgresConnectionTests.swift
+++ b/Tests/PostgresNIOTests/New/PostgresConnectionTests.swift
@@ -344,9 +344,12 @@ class PostgresConnectionTests: XCTestCase {
             try await channel.testingEventLoop.executeInContext { channel.read() }
 
             // Wait for the EXECUTE request
-            guard case .bind = try await channel.waitForOutboundWrite(as: PostgresFrontendMessage.self) else {
+            guard case .bind(let bind) = try await channel.waitForOutboundWrite(as: PostgresFrontendMessage.self) else {
                 fatalError("Unexpected message")
             }
+            XCTAssertEqual(bind.preparedStatementName, String(reflecting: TestPrepareStatement.self))
+            XCTAssertEqual(bind.parameters.count, 1)
+            XCTAssertEqual(bind.resultColumnFormats, [.binary])
             guard case .execute = try await channel.waitForOutboundWrite(as: PostgresFrontendMessage.self) else {
                 fatalError("Unexpected message")
             }

--- a/Tests/PostgresNIOTests/New/PostgresConnectionTests.swift
+++ b/Tests/PostgresNIOTests/New/PostgresConnectionTests.swift
@@ -339,7 +339,7 @@ class PostgresConnectionTests: XCTestCase {
 
             try await channel.sendPreparedResponse(
                 dataRows: [
-                    DataRow(arrayLiteral: "test_database")
+                    ["test_database"]
                 ],
                 commandTag: TestPrepareStatement.sql
             )
@@ -394,7 +394,7 @@ class PostgresConnectionTests: XCTestCase {
             XCTAssertEqual(parameter1, "active")
             try await channel.sendPreparedResponse(
                 dataRows: [
-                    DataRow(arrayLiteral: "test_database")
+                    ["test_database"]
                 ],
                 commandTag: TestPrepareStatement.sql
             )
@@ -418,7 +418,7 @@ class PostgresConnectionTests: XCTestCase {
             XCTAssertEqual(parameter2, "idle")
             try await channel.sendPreparedResponse(
                 dataRows: [
-                    DataRow(arrayLiteral: "test_database")
+                    ["test_database"]
                 ],
                 commandTag: TestPrepareStatement.sql
             )
@@ -489,7 +489,7 @@ class PostgresConnectionTests: XCTestCase {
             let parameter1 = buffer.readString(length: buffer.readableBytes)!
             try await channel.sendPreparedResponse(
                 dataRows: [
-                    DataRow(arrayLiteral: "test_database_\(parameter1)")
+                    ["test_database_\(parameter1)"]
                 ],
                 commandTag: TestPrepareStatement.sql
             )
@@ -498,7 +498,7 @@ class PostgresConnectionTests: XCTestCase {
             let parameter2 = buffer.readString(length: buffer.readableBytes)!
             try await channel.sendPreparedResponse(
                 dataRows: [
-                    DataRow(arrayLiteral: "test_database_\(parameter2)")
+                    ["test_database_\(parameter2)"]
                 ],
                 commandTag: TestPrepareStatement.sql
             )


### PR DESCRIPTION
Implementation of async/await API for prepared statements (See also https://github.com/vapor/postgres-nio/issues/385).

This PR adds a new `PreparedStatement` protocol to represent prepared statements and an `execute` function on `PostgresConnection` to prepare and execute statements.

To implement the features the PR also introduces a `PreparedStatementStateMachine` that keeps track of the state of a prepared statement at the connection level. This ensures that, for each connection, each statement is prepared once at time of first use and then subsequent uses are going to skip the preparation step and just execute it.

## Example usage

First define the struct to represent the prepared statement:
```swift
 struct ExamplePreparedStatement: PreparedStatement {
     static var sql = "SELECT pid, datname FROM pg_stat_activity WHERE state = $1"
     typealias Row = (Int, String)
     var state: String
     
    func makeBindings() -> PostgresBindings {
        var bindings = PostgresBindings()
        bindings.append(.init(string: self.state))
        return bindings
    }

    func decodeRow(_ row: PostgresNIO.PostgresRow) throws -> Row {
        try row.decode(Row.self)
    }
}
```
then, assuming you already have a `PostgresConnection` you can execute it:
```swift
let preparedStatement = ExamplePreparedStatement(state: "active")
let results = try await connection.execute(preparedStatement, logger: logger)
for (pid, database) in results {
    print("PID: \(pid), database: \(database)")
}
```