### PR TITLE
`TinyFastSequence` logic fixes

### DIFF
--- a/Sources/ConnectionPoolModule/TinyFastSequence.swift
+++ b/Sources/ConnectionPoolModule/TinyFastSequence.swift
@@ -30,9 +30,13 @@ struct TinyFastSequence<Element>: Sequence {
         case 1:
             self.base = .one(collection.first!, reserveCapacity: 0)
         case 2:
-            self.base = .two(collection.first!, collection[collection.endIndex], reserveCapacity: 0)
+            self.base = .two(
+                collection.first!,
+                collection[collection.index(after: collection.startIndex)],
+                reserveCapacity: 0
+            )
         default:
-            if let collection = collection as? [Element] {
+            if let collection = collection as? Array<Element> {
                 self.base = .n(collection)
             } else {
                 self.base = .n(Array(collection))

--- a/Sources/ConnectionPoolModule/TinyFastSequence.swift
+++ b/Sources/ConnectionPoolModule/TinyFastSequence.swift
@@ -30,7 +30,7 @@ struct TinyFastSequence<Element>: Sequence {
         case 1:
             self.base = .one(collection.first!, reserveCapacity: 0)
         case 2:
-            self.base = .two(collection.first, collection[collection.endIndex], reserveCapacity: 0)
+            self.base = .two(collection.first!, collection[collection.endIndex], reserveCapacity: 0)
         default:
             if let collection = collection as? [Element] {
                 self.base = .n(collection)

--- a/Sources/ConnectionPoolModule/TinyFastSequence.swift
+++ b/Sources/ConnectionPoolModule/TinyFastSequence.swift
@@ -29,8 +29,10 @@ struct TinyFastSequence<Element>: Sequence {
             self.base = .none(reserveCapacity: 0)
         case 1:
             self.base = .one(collection.first!, reserveCapacity: 0)
+        case 2:
+            self.base = .two(collection.first, collection[collection.endIndex], reserveCapacity: 0)
         default:
-            if let collection = collection as? Array<Element> {
+            if let collection = collection as? [Element] {
                 self.base = .n(collection)
             } else {
                 self.base = .n(Array(collection))
@@ -46,7 +48,7 @@ struct TinyFastSequence<Element>: Sequence {
         case 1:
             self.base = .one(max2Sequence.first!, reserveCapacity: 0)
         case 2:
-            self.base = .n(Array(max2Sequence))
+            self.base = .two(max2Sequence.first!, max2Sequence.second!, reserveCapacity: 0)
         default:
             fatalError()
         }
@@ -169,7 +171,7 @@ struct TinyFastSequence<Element>: Sequence {
 
             case .n(let array):
                 if self.index < array.endIndex {
-                    defer { self.index += 1}
+                    defer { self.index += 1 }
                     return array[self.index]
                 }
                 return nil

--- a/Tests/ConnectionPoolModuleTests/TinyFastSequenceTests.swift
+++ b/Tests/ConnectionPoolModuleTests/TinyFastSequenceTests.swift
@@ -46,8 +46,16 @@ final class TinyFastSequenceTests: XCTestCase {
         XCTAssertEqual(array.capacity, 8)
 
         var twoElemSequence = TinyFastSequence<Int>([1, 2])
+        twoElemSequence.append(3)
         twoElemSequence.reserveCapacity(8)
         guard case .n(let array) = twoElemSequence.base else {
+            return XCTFail("Expected sequence to be backed by an array")
+        }
+        XCTAssertEqual(array.capacity, 8)
+
+        var threeElemSequence = TinyFastSequence<Int>([1, 2, 3])
+        threeElemSequence.reserveCapacity(8)
+        guard case .n(let array) = threeElemSequence.base else {
             return XCTFail("Expected sequence to be backed by an array")
         }
         XCTAssertEqual(array.capacity, 8)


### PR DESCRIPTION
My guess is Fabian forgot to update all related places when he introduced a `two` case in `TinyFastSequence`.
This PR fixes that.