### PR TITLE
Fix `PostgresDecodable` inference for `RawRepresentable` enums

### DIFF
--- a/Sources/PostgresNIO/New/Data/RawRepresentable+PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/Data/RawRepresentable+PostgresCodable.swift
@@ -19,7 +19,7 @@ extension PostgresEncodable where Self: RawRepresentable, RawValue: PostgresEnco
 }
 
 extension PostgresDecodable where Self: RawRepresentable, RawValue: PostgresDecodable, RawValue._DecodableType == RawValue {
-    init<JSONDecoder: PostgresJSONDecoder>(
+    public init<JSONDecoder: PostgresJSONDecoder>(
         from buffer: inout ByteBuffer,
         type: PostgresDataType,
         format: PostgresFormat,

--- a/Tests/IntegrationTests/PSQLIntegrationTests.swift
+++ b/Tests/IntegrationTests/PSQLIntegrationTests.swift
@@ -263,7 +263,7 @@ final class IntegrationTests: XCTestCase {
         XCTAssertEqual(cells?.1, Decimal(string: "-123456.789123"))
     }
 
-    func testDecodeRawRepresentable() {
+    func testDecodeRawRepresentables() {
         let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully()) }
         let eventLoop = eventLoopGroup.next()


### PR DESCRIPTION
The function in extension responsible for making `PostgresDecodable` work with `RawRepresentable`, was not marked as public.

I added an integration test to make sure this now functions as expected.

I also removed the `@testable` in the `IntegrationsTests` since it wasn't needed and it would also manipulate Codable behaviors. If there is an internal extension for Codable, @testable makes it so the tests will use that while the `public` will not be able to use that, which will either result in unexpected compile errors for users, or different behavior in test vs what users see.