### PR TITLE
Fix prepared statements

### DIFF
--- a/Sources/PostgresNIO/Connection/PostgresConnection.swift
+++ b/Sources/PostgresNIO/Connection/PostgresConnection.swift
@@ -234,6 +234,7 @@ public final class PostgresConnection: @unchecked Sendable {
         let context = ExtendedQueryContext(
             name: name,
             query: query,
+            bindingDataTypes: [],
             logger: logger,
             promise: promise
         )
@@ -472,9 +473,10 @@ extension PostgresConnection {
         let bindings = try preparedStatement.makeBindings()
         let promise = self.channel.eventLoop.makePromise(of: PSQLRowStream.self)
         let task = HandlerTask.executePreparedStatement(.init(
-            name: String(reflecting: Statement.self),
+            name: Statement.name,
             sql: Statement.sql,
             bindings: bindings,
+            bindingDataTypes: Statement.bindingDataTypes,
             logger: logger,
             promise: promise
         ))
@@ -493,10 +495,10 @@ extension PostgresConnection {
             )
             throw error // rethrow with more metadata
         }
-
     }
 
     /// Execute a prepared statement, taking care of the preparation when necessary
+    @_disfavoredOverload
     public func execute<Statement: PostgresPreparedStatement>(
         _ preparedStatement: Statement,
         logger: Logger,
@@ -506,9 +508,10 @@ extension PostgresConnection {
         let bindings = try preparedStatement.makeBindings()
         let promise = self.channel.eventLoop.makePromise(of: PSQLRowStream.self)
         let task = HandlerTask.executePreparedStatement(.init(
-            name: String(reflecting: Statement.self),
+            name: Statement.name,
             sql: Statement.sql,
             bindings: bindings,
+            bindingDataTypes: Statement.bindingDataTypes,
             logger: logger,
             promise: promise
         ))

--- a/Sources/PostgresNIO/New/Connection State Machine/ConnectionStateMachine.swift
+++ b/Sources/PostgresNIO/New/Connection State Machine/ConnectionStateMachine.swift
@@ -97,7 +97,7 @@ struct ConnectionStateMachine {
         case forwardStreamError(PSQLError, read: Bool, cleanupContext: CleanUpContext?)
         
         // Prepare statement actions
-        case sendParseDescribeSync(name: String, query: String)
+        case sendParseDescribeSync(name: String, query: String, bindingDataTypes: [PostgresDataType])
         case succeedPreparedStatementCreation(EventLoopPromise<RowDescription?>, with: RowDescription?)
         case failPreparedStatementCreation(EventLoopPromise<RowDescription?>, with: PSQLError, cleanupContext: CleanUpContext?)
 
@@ -587,7 +587,7 @@ struct ConnectionStateMachine {
             switch queryContext.query {
             case .executeStatement(_, let promise), .unnamed(_, let promise):
                 return .failQuery(promise, with: psqlErrror, cleanupContext: nil)
-            case .prepareStatement(_, _, let promise):
+            case .prepareStatement(_, _, _, let promise):
                 return .failPreparedStatementCreation(promise, with: psqlErrror, cleanupContext: nil)
             }
         case .closeCommand(let closeContext):
@@ -1057,8 +1057,8 @@ extension ConnectionStateMachine {
             return .read
         case .wait:
             return .wait
-        case .sendParseDescribeSync(name: let name, query: let query):
-            return .sendParseDescribeSync(name: name, query: query)
+        case .sendParseDescribeSync(name: let name, query: let query, bindingDataTypes: let bindingDataTypes):
+            return .sendParseDescribeSync(name: name, query: query, bindingDataTypes: bindingDataTypes)
         case .succeedPreparedStatementCreation(let promise, with: let rowDescription):
             return .succeedPreparedStatementCreation(promise, with: rowDescription)
         case .failPreparedStatementCreation(let promise, with: let error):

--- a/Sources/PostgresNIO/New/PreparedStatement.swift
+++ b/Sources/PostgresNIO/New/PreparedStatement.swift
@@ -26,15 +26,36 @@
 /// Structs conforming to this protocol can then be used with `PostgresConnection.execute(_ preparedStatement:, logger:)`,
 /// which will take care of preparing the statement on the server side and executing it.
 public protocol PostgresPreparedStatement: Sendable {
+    /// The prepared statements name.
+    ///
+    /// > Note: There is a default implementation that returns the implementor's name.
+    static var name: String { get }
+
     /// The type rows returned by the statement will be decoded into
     associatedtype Row
 
     /// The SQL statement to prepare on the database server.
     static var sql: String { get }
 
-    /// Make the bindings to provided concrete values to use when executing the prepared SQL statement
+    /// The postgres data types of the values that are bind when this statement is executed.
+    ///
+    /// If an empty array is returned the datatypes are inferred from the ``PostgresBindings`` returned
+    /// from ``PostgresPreparedStatement/makeBindings()``.
+    ///
+    /// > Note: There is a default implementation that returns an empty array, which will lead to
+    /// automatic inference.
+    static var bindingDataTypes: [PostgresDataType] { get }
+
+    /// Make the bindings to provided concrete values to use when executing the prepared SQL statement. 
+    /// The order must match ``PostgresPreparedStatement/bindingDataTypes-4b6tx``.
     func makeBindings() throws -> PostgresBindings
     
     /// Decode a row returned by the database into an instance of `Row`
     func decodeRow(_ row: PostgresRow) throws -> Row
+}
+
+extension PostgresPreparedStatement {
+    public static var name: String { String(reflecting: self) }
+
+    public static var bindingDataTypes: [PostgresDataType] { [] }
 }

--- a/Tests/IntegrationTests/AsyncTests.swift
+++ b/Tests/IntegrationTests/AsyncTests.swift
@@ -358,6 +358,87 @@ final class AsyncPostgresConnectionTests: XCTestCase {
             }
         }
     }
+
+    static let preparedStatementTestTable = "AsyncTestPreparedStatementTestTable"
+    func testPreparedStatementWithIntegerBinding() async throws {
+        let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully()) }
+        let eventLoop = eventLoopGroup.next()
+
+        struct InsertPreparedStatement: PostgresPreparedStatement {
+            static let name = "INSERT-AsyncTestPreparedStatementTestTable"
+
+            static let sql = #"INSERT INTO "\#(AsyncPostgresConnectionTests.preparedStatementTestTable)" (uuid) VALUES ($1);"#
+            typealias Row = ()
+
+            var uuid: UUID
+
+            func makeBindings() -> PostgresBindings {
+                var bindings = PostgresBindings()
+                bindings.append(self.uuid)
+                return bindings
+            }
+
+            func decodeRow(_ row: PostgresNIO.PostgresRow) throws -> Row {
+                ()
+            }
+        }
+
+        struct SelectPreparedStatement: PostgresPreparedStatement {
+            static let name = "SELECT-AsyncTestPreparedStatementTestTable"
+
+            static let sql = #"SELECT id, uuid FROM "\#(AsyncPostgresConnectionTests.preparedStatementTestTable)" WHERE id <= $1;"#
+            typealias Row = (Int, UUID)
+
+            var id: Int
+
+            func makeBindings() -> PostgresBindings {
+                var bindings = PostgresBindings()
+                bindings.append(self.id)
+                return bindings
+            }
+
+            func decodeRow(_ row: PostgresNIO.PostgresRow) throws -> Row {
+                try row.decode((Int, UUID).self)
+            }
+        }
+
+        do {
+            try await withTestConnection(on: eventLoop) { connection in
+                try await connection.query("""
+                    CREATE TABLE IF NOT EXISTS "\(unescaped: Self.preparedStatementTestTable)" (
+                        id SERIAL PRIMARY KEY,
+                        uuid UUID NOT NULL
+                    )
+                    """,
+                    logger: .psqlTest
+                )
+
+                _ = try await connection.execute(InsertPreparedStatement(uuid: .init()), logger: .psqlTest)
+                _ = try await connection.execute(InsertPreparedStatement(uuid: .init()), logger: .psqlTest)
+                _ = try await connection.execute(InsertPreparedStatement(uuid: .init()), logger: .psqlTest)
+                _ = try await connection.execute(InsertPreparedStatement(uuid: .init()), logger: .psqlTest)
+                _ = try await connection.execute(InsertPreparedStatement(uuid: .init()), logger: .psqlTest)
+
+                let rows = try await connection.execute(SelectPreparedStatement(id: 3), logger: .psqlTest)
+                var counter = 0
+                for try await (id, uuid) in rows {
+                    Logger.psqlTest.info("Received row", metadata: [
+                        "id": "\(id)", "uuid": "\(uuid)"
+                    ])
+                    counter += 1
+                }
+
+                try await connection.query("""
+                    DROP TABLE "\(unescaped: Self.preparedStatementTestTable)";
+                    """,
+                    logger: .psqlTest
+                )
+            }
+        } catch {
+            XCTFail("Unexpected error: \(String(describing: error))")
+        }
+    }
 }
 
 extension XCTestCase {

--- a/Tests/PostgresNIOTests/New/Connection State Machine/PrepareStatementStateMachineTests.swift
+++ b/Tests/PostgresNIOTests/New/Connection State Machine/PrepareStatementStateMachineTests.swift
@@ -12,11 +12,11 @@ class PrepareStatementStateMachineTests: XCTestCase {
         let name = "haha"
         let query = #"SELECT id FROM users WHERE id = $1 "#
         let prepareStatementContext = ExtendedQueryContext(
-            name: name, query: query, logger: .psqlTest, promise: promise
+            name: name, query: query, bindingDataTypes: [], logger: .psqlTest, promise: promise
         )
 
         XCTAssertEqual(state.enqueue(task: .extendedQuery(prepareStatementContext)),
-                       .sendParseDescribeSync(name: name, query: query))
+                       .sendParseDescribeSync(name: name, query: query, bindingDataTypes: []))
         XCTAssertEqual(state.parseCompleteReceived(), .wait)
         XCTAssertEqual(state.parameterDescriptionReceived(.init(dataTypes: [.int8])), .wait)
         
@@ -38,11 +38,11 @@ class PrepareStatementStateMachineTests: XCTestCase {
         let name = "haha"
         let query = #"DELETE FROM users WHERE id = $1 "#
         let prepareStatementContext = ExtendedQueryContext(
-            name: name, query: query, logger: .psqlTest, promise: promise
+            name: name, query: query, bindingDataTypes: [], logger: .psqlTest, promise: promise
         )
 
         XCTAssertEqual(state.enqueue(task: .extendedQuery(prepareStatementContext)),
-                       .sendParseDescribeSync(name: name, query: query))
+                       .sendParseDescribeSync(name: name, query: query, bindingDataTypes: []))
         XCTAssertEqual(state.parseCompleteReceived(), .wait)
         XCTAssertEqual(state.parameterDescriptionReceived(.init(dataTypes: [.int8])), .wait)
         
@@ -60,11 +60,11 @@ class PrepareStatementStateMachineTests: XCTestCase {
         let name = "haha"
         let query = #"DELETE FROM users WHERE id = $1 "#
         let prepareStatementContext = ExtendedQueryContext(
-            name: name, query: query, logger: .psqlTest, promise: promise
+            name: name, query: query, bindingDataTypes: [], logger: .psqlTest, promise: promise
         )
 
         XCTAssertEqual(state.enqueue(task: .extendedQuery(prepareStatementContext)),
-                       .sendParseDescribeSync(name: name, query: query))
+                       .sendParseDescribeSync(name: name, query: query, bindingDataTypes: []))
         XCTAssertEqual(state.parseCompleteReceived(), .wait)
         XCTAssertEqual(state.parameterDescriptionReceived(.init(dataTypes: [.int8])), .wait)
 

--- a/Tests/PostgresNIOTests/New/Connection State Machine/PreparedStatementStateMachineTests.swift
+++ b/Tests/PostgresNIOTests/New/Connection State Machine/PreparedStatementStateMachineTests.swift
@@ -152,6 +152,7 @@ class PreparedStatementStateMachineTests: XCTestCase {
             name: "test",
             sql: "INSERT INTO test_table (column1) VALUES (1)",
             bindings: PostgresBindings(),
+            bindingDataTypes: [],
             logger: .psqlTest,
             promise: promise
         )

--- a/Tests/PostgresNIOTests/New/Extensions/ConnectionAction+TestUtils.swift
+++ b/Tests/PostgresNIOTests/New/Extensions/ConnectionAction+TestUtils.swift
@@ -36,8 +36,8 @@ extension PostgresNIO.ConnectionStateMachine.ConnectionAction: Swift.Equatable {
             return lhsBuffer == rhsBuffer && lhsCommandTag == rhsCommandTag
         case (.forwardStreamError(let lhsError, let lhsRead, let lhsCleanupContext), .forwardStreamError(let rhsError , let rhsRead, let rhsCleanupContext)):
             return lhsError == rhsError && lhsRead == rhsRead && lhsCleanupContext == rhsCleanupContext
-        case (.sendParseDescribeSync(let lhsName, let lhsQuery), .sendParseDescribeSync(let rhsName, let rhsQuery)):
-            return lhsName == rhsName && lhsQuery == rhsQuery
+        case (.sendParseDescribeSync(let lhsName, let lhsQuery, let lhsDataTypes), .sendParseDescribeSync(let rhsName, let rhsQuery, let rhsDataTypes)):
+            return lhsName == rhsName && lhsQuery == rhsQuery && lhsDataTypes == rhsDataTypes
         case (.succeedPreparedStatementCreation(let lhsPromise, let lhsRowDescription), .succeedPreparedStatementCreation(let rhsPromise, let rhsRowDescription)):
             return lhsPromise.futureResult === rhsPromise.futureResult && lhsRowDescription == rhsRowDescription
         case (.fireChannelInactive, .fireChannelInactive):

--- a/Tests/PostgresNIOTests/New/PostgresConnectionTests.swift
+++ b/Tests/PostgresNIOTests/New/PostgresConnectionTests.swift
@@ -337,7 +337,7 @@ class PostgresConnectionTests: XCTestCase {
 
             let prepareRequest = try await channel.waitForPrepareRequest()
             XCTAssertEqual(prepareRequest.parse.query, "SELECT datname FROM pg_stat_activity WHERE state = $1")
-            XCTAssertEqual(prepareRequest.parse.parameters.count, 0)
+            XCTAssertEqual(prepareRequest.parse.parameters.first, .text)
             guard case .preparedStatement(let name) = prepareRequest.describe else {
                 fatalError("Describe should contain a prepared statement")
             }
@@ -393,7 +393,7 @@ class PostgresConnectionTests: XCTestCase {
 
             let prepareRequest = try await channel.waitForPrepareRequest()
             XCTAssertEqual(prepareRequest.parse.query, "SELECT datname FROM pg_stat_activity WHERE state = $1")
-            XCTAssertEqual(prepareRequest.parse.parameters.count, 0)
+            XCTAssertEqual(prepareRequest.parse.parameters.first, .text)
             guard case .preparedStatement(let name) = prepareRequest.describe else {
                 fatalError("Describe should contain a prepared statement")
             }
@@ -487,7 +487,7 @@ class PostgresConnectionTests: XCTestCase {
             // The channel deduplicates prepare requests, we're going to see only one of them
             let prepareRequest = try await channel.waitForPrepareRequest()
             XCTAssertEqual(prepareRequest.parse.query, "SELECT datname FROM pg_stat_activity WHERE state = $1")
-            XCTAssertEqual(prepareRequest.parse.parameters.count, 0)
+            XCTAssertEqual(prepareRequest.parse.parameters.first, .text)
             guard case .preparedStatement(let name) = prepareRequest.describe else {
                 fatalError("Describe should contain a prepared statement")
             }
@@ -555,7 +555,7 @@ class PostgresConnectionTests: XCTestCase {
 
             let prepareRequest = try await channel.waitForPrepareRequest()
             XCTAssertEqual(prepareRequest.parse.query, "SELECT datname FROM pg_stat_activity WHERE state = $1")
-            XCTAssertEqual(prepareRequest.parse.parameters.count, 0)
+            XCTAssertEqual(prepareRequest.parse.parameters.first, .text)
             guard case .preparedStatement(let name) = prepareRequest.describe else {
                 fatalError("Describe should contain a prepared statement")
             }


### PR DESCRIPTION
### Motivation

Currently Prepared Statements only work if they only use bindings that have the `PostgresDataType` `text`. The reason for this is that `text` has the same representation in `text` and `binary` form. For this reason Postgres does not need to know the datatype upfront.

### Changes

- Allow users to specify the bindings datatypes explicitly. Fallback to unspecified.
- If binding datatypes are unspecified infer them from the first provided bindings
- Allow users to override the prepared statement name
- Add integration test that validates the behavior