### PR TITLE
Fixes an availability issue for DiscardingTaskGroup on watchOS

### DIFF
--- a/Sources/ConnectionPoolModule/ConnectionPool.swift
+++ b/Sources/ConnectionPoolModule/ConnectionPool.swift
@@ -591,7 +591,7 @@ protocol TaskGroupProtocol {
 }
 
 #if swift(>=5.8) && os(Linux) || swift(>=5.9)
-@available(macOS 14.0, iOS 17.0, tvOS 17.0, watchOS 9.0, *)
+@available(macOS 14.0, iOS 17.0, tvOS 17.0, watchOS 10.0, *)
 extension DiscardingTaskGroup: TaskGroupProtocol {}
 #endif
 


### PR DESCRIPTION
DiscardingTaskGroup is only available on watchOS >=10.0 :).

This patch allows the ConnectionPoolModule to be successfully built for watchOS.
