### PR TITLE
Remove generic usage from `avoidingStateMachineCoW()`  so it doesn't need to be force-inlined

### DIFF
--- a/Sources/PostgresNIO/New/Connection State Machine/ConnectionStateMachine.swift
+++ b/Sources/PostgresNIO/New/Connection State Machine/ConnectionStateMachine.swift
@@ -978,11 +978,7 @@ extension ConnectionStateMachine {
     /// remains in this bad state.
     ///
     /// A key note here is that all callers must ensure that they return to a good state before they exit.
-    ///
-    /// Sadly, because it's generic and has a closure, we need to force it to be inlined at all call sites, which is
-    /// not ideal.
-    @inline(__always)
-    private mutating func avoidingStateMachineCoW<ReturnType>(_ body: (inout ConnectionStateMachine) -> ReturnType) -> ReturnType {
+    private mutating func avoidingStateMachineCoW(_ body: (inout ConnectionStateMachine) -> ConnectionAction) -> ConnectionAction {
         self.state = .modifying
         defer {
             assert(!self.isModifying)

--- a/Sources/PostgresNIO/New/Connection State Machine/ExtendedQueryStateMachine.swift
+++ b/Sources/PostgresNIO/New/Connection State Machine/ExtendedQueryStateMachine.swift
@@ -540,17 +540,22 @@ extension ExtendedQueryStateMachine {
     /// remains in this bad state.
     ///
     /// A key note here is that all callers must ensure that they return to a good state before they exit.
-    ///
-    /// Sadly, because it's generic and has a closure, we need to force it to be inlined at all call sites, which is
-    /// not ideal.
-    @inline(__always)
-    private mutating func avoidingStateMachineCoW<ReturnType>(_ body: (inout State) -> ReturnType) -> ReturnType {
+    private mutating func avoidingStateMachineCoW(_ body: (inout State) -> Action) -> Action {
         self.state = .modifying
         defer {
             assert(!self.isModifying)
         }
 
         return body(&self.state)
+    }
+    
+    private mutating func avoidingStateMachineCoW(_ body: (inout State) -> Void) {
+        self.state = .modifying
+        defer {
+            assert(!self.isModifying)
+        }
+        
+        body(&self.state)
     }
 
     private var isModifying: Bool {


### PR DESCRIPTION
The comment explaining `avoidingStateMachineCoW()` states:
```swift
/// Sadly, because it's generic and has a closure, we need to force it to be inlined
/// at all call sites, which is not ideal.
```
However, at all but one call site, it always returns the same type, so it doesn't really need to be generic and we can avoid the "not ideal" inlining requirement.