### PR TITLE
Require the correct minimum version of swift-crypto

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.81.0"),
         .package(url: "https://github.com/apple/swift-nio-transport-services.git", from: "1.19.0"),
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.25.0"),
-        .package(url: "https://github.com/apple/swift-crypto.git", "2.0.0" ..< "4.0.0"),
+        .package(url: "https://github.com/apple/swift-crypto.git", "3.9.0" ..< "4.0.0"),
         .package(url: "https://github.com/apple/swift-metrics.git", from: "2.4.1"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.5.3"),
         .package(url: "https://github.com/swift-server/swift-service-lifecycle.git", from: "2.5.0"),


### PR DESCRIPTION
The SCRAM-SHA-256 authentication method now uses the PBKDF2 implementation added to [swift-crypto](https://github.com/apple/swift-crypto) in [the 3.9.0 release](https://github.com/apple/swift-crypto/releases/tag/3.9.0). We should therefore require that version as a minimum in PostgresNIO.