### PR TITLE
Update README.md to reflect current minimum Swift version 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
 <p align="center">
-<picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://user-images.githubusercontent.com/1130717/259709891-64d4c78b-1cd1-4446-8746-d3a009992811.png">
-  <source media="(prefers-color-scheme: light)" srcset="https://user-images.githubusercontent.com/1130717/259710040-d79ee9eb-b5d9-4a82-a894-3eb5ef366c1f.png">
-  <img src="https://user-images.githubusercontent.com/1130717/259710040-d79ee9eb-b5d9-4a82-a894-3eb5ef366c1f.png" height="96" alt="PostgresNIO">
-</picture>
+<img src="https://design.vapor.codes/images/vapor-postgresnio.svg" height="96" alt="PostgresNIO">
 <br>
 <br>
 <a href="https://api.vapor.codes/postgresnio/documentation/postgresnio/">
@@ -16,7 +12,7 @@
     <img src="https://img.shields.io/github/actions/workflow/status/vapor/postgres-nio/test.yml?event=push&style=plastic&logo=github&label=tests&logoColor=%23ccc" alt="Continuous Integration">
 </a>
 <a href="https://swift.org">
-    <img src="https://design.vapor.codes/images/swift58up.svg" alt="Swift 5.8+">
+    <img src="https://design.vapor.codes/images/swift510up.svg" alt="Swift 5.10+">
 </a>
 <a href="https://www.swift.org/sswg/incubation-process.html">
     <img src="https://design.vapor.codes/images/sswg-graduated.svg" alt="SSWG Incubation Level: Graduated">
@@ -167,7 +163,7 @@ Please see [SECURITY.md] for details on the security process.
 [Team Chat]: https://discord.gg/vapor
 [MIT License]: LICENSE
 [Continuous Integration]: https://github.com/vapor/postgres-nio/actions
-[Swift 5.8]: https://swift.org
+[Swift 5.10]: https://swift.org
 [Security.md]: https://github.com/vapor/.github/blob/main/SECURITY.md
 
 [`PostgresConnection`]: https://api.vapor.codes/postgresnio/documentation/postgresnio/postgresconnection


### PR DESCRIPTION
We now require Swift 5.10 as a minimum version; the README should reflect that. Also switch to the vector header image, while we're at it.