### PR TITLE
Handle `EmptyQueryResponse`

### DIFF
--- a/Sources/PostgresNIO/New/Connection State Machine/ExtendedQueryStateMachine.swift
+++ b/Sources/PostgresNIO/New/Connection State Machine/ExtendedQueryStateMachine.swift
@@ -288,7 +288,7 @@ struct ExtendedQueryStateMachine {
             case .unnamed(_, let eventLoopPromise), .executeStatement(_, let eventLoopPromise):
                 return self.avoidingStateMachineCoW { state -> Action in
                     state = .commandComplete(commandTag: commandTag)
-                    let result = QueryResult(value: .noRows(commandTag), logger: context.logger)
+                    let result = QueryResult(value: .noRows(.tag(commandTag)), logger: context.logger)
                     return .succeedQuery(eventLoopPromise, with: result)
                 }
 
@@ -332,7 +332,7 @@ struct ExtendedQueryStateMachine {
              .executeStatement(_, let eventLoopPromise):
             return self.avoidingStateMachineCoW { state -> Action in
                 state = .emptyQueryResponseReceived
-                let result = QueryResult(value: .emptyResponse, logger: queryContext.logger)
+                let result = QueryResult(value: .noRows(.emptyResponse), logger: queryContext.logger)
                 return .succeedQuery(eventLoopPromise, with: result)
             }
 

--- a/Sources/PostgresNIO/New/Connection State Machine/ExtendedQueryStateMachine.swift
+++ b/Sources/PostgresNIO/New/Connection State Machine/ExtendedQueryStateMachine.swift
@@ -10,7 +10,8 @@ struct ExtendedQueryStateMachine {
         case parameterDescriptionReceived(ExtendedQueryContext)
         case rowDescriptionReceived(ExtendedQueryContext, [RowDescription.Column])
         case noDataMessageReceived(ExtendedQueryContext)
-        
+        case emptyQueryResponseReceived
+
         /// A state that is used if a noData message was received before. If a row description was received `bufferingRows` is
         /// used after receiving a `bindComplete` message
         case bindCompleteReceived(ExtendedQueryContext)
@@ -122,7 +123,7 @@ struct ExtendedQueryStateMachine {
                 return .forwardStreamError(.queryCancelled, read: true)
             }
 
-        case .commandComplete, .error, .drain:
+        case .commandComplete, .emptyQueryResponseReceived, .error, .drain:
             // the stream has already finished.
             return .wait
 
@@ -229,6 +230,7 @@ struct ExtendedQueryStateMachine {
              .messagesSent,
              .parseCompleteReceived,
              .parameterDescriptionReceived,
+             .emptyQueryResponseReceived,
              .bindCompleteReceived,
              .streaming,
              .drain,
@@ -268,6 +270,7 @@ struct ExtendedQueryStateMachine {
              .parseCompleteReceived,
              .parameterDescriptionReceived,
              .noDataMessageReceived,
+             .emptyQueryResponseReceived,
              .rowDescriptionReceived,
              .bindCompleteReceived,
              .commandComplete,
@@ -309,6 +312,7 @@ struct ExtendedQueryStateMachine {
              .parseCompleteReceived,
              .parameterDescriptionReceived,
              .noDataMessageReceived,
+             .emptyQueryResponseReceived,
              .rowDescriptionReceived,
              .commandComplete,
              .error:
@@ -319,7 +323,22 @@ struct ExtendedQueryStateMachine {
     }
     
     mutating func emptyQueryResponseReceived() -> Action {
-        preconditionFailure("Unimplemented")
+        guard case .bindCompleteReceived(let queryContext) = self.state else {
+            return self.setAndFireError(.unexpectedBackendMessage(.emptyQueryResponse))
+        }
+
+        switch queryContext.query {
+        case .unnamed(_, let eventLoopPromise),
+             .executeStatement(_, let eventLoopPromise):
+            return self.avoidingStateMachineCoW { state -> Action in
+                state = .emptyQueryResponseReceived
+                let result = QueryResult(value: .emptyResponse, logger: queryContext.logger)
+                return .succeedQuery(eventLoopPromise, with: result)
+            }
+
+        case .prepareStatement(_, _, _, _):
+            return self.setAndFireError(.unexpectedBackendMessage(.emptyQueryResponse))
+        }
     }
     
     mutating func errorReceived(_ errorMessage: PostgresBackendMessage.ErrorResponse) -> Action {
@@ -336,7 +355,7 @@ struct ExtendedQueryStateMachine {
             return self.setAndFireError(error)
         case .streaming, .drain:
             return self.setAndFireError(error)
-        case .commandComplete:
+        case .commandComplete, .emptyQueryResponseReceived:
             return self.setAndFireError(.unexpectedBackendMessage(.error(errorMessage)))
         case .error:
             preconditionFailure("""
@@ -382,6 +401,7 @@ struct ExtendedQueryStateMachine {
              .parseCompleteReceived,
              .parameterDescriptionReceived,
              .noDataMessageReceived,
+             .emptyQueryResponseReceived,
              .rowDescriptionReceived,
              .bindCompleteReceived:
             preconditionFailure("Requested to consume next row without anything going on.")
@@ -405,6 +425,7 @@ struct ExtendedQueryStateMachine {
              .parseCompleteReceived,
              .parameterDescriptionReceived,
              .noDataMessageReceived,
+             .emptyQueryResponseReceived,
              .rowDescriptionReceived,
              .bindCompleteReceived:
             return .wait
@@ -449,6 +470,7 @@ struct ExtendedQueryStateMachine {
             }
         case .initialized,
              .commandComplete,
+             .emptyQueryResponseReceived,
              .drain,
              .error:
             // we already have the complete stream received, now we are waiting for a
@@ -495,7 +517,7 @@ struct ExtendedQueryStateMachine {
                 return .forwardStreamError(error, read: true)
             }
             
-        case .commandComplete, .error:
+        case .commandComplete, .emptyQueryResponseReceived, .error:
             preconditionFailure("""
                 This state must not be reached. If the query `.isComplete`, the
                 ConnectionStateMachine must not send any further events to the substate machine.
@@ -517,6 +539,9 @@ struct ExtendedQueryStateMachine {
             case .unnamed, .executeStatement:
                 return false
             }
+
+        case .emptyQueryResponseReceived:
+            return true
 
         case .initialized, .messagesSent, .parseCompleteReceived, .parameterDescriptionReceived, .bindCompleteReceived, .streaming, .drain:
             return false

--- a/Sources/PostgresNIO/New/Connection State Machine/ExtendedQueryStateMachine.swift
+++ b/Sources/PostgresNIO/New/Connection State Machine/ExtendedQueryStateMachine.swift
@@ -529,7 +529,7 @@ struct ExtendedQueryStateMachine {
     
     var isComplete: Bool {
         switch self.state {
-        case .commandComplete, .error:
+        case .commandComplete, .emptyQueryResponseReceived, .error:
             return true
 
         case .noDataMessageReceived(let context), .rowDescriptionReceived(let context, _):
@@ -539,9 +539,6 @@ struct ExtendedQueryStateMachine {
             case .unnamed, .executeStatement:
                 return false
             }
-
-        case .emptyQueryResponseReceived:
-            return true
 
         case .initialized, .messagesSent, .parseCompleteReceived, .parameterDescriptionReceived, .bindCompleteReceived, .streaming, .drain:
             return false

--- a/Sources/PostgresNIO/New/PostgresChannelHandler.swift
+++ b/Sources/PostgresNIO/New/PostgresChannelHandler.swift
@@ -556,6 +556,13 @@ final class PostgresChannelHandler: ChannelDuplexHandler {
                 eventLoop: context.channel.eventLoop,
                 logger: result.logger
             )
+
+        case .emptyResponse:
+            rows = PSQLRowStream(
+                source: .emptyResponse,
+                eventLoop: context.channel.eventLoop,
+                logger: result.logger
+            )
         }
 
         promise.succeed(rows)

--- a/Sources/PostgresNIO/New/PostgresChannelHandler.swift
+++ b/Sources/PostgresNIO/New/PostgresChannelHandler.swift
@@ -550,16 +550,9 @@ final class PostgresChannelHandler: ChannelDuplexHandler {
             )
             self.rowStream = rows
 
-        case .noRows(let commandTag):
+        case .noRows(let summary):
             rows = PSQLRowStream(
-                source: .noRows(.success(commandTag)),
-                eventLoop: context.channel.eventLoop,
-                logger: result.logger
-            )
-
-        case .emptyResponse:
-            rows = PSQLRowStream(
-                source: .emptyResponse,
+                source: .noRows(.success(summary)),
                 eventLoop: context.channel.eventLoop,
                 logger: result.logger
             )

--- a/Sources/PostgresNIO/PostgresDatabase+Query.swift
+++ b/Sources/PostgresNIO/PostgresDatabase+Query.swift
@@ -73,10 +73,7 @@ public struct PostgresQueryMetadata: Sendable {
 
     init?(string: String) {
         let parts = string.split(separator: " ")
-        guard parts.count >= 1 else {
-            return nil
-        }
-        switch parts[0] {
+        switch parts.first {
         case "INSERT":
             // INSERT oid rows
             guard parts.count == 3 else {

--- a/Tests/IntegrationTests/PSQLIntegrationTests.swift
+++ b/Tests/IntegrationTests/PSQLIntegrationTests.swift
@@ -123,6 +123,25 @@ final class IntegrationTests: XCTestCase {
         XCTAssertEqual(foo, "hello")
     }
 
+    func testQueryNothing() throws {
+        let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully()) }
+        let eventLoop = eventLoopGroup.next()
+
+        var conn: PostgresConnection?
+        XCTAssertNoThrow(conn = try PostgresConnection.test(on: eventLoop).wait())
+        defer { XCTAssertNoThrow(try conn?.close().wait()) }
+
+        var _result: PostgresQueryResult?
+        XCTAssertNoThrow(_result = try conn?.query("""
+            -- Some comments
+            """, logger: .psqlTest).wait())
+
+        let result = try XCTUnwrap(_result)
+        XCTAssertEqual(result.rows, [])
+        XCTAssertEqual(result.metadata.command, "")
+    }
+
     func testDecodeIntegers() {
         let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully()) }

--- a/Tests/PostgresNIOTests/New/Connection State Machine/ExtendedQueryStateMachineTests.swift
+++ b/Tests/PostgresNIOTests/New/Connection State Machine/ExtendedQueryStateMachineTests.swift
@@ -20,7 +20,7 @@ class ExtendedQueryStateMachineTests: XCTestCase {
         XCTAssertEqual(state.parameterDescriptionReceived(.init(dataTypes: [.int8])), .wait)
         XCTAssertEqual(state.noDataReceived(), .wait)
         XCTAssertEqual(state.bindCompleteReceived(), .wait)
-        XCTAssertEqual(state.commandCompletedReceived("DELETE 1"), .succeedQuery(promise, with: .init(value: .noRows("DELETE 1"), logger: logger)))
+        XCTAssertEqual(state.commandCompletedReceived("DELETE 1"), .succeedQuery(promise, with: .init(value: .noRows(.tag("DELETE 1")), logger: logger)))
         XCTAssertEqual(state.readyForQueryReceived(.idle), .fireEventReadyForQuery)
     }
     
@@ -92,7 +92,7 @@ class ExtendedQueryStateMachineTests: XCTestCase {
         XCTAssertEqual(state.parameterDescriptionReceived(.init(dataTypes: [.int8])), .wait)
         XCTAssertEqual(state.noDataReceived(), .wait)
         XCTAssertEqual(state.bindCompleteReceived(), .wait)
-        XCTAssertEqual(state.emptyQueryResponseReceived(), .succeedQuery(promise, with: .init(value: .emptyResponse, logger: logger)))
+        XCTAssertEqual(state.emptyQueryResponseReceived(), .succeedQuery(promise, with: .init(value: .noRows(.emptyResponse), logger: logger)))
         XCTAssertEqual(state.readyForQueryReceived(.idle), .fireEventReadyForQuery)
     }
 

--- a/Tests/PostgresNIOTests/New/Connection State Machine/ExtendedQueryStateMachineTests.swift
+++ b/Tests/PostgresNIOTests/New/Connection State Machine/ExtendedQueryStateMachineTests.swift
@@ -77,7 +77,25 @@ class ExtendedQueryStateMachineTests: XCTestCase {
         XCTAssertEqual(state.commandCompletedReceived("SELECT 2"), .forwardStreamComplete([row5, row6], commandTag: "SELECT 2"))
         XCTAssertEqual(state.readyForQueryReceived(.idle), .fireEventReadyForQuery)
     }
-    
+
+    func testExtendedQueryWithNoQuery() {
+        var state = ConnectionStateMachine.readyForQuery()
+
+        let logger = Logger.psqlTest
+        let promise = EmbeddedEventLoop().makePromise(of: PSQLRowStream.self)
+        promise.fail(PSQLError.uncleanShutdown) // we don't care about the error at all.
+        let query: PostgresQuery = "-- some comments"
+        let queryContext = ExtendedQueryContext(query: query, logger: logger, promise: promise)
+
+        XCTAssertEqual(state.enqueue(task: .extendedQuery(queryContext)), .sendParseDescribeBindExecuteSync(query))
+        XCTAssertEqual(state.parseCompleteReceived(), .wait)
+        XCTAssertEqual(state.parameterDescriptionReceived(.init(dataTypes: [.int8])), .wait)
+        XCTAssertEqual(state.noDataReceived(), .wait)
+        XCTAssertEqual(state.bindCompleteReceived(), .wait)
+        XCTAssertEqual(state.emptyQueryResponseReceived(), .succeedQuery(promise, with: .init(value: .emptyResponse, logger: logger)))
+        XCTAssertEqual(state.readyForQueryReceived(.idle), .fireEventReadyForQuery)
+    }
+
     func testReceiveTotallyUnexpectedMessageInQuery() {
         var state = ConnectionStateMachine.readyForQuery()
         

--- a/Tests/PostgresNIOTests/New/Connection State Machine/PreparedStatementStateMachineTests.swift
+++ b/Tests/PostgresNIOTests/New/Connection State Machine/PreparedStatementStateMachineTests.swift
@@ -28,7 +28,7 @@ class PreparedStatementStateMachineTests: XCTestCase {
         XCTAssertEqual(preparationCompleteAction.statements.count, 1)
         XCTAssertNil(preparationCompleteAction.rowDescription)
         firstPreparedStatement.promise.succeed(PSQLRowStream(
-            source: .noRows(.success("tag")),
+            source: .noRows(.success(.tag("tag"))),
             eventLoop: eventLoop,
             logger: .psqlTest
         ))
@@ -46,7 +46,7 @@ class PreparedStatementStateMachineTests: XCTestCase {
             return
         }
         secondPreparedStatement.promise.succeed(PSQLRowStream(
-            source: .noRows(.success("tag")),
+            source: .noRows(.success(.tag("tag"))),
             eventLoop: eventLoop,
             logger: .psqlTest
         ))
@@ -135,12 +135,12 @@ class PreparedStatementStateMachineTests: XCTestCase {
         XCTAssertNil(preparationCompleteAction.rowDescription)
 
         firstPreparedStatement.promise.succeed(PSQLRowStream(
-            source: .noRows(.success("tag")),
+            source: .noRows(.success(.tag("tag"))),
             eventLoop: eventLoop,
             logger: .psqlTest
         ))
         secondPreparedStatement.promise.succeed(PSQLRowStream(
-            source: .noRows(.success("tag")),
+            source: .noRows(.success(.tag("tag"))),
             eventLoop: eventLoop,
             logger: .psqlTest
         ))

--- a/Tests/PostgresNIOTests/New/PSQLRowStreamTests.swift
+++ b/Tests/PostgresNIOTests/New/PSQLRowStreamTests.swift
@@ -12,7 +12,7 @@ final class PSQLRowStreamTests: XCTestCase {
 
     func testEmptyStream() {
         let stream = PSQLRowStream(
-            source: .noRows(.success("INSERT 0 1")),
+            source: .noRows(.success(.tag("INSERT 0 1"))),
             eventLoop: self.eventLoop,
             logger: self.logger
         )


### PR DESCRIPTION
resolves #488.