### PR TITLE
Allow TLS enabled connections when providing an established channel

### DIFF
--- a/Sources/PostgresNIO/Connection/PostgresConnection+Configuration.swift
+++ b/Sources/PostgresNIO/Connection/PostgresConnection+Configuration.swift
@@ -193,8 +193,8 @@ extension PostgresConnection {
         ///   - channel: The `NIOCore/Channel` to use. The channel must already be active and connected to an
         ///     endpoint (i.e. `NIOCore/Channel/isActive` must be `true`).
         ///   - tls: The TLS mode to use. Defaults to ``TLS-swift.struct/disable``.
-        public init(establishedChannel channel: Channel, username: String, password: String?, database: String?) {
-            self.init(endpointInfo: .configureChannel(channel), tls: .disable, username: username, password: password, database: database)
+        public init(establishedChannel channel: Channel, tls: PostgresConnection.Configuration.TLS = .disable, username: String, password: String?, database: String?) {
+            self.init(endpointInfo: .configureChannel(channel), tls: tls, username: username, password: password, database: database)
         }
 
         // MARK: - Implementation details

--- a/Sources/PostgresNIO/Connection/PostgresConnection+Configuration.swift
+++ b/Sources/PostgresNIO/Connection/PostgresConnection+Configuration.swift
@@ -192,9 +192,22 @@ extension PostgresConnection {
         /// - Parameters:
         ///   - channel: The `NIOCore/Channel` to use. The channel must already be active and connected to an
         ///     endpoint (i.e. `NIOCore/Channel/isActive` must be `true`).
-        ///   - tls: The TLS mode to use. Defaults to ``TLS-swift.struct/disable``.
-        public init(establishedChannel channel: Channel, tls: PostgresConnection.Configuration.TLS = .disable, username: String, password: String?, database: String?) {
+        ///   - tls: The TLS mode to use.
+        public init(establishedChannel channel: Channel, tls: PostgresConnection.Configuration.TLS, username: String, password: String?, database: String?) {
             self.init(endpointInfo: .configureChannel(channel), tls: tls, username: username, password: password, database: database)
+        }
+        
+        /// Create a configuration for establishing a connection to a Postgres server over a preestablished
+        /// `NIOCore/Channel`.
+        ///
+        /// This is provided for calling code which wants to manage the underlying connection transport on its
+        /// own, such as when tunneling a connection through SSH.
+        ///
+        /// - Parameters:
+        ///   - channel: The `NIOCore/Channel` to use. The channel must already be active and connected to an
+        ///     endpoint (i.e. `NIOCore/Channel/isActive` must be `true`).
+        public init(establishedChannel channel: Channel, username: String, password: String?, database: String?) {
+            self.init(establishedChannel: channel, tls: .disable, username: username, password: password, database: database)
         }
 
         // MARK: - Implementation details


### PR DESCRIPTION
When connecting through an established channel (e.g. an SSH tunnel) it can still be useful to allow postgres to connect using TLS. This PR exposes the tls parameter on the connection method for using an established channel.