### PR TITLE
Add Interpolation Function for Collection types

### DIFF
--- a/Sources/PostgresNIO/New/PostgresQuery.swift
+++ b/Sources/PostgresNIO/New/PostgresQuery.swift
@@ -99,7 +99,7 @@ extension PostgresQuery {
         @inlinable
         public mutating func appendInterpolation<C: Collection>(
             _ values: C
-        ) throws where C.Element: PostgresThrowingDynamicTypeEncodable {
+        ) throws where C.Element: PostgresArrayEncodable {
             guard !values.isEmpty else {
                 throw PostgresEncodableSequenceCannotBeEmpty()
             }

--- a/Sources/PostgresNIO/New/PostgresQuery.swift
+++ b/Sources/PostgresNIO/New/PostgresQuery.swift
@@ -92,7 +92,7 @@ extension PostgresQuery {
 
 
         @usableFromInline
-        struct PostgresEncodableSequenceCannotBeEmpty: Error {
+        struct InterpolatedCollectionCannotBeEmpty: Error {
             @usableFromInline init() { }
         }
 
@@ -101,7 +101,7 @@ extension PostgresQuery {
             _ values: C
         ) throws where C.Element: PostgresArrayEncodable {
             guard !values.isEmpty else {
-                throw PostgresEncodableSequenceCannotBeEmpty()
+                throw InterpolatedCollectionCannotBeEmpty()
             }
             let bindsSQL = try values.map { value in
                 try self.binds.append(value, context: .default)

--- a/Sources/PostgresNIO/New/PostgresQuery.swift
+++ b/Sources/PostgresNIO/New/PostgresQuery.swift
@@ -43,7 +43,6 @@ extension PostgresQuery {
             self.sql.append(contentsOf: literal)
         }
 
-        @_disfavoredOverload
         @inlinable
         public mutating func appendInterpolation<Value: PostgresThrowingDynamicTypeEncodable>(_ value: Value) throws {
             try self.binds.append(value, context: .default)
@@ -62,7 +61,6 @@ extension PostgresQuery {
             self.sql.append(contentsOf: "$\(self.binds.count)")
         }
 
-        @_disfavoredOverload
         @inlinable
         public mutating func appendInterpolation<Value: PostgresDynamicTypeEncodable>(_ value: Value) {
             self.binds.append(value, context: .default)
@@ -98,7 +96,7 @@ extension PostgresQuery {
 
         @inlinable
         public mutating func appendInterpolation<C: Collection>(
-            _ values: C
+            collection values: C
         ) throws where C.Element: PostgresArrayEncodable {
             guard !values.isEmpty else {
                 throw InterpolatedCollectionCannotBeEmpty()

--- a/Tests/IntegrationTests/PSQLIntegrationTests.swift
+++ b/Tests/IntegrationTests/PSQLIntegrationTests.swift
@@ -223,9 +223,9 @@ final class IntegrationTests: XCTestCase {
 
         var result: PostgresQueryResult?
         let doubles: [Double] = [3.14, 42]
-        XCTAssertNoThrow(result = try conn?.query("CREATE TABLE foo (accuracy double precision)", logger: .psqlTest).wait())
-        XCTAssertNoThrow(result = try conn?.query("INSERT INTO foo VALUES (\(doubles[0]))", logger: .psqlTest).wait())
-        XCTAssertNoThrow(result = try conn?.query("INSERT INTO foo VALUES (\(doubles[1]))", logger: .psqlTest).wait())
+        XCTAssertNoThrow(try conn?.query("CREATE TABLE foo (accuracy double precision)", logger: .psqlTest).wait())
+        XCTAssertNoThrow(try conn?.query("INSERT INTO foo VALUES (\(doubles[0]))", logger: .psqlTest).wait())
+        XCTAssertNoThrow(try conn?.query("INSERT INTO foo VALUES (\(doubles[1]))", logger: .psqlTest).wait())
         XCTAssertNoThrow(result = try conn?.query("SELECT * FROM foo WHERE accuracy IN \(collection: doubles)", logger: .psqlTest).wait())
 
         guard result?.count == doubles.count else {

--- a/Tests/IntegrationTests/PSQLIntegrationTests.swift
+++ b/Tests/IntegrationTests/PSQLIntegrationTests.swift
@@ -223,7 +223,7 @@ final class IntegrationTests: XCTestCase {
 
         var result: PostgresQueryResult?
         let doubles: [Double] = [3.14, 42]
-        XCTAssertNoThrow(result = try conn?.query("SELECT \(collection: doubles)::double precision[] as doubles", logger: .psqlTest).wait())
+        XCTAssertNoThrow(result = try conn?.query("SELECT \(collection: doubles) as doubles", logger: .psqlTest).wait())
         XCTAssertEqual(result?.rows.count, 1)
         XCTAssertEqual(try result?.rows.first?.decode([Double].self, context: .default), doubles)
     }

--- a/Tests/IntegrationTests/PSQLIntegrationTests.swift
+++ b/Tests/IntegrationTests/PSQLIntegrationTests.swift
@@ -223,10 +223,10 @@ final class IntegrationTests: XCTestCase {
 
         var result: PostgresQueryResult?
         let doubles: [Double] = [3.14, 42]
-        XCTAssertNoThrow(try conn?.query("CREATE TABLE foo (accuracy double precision)", logger: .psqlTest).wait())
-        XCTAssertNoThrow(try conn?.query("INSERT INTO foo VALUES (\(doubles[0]))", logger: .psqlTest).wait())
-        XCTAssertNoThrow(try conn?.query("INSERT INTO foo VALUES (\(doubles[1]))", logger: .psqlTest).wait())
-        XCTAssertNoThrow(result = try conn?.query("SELECT * FROM foo WHERE accuracy IN \(collection: doubles)", logger: .psqlTest).wait())
+        XCTAssertNoThrow(try conn?.query("CREATE TABLE array_table (accuracy double precision)", logger: .psqlTest).wait())
+        XCTAssertNoThrow(try conn?.query("INSERT INTO array_table VALUES (\(doubles[0]))", logger: .psqlTest).wait())
+        XCTAssertNoThrow(try conn?.query("INSERT INTO array_table VALUES (\(doubles[1]))", logger: .psqlTest).wait())
+        XCTAssertNoThrow(result = try conn?.query("SELECT * FROM array_table WHERE accuracy IN \(collection: doubles)", logger: .psqlTest).wait())
 
         guard result?.count == doubles.count else {
             XCTFail("Expected '\(doubles.count)' rows, but got '\(result?.count ?? 0)'. Result: \(String(describing: result))")

--- a/Tests/IntegrationTests/PSQLIntegrationTests.swift
+++ b/Tests/IntegrationTests/PSQLIntegrationTests.swift
@@ -212,7 +212,7 @@ final class IntegrationTests: XCTestCase {
         XCTAssertEqual(try result?.rows.first?.decode([Double].self, context: .default), doubles)
     }
 
-    func testDoubleArraySerializationQueryWithCollectionInterpolation() {
+    func testDoubleArraySerializationWithCollectionInterpolation() {
         let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully()) }
         let eventLoop = eventLoopGroup.next()

--- a/Tests/IntegrationTests/PSQLIntegrationTests.swift
+++ b/Tests/IntegrationTests/PSQLIntegrationTests.swift
@@ -223,7 +223,7 @@ final class IntegrationTests: XCTestCase {
 
         var result: PostgresQueryResult?
         let doubles: [Double] = [3.14, 42]
-        XCTAssertNoThrow(result = try conn?.query("SELECT \(collection: doubles) as doubles", logger: .psqlTest).wait())
+        XCTAssertNoThrow(result = try conn?.query("SELECT \(collection: doubles)::double precision[] as doubles", logger: .psqlTest).wait())
         XCTAssertEqual(result?.rows.count, 1)
         XCTAssertEqual(try result?.rows.first?.decode([Double].self, context: .default), doubles)
     }

--- a/Tests/IntegrationTests/PSQLIntegrationTests.swift
+++ b/Tests/IntegrationTests/PSQLIntegrationTests.swift
@@ -212,6 +212,22 @@ final class IntegrationTests: XCTestCase {
         XCTAssertEqual(try result?.rows.first?.decode([Double].self, context: .default), doubles)
     }
 
+    func testDoubleArraySerializationWithCollectionInterpolation() {
+        let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully()) }
+        let eventLoop = eventLoopGroup.next()
+
+        var conn: PostgresConnection?
+        XCTAssertNoThrow(conn = try PostgresConnection.test(on: eventLoop).wait())
+        defer { XCTAssertNoThrow(try conn?.close().wait()) }
+
+        var result: PostgresQueryResult?
+        let doubles: [Double] = [3.14, 42]
+        XCTAssertNoThrow(result = try conn?.query("SELECT \(collection: doubles) as doubles", logger: .psqlTest).wait())
+        XCTAssertEqual(result?.rows.count, 1)
+        XCTAssertEqual(try result?.rows.first?.decode([Double].self, context: .default), doubles)
+    }
+
     func testDecodeDates() {
         let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully()) }

--- a/Tests/PostgresNIOTests/New/PostgresQueryTests.swift
+++ b/Tests/PostgresNIOTests/New/PostgresQueryTests.swift
@@ -97,6 +97,23 @@ final class PostgresQueryTests: XCTestCase {
         XCTAssertEqual(query.binds.bytes, expected)
     }
 
+    func testStringInterpolationWithSequence() throws {
+        let titles = ["bar", "baz"]
+        let query: PostgresQuery = try """
+        SELECT * FROM foo WHERE title in \(titles)
+        """
+
+        XCTAssertEqual(query.sql, "SELECT * FROM foo WHERE title in ($1, $2)")
+
+        var expected = ByteBuffer()
+        for title in titles {
+            expected.writeInteger(UInt32(3))
+            expected.writeString(title)
+        }
+
+        XCTAssertEqual(query.binds.bytes, expected)
+    }
+
     func testUnescapedSQL() {
         let tableName = UUID().uuidString.uppercased()
         let value = 1

--- a/Tests/PostgresNIOTests/New/PostgresQueryTests.swift
+++ b/Tests/PostgresNIOTests/New/PostgresQueryTests.swift
@@ -100,7 +100,7 @@ final class PostgresQueryTests: XCTestCase {
     func testStringInterpolationWithSequence() throws {
         let titles = ["bar", "baz"]
         let query: PostgresQuery = try """
-        SELECT * FROM foo WHERE title in \(titles)
+        SELECT * FROM foo WHERE title in \(collection: titles)
         """
 
         XCTAssertEqual(query.sql, "SELECT * FROM foo WHERE title in ($1, $2)")


### PR DESCRIPTION
Adds an interpolation function for collection types.

This has proved quite useful since manually interpolating an array is quite hard to do properly, to a `PostgresQuery`.