### PR TITLE
[CI] Use Ubuntu 24.04 image, more code coverage, disable CodeQL completely

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,12 +21,9 @@ jobs:
           - swift:5.7-jammy
           - swift:5.8-jammy
           - swift:5.9-jammy
-          - swift:5.10-jammy
+          - swift:5.10-noble
           - swiftlang/swift:nightly-6.0-jammy
           - swiftlang/swift:nightly-main-jammy
-        include:
-          - swift-image: swift:5.10-jammy
-            code-coverage: true
     container: ${{ matrix.swift-image }}
     runs-on: ubuntu-latest
     steps:
@@ -40,12 +37,9 @@ jobs:
       - name: Check out package
         uses: actions/checkout@v4
       - name: Run unit tests with Thread Sanitizer
-        env:
-          CODE_COVERAGE: ${{ matrix.code-coverage && '--enable-code-coverage' || '' }}
         run: |
-          swift test --filter='^(PostgresNIOTests|ConnectionPoolModuleTests)' --sanitize=thread ${CODE_COVERAGE}
+          swift test --filter='^(PostgresNIOTests|ConnectionPoolModuleTests)' --sanitize=thread --enable-code-coverage
       - name: Submit code coverage
-        if: ${{ matrix.code-coverage }}
         uses: vapor/swift-codecov-action@v0.3
         with:
           codecov_token: ${{ secrets.CODECOV_TOKEN }}
@@ -66,7 +60,7 @@ jobs:
           - postgres-image: postgres:12
             postgres-auth: trust
     container:
-      image: swift:5.10-jammy
+      image: swift:5.10-noble
       volumes: [ 'pgrunshare:/var/run/postgresql' ]
     runs-on: ubuntu-latest
     env:
@@ -183,7 +177,7 @@ jobs:
   api-breakage:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    container: swift:jammy
+    container: swift:noble
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -195,21 +189,21 @@ jobs:
           git config --global --add safe.directory "${GITHUB_WORKSPACE}"
           swift package diagnose-api-breaking-changes origin/main
 
-  gh-codeql:
-    if: ${{ false }}
-    runs-on: ubuntu-latest
-    container: swift:jammy
-    permissions: { actions: write, contents: read, security-events: write }
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v4
-      - name: Mark repo safe in non-fake global config
-        run: git config --global --add safe.directory "${GITHUB_WORKSPACE}"
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
-        with:
-          languages: swift
-      - name: Perform build
-        run: swift build
-      - name: Run CodeQL analyze
-        uses: github/codeql-action/analyze@v3
+#  gh-codeql:
+#    if: ${{ false }}
+#    runs-on: ubuntu-latest
+#    container: swift:noble
+#    permissions: { actions: write, contents: read, security-events: write }
+#    steps:
+#      - name: Check out code
+#        uses: actions/checkout@v4
+#      - name: Mark repo safe in non-fake global config
+#        run: git config --global --add safe.directory "${GITHUB_WORKSPACE}"
+#      - name: Initialize CodeQL
+#        uses: github/codeql-action/init@v3
+#        with:
+#          languages: swift
+#      - name: Perform build
+#        run: swift build
+#      - name: Run CodeQL analyze
+#        uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
- When running Swift 5.10 images, use the Ubuntu 24.04 "Noble Numbat" image.
- Upload code coverage for all Linux test runs, not just 5.10's; Codecov intelligently merges results. This makes coverage numbers more accurate.
- Comment out the CodeQL job altogether rather than just skipping it so it doesn't clutter the Github UI.