### PR TITLE
Improve transaction handling

### DIFF
--- a/Sources/PostgresNIO/Connection/PostgresConnection.swift
+++ b/Sources/PostgresNIO/Connection/PostgresConnection.swift
@@ -552,8 +552,9 @@ extension PostgresConnection {
         file: String = #file,
         line: Int = #line,
         isolation: isolated (any Actor)? = #isolation,
-        _ process: (PostgresConnection) async throws -> sending Result
-    ) async throws -> sending Result {
+        // DO NOT FIX THE WHITESPACE IN THE NEXT LINE UNTIL 5.10 IS UNSUPPORTED
+        // https://github.com/swiftlang/swift/issues/79285
+        _ process: (PostgresConnection) async throws -> sending Result) async throws -> sending Result {
         do {
             try await self.query("BEGIN;", logger: logger)
         } catch {

--- a/Sources/PostgresNIO/Connection/PostgresConnection.swift
+++ b/Sources/PostgresNIO/Connection/PostgresConnection.swift
@@ -550,8 +550,9 @@ extension PostgresConnection {
         logger: Logger,
         file: String = #file,
         line: Int = #line,
-        _ process: (PostgresConnection) async throws -> Result
-    ) async throws -> Result {
+        isolation: isolated (any Actor)? = #isolation,
+        _ process: (PostgresConnection) async throws -> sending Result
+    ) async throws -> sending Result {
         do {
             try await self.query("BEGIN;", logger: logger)
         } catch {

--- a/Sources/PostgresNIO/Connection/PostgresConnection.swift
+++ b/Sources/PostgresNIO/Connection/PostgresConnection.swift
@@ -531,6 +531,7 @@ extension PostgresConnection {
         }
     }
 
+    #if compiler(>=6.0)
     /// Puts the connection into an open transaction state, for the provided `closure`'s lifetime.
     ///
     /// The function starts a transaction by running a `BEGIN` query on the connection against the database. It then
@@ -581,6 +582,57 @@ extension PostgresConnection {
             throw transactionError
         }
     }
+    #else
+    /// Puts the connection into an open transaction state, for the provided `closure`'s lifetime.
+    ///
+    /// The function starts a transaction by running a `BEGIN` query on the connection against the database. It then
+    /// lends the connection to the user provided closure. The user can then modify the database as they wish. If the user
+    /// provided closure returns successfully, the function will attempt to commit the changes by running a `COMMIT`
+    /// query against the database. If the user provided closure throws an error, the function will attempt to rollback the
+    /// changes made within the closure.
+    ///
+    /// - Parameters:
+    ///   - logger: The `Logger` to log into for the transaction.
+    ///   - file: The file, the transaction was started in. Used for better error reporting.
+    ///   - line: The line, the transaction was started in. Used for better error reporting.
+    ///   - closure: The user provided code to modify the database. Use the provided connection to run queries.
+    ///              The connection must stay in the transaction mode. Otherwise this method will throw!
+    /// - Returns: The closure's return value.
+    public func withTransaction<Result>(
+        logger: Logger,
+        file: String = #file,
+        line: Int = #line,
+        _ process: (PostgresConnection) async throws -> Result
+    ) async throws -> Result {
+        do {
+            try await self.query("BEGIN;", logger: logger)
+        } catch {
+            throw PostgresTransactionError(file: file, line: line, beginError: error)
+        }
+
+        var closureHasFinished: Bool = false
+        do {
+            let value = try await process(self)
+            closureHasFinished = true
+            try await self.query("COMMIT;", logger: logger)
+            return value
+        } catch {
+            var transactionError = PostgresTransactionError(file: file, line: line)
+            if !closureHasFinished {
+                transactionError.closureError = error
+                do {
+                    try await self.query("ROLLBACK;", logger: logger)
+                } catch {
+                    transactionError.rollbackError = error
+                }
+            } else {
+                transactionError.commitError = error
+            }
+
+            throw transactionError
+        }
+    }
+    #endif
 }
 
 // MARK: EventLoopFuture interface

--- a/Sources/PostgresNIO/New/PostgresTransactionError.swift
+++ b/Sources/PostgresNIO/New/PostgresTransactionError.swift
@@ -1,0 +1,21 @@
+/// A wrapper around the errors that can occur during a transaction.
+public struct PostgresTransactionError: Error {
+
+    /// The file in which the transaction was started
+    public var file: String
+    /// The line in which the transaction was started
+    public var line: Int
+
+    /// The error thrown when running the `BEGIN` query
+    public var beginError: Error?
+    /// The error thrown in the transaction closure
+    public var closureError: Error?
+
+    /// The error thrown while rolling the transaction back. If the ``closureError`` is set,
+    /// but the ``rollbackError`` is empty, the rollback was successful. If the ``rollbackError``
+    /// is set, the rollback failed.
+    public var rollbackError: Error?
+
+    /// The error thrown while commiting the transaction.
+    public var commitError: Error?
+}

--- a/Sources/PostgresNIO/Pool/PostgresClient.swift
+++ b/Sources/PostgresNIO/Pool/PostgresClient.swift
@@ -309,6 +309,7 @@ public final class PostgresClient: Sendable, ServiceLifecycle.Service {
         return try await closure(connection)
     }
 
+    #if compiler(>=6.0)
     /// Lease a connection for the provided `closure`'s lifetime.
     ///
     /// - Parameter closure: A closure that uses the passed `PostgresConnection`. The closure **must not** capture
@@ -351,6 +352,34 @@ public final class PostgresClient: Sendable, ServiceLifecycle.Service {
             try await connection.withTransaction(logger: logger, file: file, line: line, closure)
         }
     }
+    #else
+
+    /// Lease a connection, which is in an open transaction state, for the provided `closure`'s lifetime.
+    ///
+    /// The function leases a connection from the underlying connection pool and starts a transaction by running a `BEGIN`
+    /// query on the leased connection against the database. It then lends the connection to the user provided closure.
+    /// The user can then modify the database as they wish. If the user provided closure returns successfully, the function
+    /// will attempt to commit the changes by running a `COMMIT` query against the database. If the user provided closure
+    /// throws an error, the function will attempt to rollback the changes made within the closure.
+    ///
+    /// - Parameters:
+    ///   - logger: The `Logger` to log into for the transaction.
+    ///   - file: The file, the transaction was started in. Used for better error reporting.
+    ///   - line: The line, the transaction was started in. Used for better error reporting.
+    ///   - closure: The user provided code to modify the database. Use the provided connection to run queries.
+    ///              The connection must stay in the transaction mode. Otherwise this method will throw!
+    /// - Returns: The closure's return value.
+    public func withTransaction<Result>(
+        logger: Logger,
+        file: String = #file,
+        line: Int = #line,
+        _ closure: (PostgresConnection) async throws -> Result
+    ) async throws -> Result {
+        try await self.withConnection { connection in
+            try await connection.withTransaction(logger: logger, file: file, line: line, closure)
+        }
+    }
+    #endif
 
     /// Run a query on the Postgres server the client is connected to.
     ///

--- a/Sources/PostgresNIO/Pool/PostgresClient.swift
+++ b/Sources/PostgresNIO/Pool/PostgresClient.swift
@@ -293,7 +293,6 @@ public final class PostgresClient: Sendable, ServiceLifecycle.Service {
             return ConnectionAndMetadata(connection: connection, maximalStreamsOnConnection: 1)
         }
     }
-
     
     /// Lease a connection for the provided `closure`'s lifetime.
     ///
@@ -317,8 +316,9 @@ public final class PostgresClient: Sendable, ServiceLifecycle.Service {
     /// - Returns: The closure's return value.
     public func withConnection<Result>(
         isolation: isolated (any Actor)? = #isolation,
-        _ closure: (PostgresConnection) async throws -> sending Result
-    ) async throws -> sending Result {
+        // DO NOT FIX THE WHITESPACE IN THE NEXT LINE UNTIL 5.10 IS UNSUPPORTED
+        // https://github.com/swiftlang/swift/issues/79285
+        _ closure: (PostgresConnection) async throws -> sending Result) async throws -> sending Result {
         let connection = try await self.leaseConnection()
 
         defer { self.pool.releaseConnection(connection) }
@@ -346,8 +346,9 @@ public final class PostgresClient: Sendable, ServiceLifecycle.Service {
         file: String = #file,
         line: Int = #line,
         isolation: isolated (any Actor)? = #isolation,
-        _ closure: (PostgresConnection) async throws -> sending Result
-    ) async throws -> sending Result {
+        // DO NOT FIX THE WHITESPACE IN THE NEXT LINE UNTIL 5.10 IS UNSUPPORTED
+        // https://github.com/swiftlang/swift/issues/79285
+        _ closure: (PostgresConnection) async throws -> sending Result) async throws -> sending Result {
         try await self.withConnection { connection in
             try await connection.withTransaction(logger: logger, file: file, line: line, closure)
         }

--- a/Tests/IntegrationTests/PostgresClientTests.swift
+++ b/Tests/IntegrationTests/PostgresClientTests.swift
@@ -77,7 +77,7 @@ final class PostgresClientTests: XCTestCase {
                 
                 for _ in 0..<iterations {
                     taskGroup.addTask {
-                        let _ = try await client.withTransaction { transaction in
+                        let _ = try await client.withTransaction(logger: logger) { transaction in
                             try await transaction.query(
                             """
                             INSERT INTO "\(unescaped: tableName)" (uuid) VALUES (\(UUID()));
@@ -101,7 +101,7 @@ final class PostgresClientTests: XCTestCase {
                 taskGroup.addTask {
                     
                     do {
-                        let _ = try await client.withTransaction { transaction in
+                        let _ = try await client.withTransaction(logger: logger) { transaction in
                             /// insert valid data
                             try await transaction.query(
                                 """

--- a/Tests/IntegrationTests/PostgresClientTests.swift
+++ b/Tests/IntegrationTests/PostgresClientTests.swift
@@ -120,10 +120,10 @@ final class PostgresClientTests: XCTestCase {
                         }
                     } catch {
                         XCTAssertNotNil(error)
-                        guard let error = error as? PSQLError else { return XCTFail("Unexpected error type") }
-                    
-                        XCTAssertEqual(error.code, .server)
-                        XCTAssertEqual(error.serverInfo?[.severity], "ERROR")
+                        guard let error = error as? PostgresTransactionError else { return XCTFail("Unexpected error type: \(error)") }
+
+                        XCTAssertEqual((error.closureError as? PSQLError)?.code, .server)
+                        XCTAssertEqual((error.closureError as? PSQLError)?.serverInfo?[.severity], "ERROR")
                     }
                 }
                 


### PR DESCRIPTION
Improve transaction handling a bit further:

- Add an explicit `PostgresTransactionError`
- Populate the `PostgresTransactionError` if needed
- Add `withTransaction` function to PostgresConnection as well

cc @thoven87 @FranzBusch 

Follow up to #519.