### PR TITLE
Fix cross-compilation to the static Linux SDK

### DIFF
--- a/Sources/ConnectionPoolModule/PoolStateMachine.swift
+++ b/Sources/ConnectionPoolModule/PoolStateMachine.swift
@@ -1,7 +1,9 @@
 #if canImport(Darwin)
 import Darwin
-#else
+#elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #endif
 
 @usableFromInline


### PR DESCRIPTION
When cross-compiling a Vapor app with the Swift Static Linux SDK, postgres-nio will throw `error: no such module 'Glibc'`. This fix imports `Musl` instead of `Glibc` when it is available to fix cross-compilation.

Note: given other errors with the Static Linux SDK and Swift toolchain, you'll need to run at least the `swift-6.0-DEVELOPMENT-SNAPSHOT-2024-09-17-a` Swift development toolchain and corresponding Linux SDK. Also, there's an unreleased fix in swift-nio, so it's recommended to run at least the `1b33db2dea6a64d5b619b9e888175133c6d7f410` revision of the package when cross-compiling.