### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ await withTaskGroup(of: Void.self) { taskGroup in
 Once a client is running, queries can be sent to the server. This is straightforward:
 
 ```swift
-let rows = try await client.query("SELECT id, username, birthday FROM users")
+let rows = try await client.query("SELECT id, username, birthday FROM users", logger: Logger(label: "my-example-logger"))
 ```
 
 The query will return a [`PostgresRowSequence`], which is an AsyncSequence of [`PostgresRow`]s. 


### PR DESCRIPTION
The readme has a broken example snippet for running queries which is _extremely_ confusing if you try to use it.
The result of this omission results in trying to run a query which leads users to use a `String` overload rather than the `PostgresQuery` overload which is not only SQL injection vulnerable but also returns an `EventLoopFuture<PostgresResult>`