### PR TITLE
Remove PSQLError.Code.clientClosesConnection

### DIFF
--- a/Sources/PostgresNIO/New/Connection State Machine/ConnectionStateMachine.swift
+++ b/Sources/PostgresNIO/New/Connection State Machine/ConnectionStateMachine.swift
@@ -550,7 +550,7 @@ struct ConnectionStateMachine {
         // check if we are quiescing. if so fail task immidiatly
         switch self.quiescingState {
         case .quiescing:
-            psqlErrror = PSQLError.clientClosesConnection(underlying: nil)
+            psqlErrror = PSQLError.clientClosedConnection(underlying: nil)
 
         case .notQuiescing:
             switch self.state {
@@ -570,7 +570,7 @@ struct ConnectionStateMachine {
                 return self.executeTask(task)
 
             case .closing(let error):
-                psqlErrror = PSQLError.clientClosesConnection(underlying: error)
+                psqlErrror = PSQLError.clientClosedConnection(underlying: error)
 
             case .closed(clientInitiated: true, error: let error):
                 psqlErrror = PSQLError.clientClosedConnection(underlying: error)
@@ -1033,7 +1033,7 @@ extension ConnectionStateMachine {
             }
             
             return false
-        case .clientClosesConnection, .clientClosedConnection:
+        case .clientClosedConnection:
             preconditionFailure("A pure client error was thrown directly in PostgresConnection, this shouldn't happen")
         case .serverClosedConnection:
             return true

--- a/Sources/PostgresNIO/New/PSQLError.swift
+++ b/Sources/PostgresNIO/New/PSQLError.swift
@@ -18,7 +18,6 @@ public struct PSQLError: Error {
 
             case queryCancelled
             case tooManyParameters
-            case clientClosesConnection
             case clientClosedConnection
             case serverClosedConnection
             case connectionError
@@ -46,7 +45,6 @@ public struct PSQLError: Error {
         public static let invalidCommandTag = Self(.invalidCommandTag)
         public static let queryCancelled = Self(.queryCancelled)
         public static let tooManyParameters = Self(.tooManyParameters)
-        public static let clientClosesConnection = Self(.clientClosesConnection)
         public static let clientClosedConnection = Self(.clientClosedConnection)
         public static let serverClosedConnection = Self(.serverClosedConnection)
         public static let connectionError = Self(.connectionError)
@@ -54,8 +52,8 @@ public struct PSQLError: Error {
         public static let listenFailed = Self.init(.listenFailed)
         public static let unlistenFailed = Self.init(.unlistenFailed)
 
-        @available(*, deprecated, renamed: "clientClosesConnection")
-        public static let connectionQuiescing = Self.clientClosesConnection
+        @available(*, deprecated, renamed: "clientClosedConnection")
+        public static let connectionQuiescing = Self.clientClosedConnection
 
         @available(*, deprecated, message: "Use the more specific `serverClosedConnection` or `clientClosedConnection` instead")
         public static let connectionClosed = Self.serverClosedConnection
@@ -86,8 +84,6 @@ public struct PSQLError: Error {
                 return "queryCancelled"
             case .tooManyParameters:
                 return "tooManyParameters"
-            case .clientClosesConnection:
-                return "clientClosesConnection"
             case .clientClosedConnection:
                 return "clientClosedConnection"
             case .serverClosedConnection:
@@ -385,12 +381,6 @@ public struct PSQLError: Error {
         var new = Self(code: .messageDecodingFailure)
         new.underlying = error
         return new
-    }
-
-    static func clientClosesConnection(underlying: Error?) -> PSQLError {
-        var error = PSQLError(code: .clientClosesConnection)
-        error.underlying = underlying
-        return error
     }
 
     static func clientClosedConnection(underlying: Error?) -> PSQLError {

--- a/Sources/PostgresNIO/New/PostgresChannelHandler.swift
+++ b/Sources/PostgresNIO/New/PostgresChannelHandler.swift
@@ -576,8 +576,10 @@ final class PostgresChannelHandler: ChannelDuplexHandler {
         }
 
         // 3. fire an error
-        context.fireErrorCaught(cleanup.error)
-        
+        if cleanup.error.code != .clientClosedConnection {
+            context.fireErrorCaught(cleanup.error)
+        }
+
         // 4. close the connection or fire channel inactive
         switch cleanup.action {
         case .close:

--- a/Sources/PostgresNIO/Postgres+PSQLCompat.swift
+++ b/Sources/PostgresNIO/Postgres+PSQLCompat.swift
@@ -37,8 +37,7 @@ extension PSQLError {
             return self.underlying ?? self
         case .tooManyParameters, .invalidCommandTag:
             return self
-        case .clientClosesConnection, 
-             .clientClosedConnection,
+        case .clientClosedConnection,
              .serverClosedConnection:
             return PostgresError.connectionClosed
         case .connectionError:

--- a/Tests/PostgresNIOTests/New/PostgresChannelHandlerTests.swift
+++ b/Tests/PostgresNIOTests/New/PostgresChannelHandlerTests.swift
@@ -25,8 +25,7 @@ class PostgresChannelHandlerTests: XCTestCase {
             handler
         ], loop: self.eventLoop)
         defer {
-            do { try embedded.finish() }
-            catch { print("\(String(reflecting: error))") }
+            XCTAssertNoThrow({ try embedded.finish() })
         }
 
         var maybeMessage: PostgresFrontendMessage?


### PR DESCRIPTION
Follow up to #383. This has breaking change which is fine, since we haven't cut a release after #383, which introduces the error code that we remove now.