### PR TITLE
updating error type to use computed properties

### DIFF
--- a/Sources/ConnectionPoolModule/ConnectionPoolError.swift
+++ b/Sources/ConnectionPoolModule/ConnectionPoolError.swift
@@ -13,10 +13,12 @@ public struct ConnectionPoolError: Error, Hashable {
     init(_ base: Base) { self.base = base }
 
     /// The connection requests got cancelled
+    @inlinable
     public static var requestCancelled: Self {
         ConnectionPoolError(.requestCancelled)
     }
     /// The connection requests can't be fulfilled as the pool has already been shutdown
+    @inlinable
     public static var poolShutdown: Self {
         ConnectionPoolError(.poolShutdown)
     }


### PR DESCRIPTION
Small updates to convert this error type to using computed properties instead of static properties, following the pattern at https://github.com/apple/swift-nio/pull/3229