### PR TITLE
Use README header image compatible with light/dark mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,19 @@
-<img src="https://user-images.githubusercontent.com/1342803/59061804-5548e280-8872-11e9-819f-14f19f16fcb6.png" height="64" alt="PostgresNIO">
-
-[![SSWG Incubating Badge](https://img.shields.io/badge/sswg-incubating-green.svg)][SSWG Incubation]
-[![Documentation](http://img.shields.io/badge/read_the-docs-2196f3.svg)][Documentation]
-[![Team Chat](https://img.shields.io/discord/431917998102675485.svg)][Team Chat]
-[![MIT License](http://img.shields.io/badge/license-MIT-brightgreen.svg)][MIT License]
-[![Continuous Integration](https://github.com/vapor/postgres-nio/actions/workflows/test.yml/badge.svg)][Continuous Integration]
-[![Swift 5.6](http://img.shields.io/badge/swift-5.6-brightgreen.svg)][Swift 5.6]
+<p align="center">
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://user-images.githubusercontent.com/1130717/259709891-64d4c78b-1cd1-4446-8746-d3a009992811.png">
+  <source media="(prefers-color-scheme: light)" srcset="https://user-images.githubusercontent.com/1130717/259710040-d79ee9eb-b5d9-4a82-a894-3eb5ef366c1f.png">
+  <img src="https://user-images.githubusercontent.com/1130717/259710040-d79ee9eb-b5d9-4a82-a894-3eb5ef366c1f.png" height="96" alt="PostgresNIO">
+</picture>
 <br>
 <br>
-
+<a name=""><img src="https://img.shields.io/badge/sswg-incubating-green.svg" alt="SSWG Incubation"></a>
+<a href="https://docs.vapor.codes/4.0/"><img src="https://img.shields.io/badge/read_the-docs-2196f3.svg" alt="Documentation"></a>
+<a href="https://discord.gg/vapor"><img src="https://img.shields.io/discord/431917998102675485.svg" alt="Team Chat"></a>
+<a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-brightgreen.svg" alt="MIT License"></a>
+<a href="https://github.com/vapor/postgres-nio/actions/workflows/test.yml"><img src="https://github.com/vapor/postgres-nio/actions/workflows/test.yml/badge.svg" alt="Continuous Integration"></a>
+<a href="https://swift.org"><img src="https://img.shields.io/badge/swift-5.6-brightgreen.svg" alt="Swift 5.6"></a>
+</p>
+<br>
 🐘 Non-blocking, event-driven Swift client for PostgreSQL built on [SwiftNIO].
 
 Features:


### PR DESCRIPTION
Also centers the logo and badges, adds proper links to the badges, and fixes use of non-https image URLs.