### PR TITLE
Fixes `LISTEN` to quote channel name

### DIFF
--- a/Sources/PostgresNIO/New/PostgresChannelHandler.swift
+++ b/Sources/PostgresNIO/New/PostgresChannelHandler.swift
@@ -594,7 +594,7 @@ final class PostgresChannelHandler: ChannelDuplexHandler {
     private func makeStartListeningQuery(channel: String, context: ChannelHandlerContext) -> PSQLTask {
         let promise = context.eventLoop.makePromise(of: PSQLRowStream.self)
         let query = ExtendedQueryContext(
-            query: PostgresQuery(unsafeSQL: "LISTEN \(channel);"),
+            query: PostgresQuery(unsafeSQL: #"LISTEN "\#(channel)";"#),
             logger: self.logger,
             promise: promise
         )
@@ -642,7 +642,7 @@ final class PostgresChannelHandler: ChannelDuplexHandler {
     private func makeUnlistenQuery(channel: String, context: ChannelHandlerContext) -> PSQLTask {
         let promise = context.eventLoop.makePromise(of: PSQLRowStream.self)
         let query = ExtendedQueryContext(
-            query: PostgresQuery(unsafeSQL: "UNLISTEN \(channel);"),
+            query: PostgresQuery(unsafeSQL: #"UNLISTEN "\#(channel)";"#),
             logger: self.logger,
             promise: promise
         )

--- a/Tests/PostgresNIOTests/New/PostgresConnectionTests.swift
+++ b/Tests/PostgresNIOTests/New/PostgresConnectionTests.swift
@@ -51,7 +51,7 @@ class PostgresConnectionTests: XCTestCase {
             }
 
             let listenMessage = try await channel.waitForUnpreparedRequest()
-            XCTAssertEqual(listenMessage.parse.query, "LISTEN foo;")
+            XCTAssertEqual(listenMessage.parse.query, #"LISTEN "foo";"#)
 
             try await channel.writeInbound(PostgresBackendMessage.parseComplete)
             try await channel.writeInbound(PostgresBackendMessage.parameterDescription(.init(dataTypes: [])))
@@ -63,7 +63,7 @@ class PostgresConnectionTests: XCTestCase {
             try await channel.writeInbound(PostgresBackendMessage.notification(.init(backendPID: 12, channel: "foo", payload: "wooohooo")))
 
             let unlistenMessage = try await channel.waitForUnpreparedRequest()
-            XCTAssertEqual(unlistenMessage.parse.query, "UNLISTEN foo;")
+            XCTAssertEqual(unlistenMessage.parse.query, #"UNLISTEN "foo";"#)
 
             try await channel.writeInbound(PostgresBackendMessage.parseComplete)
             try await channel.writeInbound(PostgresBackendMessage.parameterDescription(.init(dataTypes: [])))
@@ -111,7 +111,7 @@ class PostgresConnectionTests: XCTestCase {
             }
 
             let listenMessage = try await channel.waitForUnpreparedRequest()
-            XCTAssertEqual(listenMessage.parse.query, "LISTEN foo;")
+            XCTAssertEqual(listenMessage.parse.query, #"LISTEN "foo";"#)
 
             try await channel.writeInbound(PostgresBackendMessage.parseComplete)
             try await channel.writeInbound(PostgresBackendMessage.parameterDescription(.init(dataTypes: [])))
@@ -124,7 +124,7 @@ class PostgresConnectionTests: XCTestCase {
             try await channel.writeInbound(PostgresBackendMessage.notification(.init(backendPID: 12, channel: "foo", payload: "wooohooo2")))
 
             let unlistenMessage = try await channel.waitForUnpreparedRequest()
-            XCTAssertEqual(unlistenMessage.parse.query, "UNLISTEN foo;")
+            XCTAssertEqual(unlistenMessage.parse.query, #"UNLISTEN "foo";"#)
 
             try await channel.writeInbound(PostgresBackendMessage.parseComplete)
             try await channel.writeInbound(PostgresBackendMessage.parameterDescription(.init(dataTypes: [])))
@@ -160,7 +160,7 @@ class PostgresConnectionTests: XCTestCase {
             }
 
             let listenMessage = try await channel.waitForUnpreparedRequest()
-            XCTAssertEqual(listenMessage.parse.query, "LISTEN foo;")
+            XCTAssertEqual(listenMessage.parse.query, #"LISTEN "foo";"#)
 
             try await channel.writeInbound(PostgresBackendMessage.parseComplete)
             try await channel.writeInbound(PostgresBackendMessage.parameterDescription(.init(dataTypes: [])))


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->

This adjusts the SQL `LISTEN` statement called by `PostgresConnection.addListener` to quote the channel name.

For example, previously `addListener("abc")` would run `LISTEN abc;` and it will now run `LISTEN "abc";`

As far as I can tell, this only matters when the channel name is a reserved Postgres keyword, like `default`.

<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
