### PR TITLE
Drop support for Swift 5.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,6 @@ jobs:
       fail-fast: false
       matrix:
         swift-image:
-          - swift:5.7-jammy
           - swift:5.8-jammy
           - swift:5.9-jammy
           - swift:5.10-noble

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.7
+// swift-tools-version:5.8
 import PackageDescription
 
 let package = Package(


### PR DESCRIPTION
To land #484, we must drop support for Swift 5.7.