### PR TITLE
Update DocC settings to latest version of Vapor theme

### DIFF
--- a/Sources/PostgresNIO/Docs.docc/theme-settings.json
+++ b/Sources/PostgresNIO/Docs.docc/theme-settings.json
@@ -1,16 +1,19 @@
 {
   "theme": {
-    "aside": { "border-radius": "6px", "border-style": "double", "border-width": "3px" },
+    "aside": { "border-radius": "16px", "border-style": "double", "border-width": "3px" },
     "border-radius": "0",
     "button": { "border-radius": "16px", "border-width": "1px", "border-style": "solid" },
     "code":   { "border-radius": "16px", "border-width": "1px", "border-style": "solid" },
     "color": {
+      "fill": { "dark": "#000", "light": "#fff" }
       "psqlnio": "#336791",
       "documentation-intro-fill": "radial-gradient(circle at top, var(--color-psqlnio) 30%, #000 100%)",
       "documentation-intro-accent": "var(--color-psqlnio)",
+      "documentation-intro-eyebrow": "white",
+      "documentation-intro-figure": "white",
+      "documentation-intro-title": "white",
       "logo-base":  { "dark": "#fff", "light": "#000" },
       "logo-shape": { "dark": "#000", "light": "#fff" },
-      "fill":       { "dark": "#000", "light": "#fff" }
     },
     "icons": { "technology": "/postgresnio/images/vapor-postgresnio-logo.svg" }
   },


### PR DESCRIPTION
This in particular improves the compatibility with Swift 6's DocC changes, making the header text readable again.