### PR TITLE
Move PostgresFrontendMessage to tests

### DIFF
--- a/Sources/PostgresNIO/New/Extensions/ByteBuffer+PSQL.swift
+++ b/Sources/PostgresNIO/New/Extensions/ByteBuffer+PSQL.swift
@@ -2,14 +2,6 @@ import NIOCore
 
 internal extension ByteBuffer {
     
-    mutating func psqlWriteBackendMessageID(_ messageID: PostgresBackendMessage.ID) {
-        self.writeInteger(messageID.rawValue)
-    }
-    
-    mutating func psqlWriteFrontendMessageID(_ messageID: PostgresFrontendMessage.ID) {
-        self.writeInteger(messageID.rawValue)
-    }
-
     @usableFromInline
     mutating func psqlReadFloat() -> Float? {
         return self.readInteger(as: UInt32.self).map { Float(bitPattern: $0) }

--- a/Tests/PostgresNIOTests/New/Extensions/ByteBuffer+Utils.swift
+++ b/Tests/PostgresNIOTests/New/Extensions/ByteBuffer+Utils.swift
@@ -2,7 +2,10 @@ import NIOCore
 @testable import PostgresNIO
 
 extension ByteBuffer {
-    
+    mutating func psqlWriteBackendMessageID(_ messageID: PostgresBackendMessage.ID) {
+        self.writeInteger(messageID.rawValue)
+    }
+
     static func backendMessage(id: PostgresBackendMessage.ID, _ payload: (inout ByteBuffer) throws -> ()) rethrows -> ByteBuffer {
         var byteBuffer = ByteBuffer()
         try byteBuffer.writeBackendMessage(id: id, payload)

--- a/Tests/PostgresNIOTests/New/Extensions/PostgresFrontendMessage.swift
+++ b/Tests/PostgresNIOTests/New/Extensions/PostgresFrontendMessage.swift
@@ -1,4 +1,5 @@
 import NIOCore
+import PostgresNIO
 
 /// A wire message that is created by a Postgres client to be consumed by Postgres server.
 ///


### PR DESCRIPTION
We should remove everything that we don't need from PostgresNIO. `PostgresFrontendMessage` is only required in tests now. So let's move it to tests.