### PR TITLE
WIP: Implement `COPY … FROM STDIN`

### DIFF
--- a/Sources/PostgresNIO/Connection/PostgresConnection.swift
+++ b/Sources/PostgresNIO/Connection/PostgresConnection.swift
@@ -694,6 +694,100 @@ extension PostgresConnection {
     }
 }
 
+// MARK: Copy from
+
+fileprivate extension EventLoop {
+    /// If we are on the given event loop, execute `task` immediately. Otherwise schedule it for execution.
+    func executeImmediatelyOrSchedule(_ task: @Sendable @escaping () -> Void) {
+        if inEventLoop {
+            return task()
+        }
+        return execute(task)
+    }
+}
+
+/// A handle to send 
+public struct PostgresCopyFromWriter: Sendable {
+    private let channelHandler: NIOLoopBound<PostgresChannelHandler>
+    private let context: NIOLoopBound<ChannelHandlerContext>
+    private let eventLoop: any EventLoop
+
+    struct NotWritableError: Error, CustomStringConvertible {
+        var description = "No data must be written to `PostgresCopyFromWriter` after it has sent a CopyDone or CopyFail message, ie. after the closure producing the copy data has finished"
+    }
+
+    init(handler: PostgresChannelHandler, context: ChannelHandlerContext, eventLoop: any EventLoop) {
+        self.channelHandler = NIOLoopBound(handler, eventLoop: eventLoop)
+        self.context = NIOLoopBound(context, eventLoop: eventLoop)
+        self.eventLoop = eventLoop
+    }
+
+    /// Send data for a `COPY ... FROM STDIN` operation to the backend.
+    public func write(_ byteBuffer: ByteBuffer) async throws {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in 
+            eventLoop.executeImmediatelyOrSchedule {
+                self.channelHandler.value.copyData(byteBuffer, context: self.context.value, readyForMoreWriteContinuation: continuation)
+            }
+        }
+    }
+
+    /// Finalize the data transfer, putting the state machine out of the copy mode and sending a `CopyDone` message to 
+    /// the backend.
+    func done() async throws {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, any Error>) in 
+            eventLoop.executeImmediatelyOrSchedule {
+                self.channelHandler.value.sendCopyDone(continuation: continuation, context: self.context.value)
+            }
+        }
+    }
+
+    /// Finalize the data transfer, putting the state machine out of the copy mode and sending a `CopyFail` message to 
+    /// the backend.
+    func failed(error: any Error) async throws {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, any Error>) in 
+            eventLoop.executeImmediatelyOrSchedule {
+                self.channelHandler.value.sendCopyFailed(message: "\(error)", continuation: continuation, context: self.context.value)
+            }
+        }
+    }
+}
+
+extension PostgresConnection {
+    // TODO: Instead of an arbitrary query, make this a structured data structure.
+    // TODO: Write doc comment
+    public func copyFrom(
+        _ query: PostgresQuery,
+        writeData: @escaping @Sendable (PostgresCopyFromWriter) async throws -> Void,
+        logger: Logger,
+        file: String = #fileID,
+        line: Int = #line
+    )  async throws {
+        var logger = logger
+        logger[postgresMetadataKey: .connectionID] = "\(self.id)"
+        guard query.binds.count <= Int(UInt16.max) else {
+            throw PSQLError(code: .tooManyParameters, query: query)
+        }
+
+        let writer = try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<PostgresCopyFromWriter, any Error>) in
+            let context = ExtendedQueryContext(
+                copyFromQuery: query,
+                triggerCopy: continuation,
+                logger: logger
+            )
+            self.channel.write(HandlerTask.extendedQuery(context), promise: nil)
+        }
+
+        do {
+            try await writeData(writer)
+        } catch {
+            try await writer.failed(error: error)
+            throw error
+        }
+        try await writer.done()
+    }
+
+}
+
 // MARK: PostgresDatabase conformance
 
 extension PostgresConnection: PostgresDatabase {

--- a/Sources/PostgresNIO/New/Connection State Machine/ConnectionStateMachine.swift
+++ b/Sources/PostgresNIO/New/Connection State Machine/ConnectionStateMachine.swift
@@ -88,7 +88,23 @@ struct ConnectionStateMachine {
         case sendParseDescribeBindExecuteSync(PostgresQuery)
         case sendBindExecuteSync(PSQLExecuteStatement)
         case failQuery(EventLoopPromise<PSQLRowStream>, with: PSQLError, cleanupContext: CleanUpContext?)
+        /// Fail a query's execution by throwing an error on the given continuation.
+        case failQueryContinuation(any AnyErrorContinuation, with: PSQLError, cleanupContext: CleanUpContext?)
         case succeedQuery(EventLoopPromise<PSQLRowStream>, with: QueryResult)
+        case succeedQueryContinuation(CheckedContinuation<Void, any Error>)
+
+        /// Trigger a data transfer returning a `PostgresCopyFromWriter` to the given continuation.
+        /// 
+        /// Once the data transfer is triggered, it will send `CopyData` messages to the backend. After that the state 
+        /// machine needs to be prodded again to send a `CopyDone` or `CopyFail` by calling 
+        /// `PostgresChannelHandler.copyDone` or ``PostgresChannelHandler.copyFailed``.
+        case triggerCopyData(CheckedContinuation<PostgresCopyFromWriter, any Error>)
+
+        /// Send a `CopyDone` message to the backend, followed by a `Sync`.
+        case sendCopyDone
+
+        /// Send a `CopyFail` message to the backend with the given error message.
+        case sendCopyFailed(message: String)
 
         // --- streaming actions
         // actions if query has requested next row but we are waiting for backend
@@ -587,6 +603,8 @@ struct ConnectionStateMachine {
             switch queryContext.query {
             case .executeStatement(_, let promise), .unnamed(_, let promise):
                 return .failQuery(promise, with: psqlErrror, cleanupContext: nil)
+            case .copyFrom(_, let triggerCopy):
+                return .failQueryContinuation(triggerCopy, with: psqlErrror, cleanupContext: nil)
             case .prepareStatement(_, _, _, let promise):
                 return .failPreparedStatementCreation(promise, with: psqlErrror, cleanupContext: nil)
             }
@@ -659,6 +677,15 @@ struct ConnectionStateMachine {
         case .modifying:
             preconditionFailure("Invalid state: \(self.state)")
         }
+    }
+
+    mutating func channelWritabilityChanged(isWritable: Bool) {
+        guard case .extendedQuery(var queryState, let connectionContext) = state else {
+            return
+        }
+        self.state = .modifying // avoid CoW
+        queryState.channelWritabilityChanged(isWritable: isWritable)
+        self.state = .extendedQuery(queryState, connectionContext)
     }
     
     // MARK: - Running Queries -
@@ -748,6 +775,55 @@ struct ConnectionStateMachine {
         
         self.state = .modifying // avoid CoW
         let action = queryState.commandCompletedReceived(commandTag)
+        self.state = .extendedQuery(queryState, connectionContext)
+        return self.modify(with: action)
+    }
+
+    mutating func copyInResponseReceived(
+        _ copyInResponse: PostgresBackendMessage.CopyInResponseMessage
+    ) -> ConnectionAction {
+        guard case .extendedQuery(var queryState, let connectionContext) = self.state, !queryState.isComplete else {
+            return self.closeConnectionAndCleanup(.unexpectedBackendMessage(.emptyQueryResponse))
+        }
+
+        self.state = .modifying // avoid CoW
+        let action = queryState.copyInResponseReceived(copyInResponse)
+        self.state = .extendedQuery(queryState, connectionContext)
+        return self.modify(with: action)
+    }
+
+    /// Assuming that the channel to the backend is not writable, wait for the write buffer to become writable again and 
+    /// then resume `continuation`.
+    mutating func waitForWritableBuffer(continuation: CheckedContinuation<Void, Never>) {
+        guard case .extendedQuery(var queryState, let connectionContext) = self.state else {
+            preconditionFailure("Copy mode is only supported for extended queries")
+        }
+        
+        self.state = .modifying // avoid CoW
+        queryState.waitForWritableBuffer(continuation: continuation)
+        self.state = .extendedQuery(queryState, connectionContext)
+    }
+
+    /// Put the state machine out of the copying mode and send a `CopyDone` message to the backend.
+    mutating func sendCopyDone(continuation: CheckedContinuation<Void, any Error>) -> ConnectionAction {
+        guard case .extendedQuery(var queryState, let connectionContext) = self.state else {
+            preconditionFailure("Copy mode is only supported for extended queries")
+        }
+
+        self.state = .modifying // avoid CoW
+        let action = queryState.sendCopyDone(continuation: continuation)
+        self.state = .extendedQuery(queryState, connectionContext)
+        return self.modify(with: action)
+    }
+
+    /// Put the state machine out of the copying mode and send a `CopyFail` message to the backend.
+    mutating func sendCopyFail(message: String, continuation: CheckedContinuation<Void, any Error>) -> ConnectionAction {
+        guard case .extendedQuery(var queryState, let connectionContext) = self.state else {
+            preconditionFailure("Copy mode is only supported for extended queries")
+        }
+
+        self.state = .modifying // avoid CoW
+        let action = queryState.sendCopyFailed(message: message, continuation: continuation)
         self.state = .extendedQuery(queryState, connectionContext)
         return self.modify(with: action)
     }
@@ -860,14 +936,21 @@ struct ConnectionStateMachine {
                  .forwardRows,
                  .forwardStreamComplete,
                  .wait,
-                 .read:
+                 .read,
+                 .triggerCopyData,
+                 .sendCopyDone,
+                 .sendCopyFailed,
+                 .succeedQueryContinuation:
                 preconditionFailure("Invalid query state machine action in state: \(self.state), action: \(action)")
 
             case .evaluateErrorAtConnectionLevel:
                 return .closeConnectionAndCleanup(cleanupContext)
 
-            case .failQuery(let queryContext, with: let error):
-                return .failQuery(queryContext, with: error, cleanupContext: cleanupContext)
+            case .failQuery(let promise, with: let error):
+                return .failQuery(promise, with: error, cleanupContext: cleanupContext)
+            
+            case .failQueryContinuation(let continuation, with: let error):
+                return .failQueryContinuation(continuation, with: error, cleanupContext: cleanupContext)
 
             case .forwardStreamError(let error, let read):
                 return .forwardStreamError(error, read: read, cleanupContext: cleanupContext)
@@ -1038,8 +1121,19 @@ extension ConnectionStateMachine {
         case .failQuery(let requestContext, with: let error):
             let cleanupContext = self.setErrorAndCreateCleanupContextIfNeeded(error)
             return .failQuery(requestContext, with: error, cleanupContext: cleanupContext)
+        case .failQueryContinuation(let continuation, with: let error):
+            let cleanupContext = self.setErrorAndCreateCleanupContextIfNeeded(error)
+            return .failQueryContinuation(continuation, with: error, cleanupContext: cleanupContext)
         case .succeedQuery(let requestContext, with: let result):
             return .succeedQuery(requestContext, with: result)
+        case .succeedQueryContinuation(let continuation):
+            return .succeedQueryContinuation(continuation)
+        case .triggerCopyData(let triggerCopy):
+            return .triggerCopyData(triggerCopy)
+        case .sendCopyDone:
+            return .sendCopyDone
+        case .sendCopyFailed(message: let message):
+            return .sendCopyFailed(message: message)
         case .forwardRows(let buffer):
             return .forwardRows(buffer)
         case .forwardStreamComplete(let buffer, let commandTag):

--- a/Sources/PostgresNIO/New/Connection State Machine/ExtendedQueryStateMachine.swift
+++ b/Sources/PostgresNIO/New/Connection State Machine/ExtendedQueryStateMachine.swift
@@ -1,7 +1,16 @@
 import NIOCore
 
 struct ExtendedQueryStateMachine {
-    
+
+    private enum CopyingDataState {
+        /// The write channel is ready to handle more data
+        case readyToSend
+
+        /// The write channel has backpressure. Once that is relieved, we should resume the given continuation to allow more
+        /// data to be sent by the client.
+        case pendingBackpressureRelieve(CheckedContinuation<Void, Never>)
+    }
+
     private enum State {
         case initialized(ExtendedQueryContext)
         case messagesSent(ExtendedQueryContext)
@@ -11,6 +20,15 @@ struct ExtendedQueryStateMachine {
         case rowDescriptionReceived(ExtendedQueryContext, [RowDescription.Column])
         case noDataMessageReceived(ExtendedQueryContext)
         case emptyQueryResponseReceived
+
+        /// We are currently copying data to the backend using `CopyData` messages.
+        case copyingData(CopyingDataState)
+
+        /// We copied data to the backend and are done with that, either by sending a `CopyDone` or `CopyFail` message. 
+        /// We are now expecting a `CommandComplete` or `ErrorResponse`.
+        /// 
+        /// Once that is received the continuation is resumed.
+        case copyingFinished(CheckedContinuation<Void, any Error>)
 
         /// A state that is used if a noData message was received before. If a row description was received `bufferingRows` is
         /// used after receiving a `bindComplete` message
@@ -32,12 +50,28 @@ struct ExtendedQueryStateMachine {
         
         // --- general actions
         case failQuery(EventLoopPromise<PSQLRowStream>, with: PSQLError)
+        /// Fail a query's execution by throwing an error on the given continuation.
+        case failQueryContinuation(AnyErrorContinuation, with: PSQLError)
         case succeedQuery(EventLoopPromise<PSQLRowStream>, with: QueryResult)
+        case succeedQueryContinuation(CheckedContinuation<Void, any Error>)
 
         case evaluateErrorAtConnectionLevel(PSQLError)
 
         case succeedPreparedStatementCreation(EventLoopPromise<RowDescription?>, with: RowDescription?)
         case failPreparedStatementCreation(EventLoopPromise<RowDescription?>, with: PSQLError)
+
+        /// Trigger a data transfer returning a `PostgresCopyFromWriter` to the given continuation.
+        /// 
+        /// Once the data transfer is triggered, it will send `CopyData` messages to the backend. After that the state 
+        /// machine needs to be prodded again to send a `CopyDone` or `CopyFail` by calling 
+        /// `PostgresChannelHandler.copyDone` or ``PostgresChannelHandler.copyFailed``.
+        case triggerCopyData(CheckedContinuation<PostgresCopyFromWriter, any Error>)
+
+        /// Send a `CopyDone` message to the backend, followed by a `Sync`.
+        case sendCopyDone
+
+        /// Send a `CopyFail` message to the backend with the given error message.
+        case sendCopyFailed(message: String)
 
         // --- streaming actions
         // actions if query has requested next row but we are waiting for backend
@@ -63,7 +97,7 @@ struct ExtendedQueryStateMachine {
         }
         
         switch queryContext.query {
-        case .unnamed(let query, _):
+        case .unnamed(let query, _), .copyFrom(let query, _):
             return self.avoidingStateMachineCoW { state -> Action in
                 state = .messagesSent(queryContext)
                 return .sendParseDescribeBindExecuteSync(query)
@@ -91,7 +125,7 @@ struct ExtendedQueryStateMachine {
     mutating func cancel() -> Action {
         switch self.state {
         case .initialized:
-            preconditionFailure("Start must be called immediatly after the query was created")
+            preconditionFailure("Start must be called immediately after the query was created")
 
         case .messagesSent(let queryContext),
              .parseCompleteReceived(let queryContext),
@@ -107,10 +141,15 @@ struct ExtendedQueryStateMachine {
             switch queryContext.query {
             case .unnamed(_, let eventLoopPromise), .executeStatement(_, let eventLoopPromise):
                 return .failQuery(eventLoopPromise, with: .queryCancelled)
-
+            case .copyFrom(_, let triggerCopy):
+                return .failQueryContinuation(triggerCopy, with: .queryCancelled)
             case .prepareStatement(_, _, _, let eventLoopPromise):
                 return .failPreparedStatementCreation(eventLoopPromise, with: .queryCancelled)
             }
+        case .copyingData:
+            return .sendCopyFailed(message: "Query cancelled")
+        case .copyingFinished(let continuation):
+            return .failQueryContinuation(continuation, with: .queryCancelled)
 
         case .streaming(let columns, var streamStateMachine):
             precondition(!self.isCancelled)
@@ -160,7 +199,7 @@ struct ExtendedQueryStateMachine {
         }
         
         switch queryContext.query {
-        case .unnamed, .executeStatement:
+        case .unnamed, .copyFrom, .executeStatement:
             return self.avoidingStateMachineCoW { state -> Action in
                 state = .noDataMessageReceived(queryContext)
                 return .wait
@@ -198,7 +237,7 @@ struct ExtendedQueryStateMachine {
         }
 
         switch queryContext.query {
-        case .unnamed, .executeStatement:
+        case .unnamed, .copyFrom, .executeStatement:
             return .wait
 
         case .prepareStatement(_, _, _, let eventLoopPromise):
@@ -217,7 +256,7 @@ struct ExtendedQueryStateMachine {
                     return .succeedQuery(eventLoopPromise, with: result)
                 }
 
-            case .prepareStatement:
+            case .prepareStatement, .copyFrom:
                 return .evaluateErrorAtConnectionLevel(.unexpectedBackendMessage(.bindComplete))
             }
 
@@ -235,7 +274,9 @@ struct ExtendedQueryStateMachine {
              .streaming,
              .drain,
              .commandComplete,
-             .error:
+             .error,
+             .copyingData,
+             .copyingFinished:
             return self.setAndFireError(.unexpectedBackendMessage(.bindComplete))
 
         case .modifying:
@@ -274,7 +315,9 @@ struct ExtendedQueryStateMachine {
              .rowDescriptionReceived,
              .bindCompleteReceived,
              .commandComplete,
-             .error:
+             .error,
+             .copyingData,
+             .copyingFinished:
             return self.setAndFireError(.unexpectedBackendMessage(.dataRow(dataRow)))
         case .modifying:
             preconditionFailure("Invalid state")
@@ -291,9 +334,18 @@ struct ExtendedQueryStateMachine {
                     let result = QueryResult(value: .noRows(.tag(commandTag)), logger: context.logger)
                     return .succeedQuery(eventLoopPromise, with: result)
                 }
-
+            case .copyFrom:
+                // We expect to transition through `copyingData` to `copyingFinished` before receiving a 
+                // `CommandCompleted` message for copy queries.
+                preconditionFailure("Invalid state: \(self.state)")
             case .prepareStatement:
                 preconditionFailure("Invalid state: \(self.state)")
+            }
+        
+        case .copyingFinished(let continuation):
+            return self.avoidingStateMachineCoW { state -> Action in
+                state = .commandComplete(commandTag: commandTag)
+                return .succeedQueryContinuation(continuation)
             }
             
         case .streaming(_, var demandStateMachine):
@@ -315,13 +367,70 @@ struct ExtendedQueryStateMachine {
              .emptyQueryResponseReceived,
              .rowDescriptionReceived,
              .commandComplete,
-             .error:
+             .error,
+             .copyingData:
             return self.setAndFireError(.unexpectedBackendMessage(.commandComplete(commandTag)))
         case .modifying:
             preconditionFailure("Invalid state")
         }
     }
     
+    /// When a `CopyInResponse` message is received from the backend, return a continuation to which a 
+    /// `PostgresCopyFromWriter` can be yielded to trigger a data transfer to the backend.
+    /// 
+    /// If we are not currently in a state to handle the `CopyInResponse`, an error is thrown.
+    mutating func copyInResponseReceived(
+        _ copyInResponse: PostgresBackendMessage.CopyInResponseMessage
+    ) -> Action {
+        guard case .bindCompleteReceived(let queryContext) = self.state,
+            case .copyFrom(_, let triggerCopy) = queryContext.query else {
+            return self.setAndFireError(.unexpectedBackendMessage(.copyInResponse(copyInResponse)))
+        }
+        return avoidingStateMachineCoW { state in
+            state = .copyingData(.readyToSend)
+            return .triggerCopyData(triggerCopy)
+        }
+    }
+
+    /// Assuming that the channel to the backend is not writable, wait for the write buffer to become writable again and 
+    /// then resume `continuation`.
+    mutating func waitForWritableBuffer(continuation: CheckedContinuation<Void, Never>) {
+        guard case .copyingData(let copyingSubstate) = self.state else {
+            preconditionFailure("Must be in copy mode to copy data")
+        }
+        guard case .readyToSend = copyingSubstate else {
+            preconditionFailure("Not ready to send data")
+        }
+        return avoidingStateMachineCoW { state in
+            // Even if the buffer isn't writable, we write the current chunk of data to it. We just don't resume
+            // the continuation. This will prevent more writes from happening to build up more write backpressure.
+            state = .copyingData(.pendingBackpressureRelieve(continuation))
+        }
+    }
+
+    /// Put the state machine out of the copying mode and send a `CopyDone` message to the backend.
+    mutating func sendCopyDone(continuation: CheckedContinuation<Void, any Error>) -> Action {
+        guard case .copyingData = self.state else {
+            preconditionFailure("Must be in copy mode to send CopyDone")
+        }
+        return avoidingStateMachineCoW { state in
+            state = .copyingFinished(continuation)
+            return .sendCopyDone
+        }
+    }
+
+    /// Put the state machine out of the copying mode and send a `CopyFail` message to the backend.
+    mutating func sendCopyFailed(message: String, continuation: CheckedContinuation<Void, any Error>) -> Action {
+        guard case .copyingData = self.state else {
+            preconditionFailure("Must be in copy mode to send CopyFail")
+        }
+        return avoidingStateMachineCoW { state in
+            state = .copyingFinished(continuation)
+            return .sendCopyFailed(message: message)
+        }
+        
+    }
+
     mutating func emptyQueryResponseReceived() -> Action {
         guard case .bindCompleteReceived(let queryContext) = self.state else {
             return self.setAndFireError(.unexpectedBackendMessage(.emptyQueryResponse))
@@ -336,7 +445,7 @@ struct ExtendedQueryStateMachine {
                 return .succeedQuery(eventLoopPromise, with: result)
             }
 
-        case .prepareStatement(_, _, _, _):
+        case .prepareStatement, .copyFrom:
             return self.setAndFireError(.unexpectedBackendMessage(.emptyQueryResponse))
         }
     }
@@ -352,6 +461,8 @@ struct ExtendedQueryStateMachine {
              .bindCompleteReceived:
             return self.setAndFireError(error)
         case .rowDescriptionReceived, .noDataMessageReceived:
+            return self.setAndFireError(error)
+        case .copyingData, .copyingFinished:
             return self.setAndFireError(error)
         case .streaming, .drain:
             return self.setAndFireError(error)
@@ -403,7 +514,9 @@ struct ExtendedQueryStateMachine {
              .noDataMessageReceived,
              .emptyQueryResponseReceived,
              .rowDescriptionReceived,
-             .bindCompleteReceived:
+             .bindCompleteReceived,
+             .copyingData,
+             .copyingFinished:
             preconditionFailure("Requested to consume next row without anything going on.")
             
         case .commandComplete, .error:
@@ -427,7 +540,9 @@ struct ExtendedQueryStateMachine {
              .noDataMessageReceived,
              .emptyQueryResponseReceived,
              .rowDescriptionReceived,
-             .bindCompleteReceived:
+             .bindCompleteReceived,
+             .copyingData,
+             .copyingFinished:
             return .wait
             
         case .streaming(let columns, var demandStateMachine):
@@ -454,7 +569,9 @@ struct ExtendedQueryStateMachine {
              .parameterDescriptionReceived,
              .noDataMessageReceived,
              .rowDescriptionReceived,
-             .bindCompleteReceived:
+             .bindCompleteReceived,
+             .copyingData,
+             .copyingFinished:
             return .read
         case .streaming(let columns, var demandStateMachine):
             precondition(!self.isCancelled)
@@ -480,6 +597,16 @@ struct ExtendedQueryStateMachine {
             preconditionFailure("Invalid state")
         }
     }
+
+    mutating func channelWritabilityChanged(isWritable: Bool) {
+        guard case .copyingData(.pendingBackpressureRelieve(let continuation)) = state else {
+            return
+        }
+        self.avoidingStateMachineCoW { state in
+            state = .copyingData(.readyToSend)
+            continuation.resume()
+        }
+    }
     
     // MARK: Private Methods
     
@@ -499,11 +626,18 @@ struct ExtendedQueryStateMachine {
                 switch context.query {
                 case .unnamed(_, let eventLoopPromise), .executeStatement(_, let eventLoopPromise):
                     return .failQuery(eventLoopPromise, with: error)
+                case .copyFrom(_, let triggerCopy):
+                    return .failQueryContinuation(triggerCopy, with: error)
                 case .prepareStatement(_, _, _, let eventLoopPromise):
                     return .failPreparedStatementCreation(eventLoopPromise, with: error)
                 }
             }
-
+        case .copyingData:
+            self.state = .error(error)
+            return .evaluateErrorAtConnectionLevel(error)
+        case .copyingFinished(let continuation):
+            self.state = .error(error)
+            return .failQueryContinuation(continuation, with: error)
         case .drain:
             self.state = .error(error)
             return .evaluateErrorAtConnectionLevel(error)
@@ -536,11 +670,19 @@ struct ExtendedQueryStateMachine {
             switch context.query {
             case .prepareStatement:
                 return true
-            case .unnamed, .executeStatement:
+            case .unnamed, .copyFrom, .executeStatement:
                 return false
             }
 
-        case .initialized, .messagesSent, .parseCompleteReceived, .parameterDescriptionReceived, .bindCompleteReceived, .streaming, .drain:
+        case .initialized,
+             .messagesSent,
+             .parseCompleteReceived,
+             .parameterDescriptionReceived,
+             .bindCompleteReceived,
+             .streaming,
+             .drain, 
+             .copyingData,
+             .copyingFinished:
             return false
 
         case .modifying:

--- a/Sources/PostgresNIO/New/Extensions/AnyErrorContinuation.swift
+++ b/Sources/PostgresNIO/New/Extensions/AnyErrorContinuation.swift
@@ -1,0 +1,6 @@
+/// Any `CheckedContinuation` that has an error type of `any Error`.
+protocol AnyErrorContinuation {
+    func resume(throwing error: any Error)
+}
+
+extension CheckedContinuation: AnyErrorContinuation where E == any Error {}

--- a/Sources/PostgresNIO/New/Messages/CopyInMessage.swift
+++ b/Sources/PostgresNIO/New/Messages/CopyInMessage.swift
@@ -1,0 +1,44 @@
+extension PostgresBackendMessage {
+    struct CopyInResponseMessage: Hashable {
+        enum Format: Int {
+            case textual = 0
+            case binary = 1
+        }
+
+        let format: Format
+        let columnFormats: [Format]
+
+        static func decode(from buffer: inout ByteBuffer) throws -> Self {
+            guard let rawFormat = buffer.readInteger(endianness: .big, as: Int8.self) else {
+                throw PSQLPartialDecodingError.expectedAtLeastNRemainingBytes(1, actual: buffer.readableBytes)
+            }
+            guard let format = Format(rawValue: Int(rawFormat)) else {
+                throw PSQLPartialDecodingError.unexpectedValue(value: rawFormat)
+            }
+            
+            guard let numColumns = buffer.readInteger(endianness: .big, as: Int16.self) else {
+                throw PSQLPartialDecodingError.expectedAtLeastNRemainingBytes(2, actual: buffer.readableBytes)
+            }
+            var columnFormatCodes: [Format] = []
+            columnFormatCodes.reserveCapacity(Int(numColumns))
+
+            for _ in 0..<numColumns {
+                guard let rawColumnFormat = buffer.readInteger(endianness: .big, as: Int16.self) else {
+                    throw PSQLPartialDecodingError.expectedAtLeastNRemainingBytes(2, actual: buffer.readableBytes)
+                }
+                guard let columnFormat = Format(rawValue: Int(rawColumnFormat)) else {
+                    throw PSQLPartialDecodingError.unexpectedValue(value: rawColumnFormat)
+                }
+                columnFormatCodes.append(columnFormat)
+            }
+            
+            return CopyInResponseMessage(format: format, columnFormats: columnFormatCodes)
+        }
+    }
+}
+
+extension PostgresBackendMessage.CopyInResponseMessage: CustomDebugStringConvertible {
+    var debugDescription: String {
+        "format: \(format), columnFormats: \(columnFormats)"
+    }
+}

--- a/Sources/PostgresNIO/New/PSQLTask.swift
+++ b/Sources/PostgresNIO/New/PSQLTask.swift
@@ -19,6 +19,8 @@ enum PSQLTask {
             switch extendedQueryContext.query {
             case .unnamed(_, let eventLoopPromise):
                 eventLoopPromise.fail(error)
+            case .copyFrom(_, let triggerCopy):
+                triggerCopy.resume(throwing: error)
             case .executeStatement(_, let eventLoopPromise):
                 eventLoopPromise.fail(error)
             case .prepareStatement(_, _, _, let eventLoopPromise):
@@ -34,6 +36,14 @@ enum PSQLTask {
 final class ExtendedQueryContext: Sendable {
     enum Query {
         case unnamed(PostgresQuery, EventLoopPromise<PSQLRowStream>)
+        /// A `COPY ... FROM STDIN` query that copies data from the frontend into a table.
+        /// 
+        /// When `triggerCopy` is yielded a `PostgresCopyFromWriter`, the frontend will start sending data to the 
+        /// backend via `CopyData` messages and finalize the data transfer using a `CopyDone` message to the backend or
+        /// using a `CopyFail` message.
+        /// 
+        /// `queryCompleted` is a promise that is finished when the entire query is done.
+        case copyFrom(PostgresQuery, triggerCopy: CheckedContinuation<PostgresCopyFromWriter, any Error>)
         case executeStatement(PSQLExecuteStatement, EventLoopPromise<PSQLRowStream>)
         case prepareStatement(name: String, query: String, bindingDataTypes: [PostgresDataType], EventLoopPromise<RowDescription?>)
     }
@@ -47,6 +57,15 @@ final class ExtendedQueryContext: Sendable {
         promise: EventLoopPromise<PSQLRowStream>
     ) {
         self.query = .unnamed(query, promise)
+        self.logger = logger
+    }
+    
+   init(
+        copyFromQuery query: PostgresQuery,
+        triggerCopy: CheckedContinuation<PostgresCopyFromWriter, any Error>,
+        logger: Logger
+    ) {
+        self.query = .copyFrom(query, triggerCopy: triggerCopy)
         self.logger = logger
     }
     

--- a/Sources/PostgresNIO/New/PostgresBackendMessage.swift
+++ b/Sources/PostgresNIO/New/PostgresBackendMessage.swift
@@ -29,6 +29,7 @@ enum PostgresBackendMessage: Hashable {
     case bindComplete
     case closeComplete
     case commandComplete(String)
+    case copyInResponse(CopyInResponseMessage)
     case dataRow(DataRow)
     case emptyQueryResponse
     case error(ErrorResponse)
@@ -96,6 +97,9 @@ extension PostgresBackendMessage {
             }
             return .commandComplete(commandTag)
             
+        case .copyInResponse:
+            return try .copyInResponse(.decode(from: &buffer))
+        
         case .dataRow:
             return try .dataRow(.decode(from: &buffer))
             
@@ -131,9 +135,9 @@ extension PostgresBackendMessage {
             
         case .rowDescription:
             return try .rowDescription(.decode(from: &buffer))
-            
-        case .copyData, .copyDone, .copyInResponse, .copyOutResponse, .copyBothResponse, .functionCallResponse, .negotiateProtocolVersion:
-            preconditionFailure()
+
+        case .copyData, .copyDone, .copyOutResponse, .copyBothResponse, .functionCallResponse, .negotiateProtocolVersion:
+            preconditionFailure("Unknown message kind: \(messageID)")
         }
     }
 }
@@ -151,6 +155,8 @@ extension PostgresBackendMessage: CustomDebugStringConvertible {
             return ".closeComplete"
         case .commandComplete(let commandTag):
             return ".commandComplete(\(String(reflecting: commandTag)))"
+        case .copyInResponse(let copyInResponse):
+            return ".copyInResponse(\(String(reflecting: copyInResponse)))"
         case .dataRow(let dataRow):
             return ".dataRow(\(String(reflecting: dataRow)))"
         case .emptyQueryResponse:

--- a/Sources/PostgresNIO/New/PostgresChannelHandler.swift
+++ b/Sources/PostgresNIO/New/PostgresChannelHandler.swift
@@ -136,6 +136,8 @@ final class PostgresChannelHandler: ChannelDuplexHandler {
             action = self.state.closeCompletedReceived()
         case .commandComplete(let commandTag):
             action = self.state.commandCompletedReceived(commandTag)
+        case .copyInResponse(let copyInResponse):
+            action = self.state.copyInResponseReceived(copyInResponse)
         case .dataRow(let dataRow):
             action = self.state.dataRowReceived(dataRow)
         case .emptyQueryResponse:
@@ -169,9 +171,38 @@ final class PostgresChannelHandler: ChannelDuplexHandler {
         self.run(action, with: context)
     }
 
+    /// Send a `CopyData` message to the backend using the given data.
+    /// 
+    /// `readyForMoreWriteContinuation` is resumed when the channel is able to handle more data to be written to it.
+    func copyData(_ data: ByteBuffer, context: ChannelHandlerContext, readyForMoreWriteContinuation: CheckedContinuation<Void, Never>) {
+        self.encoder.copyData(data: data)
+        context.writeAndFlush(self.wrapOutboundOut(self.encoder.flushBuffer()), promise: nil)
+        if context.channel.isWritable {
+            readyForMoreWriteContinuation.resume()
+        } else {
+            self.state.waitForWritableBuffer(continuation: readyForMoreWriteContinuation)
+        }
+    }
+
+    /// Put the state machine out of the copying mode and send a `CopyDone` message to the backend.
+    func sendCopyDone(continuation: CheckedContinuation<Void, any Error>, context: ChannelHandlerContext) {
+        let action = self.state.sendCopyDone(continuation: continuation)
+        self.run(action, with: context)
+    }
+
+    /// Put the state machine out of the copying mode and send a `CopyFail` message to the backend.
+    func sendCopyFailed(message: String, continuation: CheckedContinuation<Void, any Error>, context: ChannelHandlerContext) {
+        let action = self.state.sendCopyFail(message: message, continuation: continuation)
+        self.run(action, with: context)
+    }
+
     func channelReadComplete(context: ChannelHandlerContext) {
         let action = self.state.channelReadComplete()
         self.run(action, with: context)
+    }
+
+    func channelWritabilityChanged(context: ChannelHandlerContext) {
+        self.state.channelWritabilityChanged(isWritable: context.channel.isWritable)
     }
     
     func userInboundEventTriggered(context: ChannelHandlerContext, event: Any) {
@@ -353,12 +384,28 @@ final class PostgresChannelHandler: ChannelDuplexHandler {
             self.sendParseDescribeBindExecuteAndSyncMessage(query: query, context: context)
         case .succeedQuery(let promise, with: let result):
             self.succeedQuery(promise, result: result, context: context)
+        case .succeedQueryContinuation(let continuation):
+            continuation.resume()
         case .failQuery(let promise, with: let error, let cleanupContext):
             promise.fail(error)
             if let cleanupContext = cleanupContext {
                 self.closeConnectionAndCleanup(cleanupContext, context: context)
             }
-        
+        case .failQueryContinuation(let continuation, with: let error, let cleanupContext):
+            continuation.resume(throwing: error)
+            if let cleanupContext = cleanupContext {
+                self.closeConnectionAndCleanup(cleanupContext, context: context)
+            }
+        case .triggerCopyData(let triggerCopy):
+            let writer = PostgresCopyFromWriter(handler: self, context: context, eventLoop: eventLoop)
+            triggerCopy.resume(returning: writer)
+        case .sendCopyDone:
+            self.encoder.copyDone()
+            self.encoder.sync()
+            context.writeAndFlush(self.wrapOutboundOut(self.encoder.flushBuffer()), promise: nil)
+        case .sendCopyFailed(message: let message):
+            self.encoder.copyFail(message: message)
+            context.writeAndFlush(self.wrapOutboundOut(self.encoder.flushBuffer()), promise: nil)
         case .forwardRows(let rows):
             self.rowStream!.receive(rows)
             

--- a/Sources/PostgresNIO/New/PostgresFrontendMessageEncoder.swift
+++ b/Sources/PostgresNIO/New/PostgresFrontendMessageEncoder.swift
@@ -167,6 +167,25 @@ struct PostgresFrontendMessageEncoder {
         self.buffer.writeMultipleIntegers(UInt32(8), Self.sslRequestCode)
     }
 
+    mutating func copyData(data: ByteBuffer) {
+        self.clearIfNeeded()
+        self.buffer.psqlWriteMultipleIntegers(id: .copyData, length: UInt32(data.readableBytes))
+        self.buffer.writeImmutableBuffer(data)
+    }
+
+    mutating func copyDone() {
+        self.clearIfNeeded()
+        self.buffer.psqlWriteMultipleIntegers(id: .copyDone, length: 0)
+    }
+
+    mutating func copyFail(message: String) {
+        self.clearIfNeeded()
+        var messageBuffer = ByteBuffer()
+        messageBuffer.writeNullTerminatedString(message)
+        self.buffer.psqlWriteMultipleIntegers(id: .copyFail, length: UInt32(messageBuffer.readableBytes))
+        self.buffer.writeImmutableBuffer(messageBuffer)
+    }
+
     mutating func sync() {
         self.clearIfNeeded()
         self.buffer.psqlWriteMultipleIntegers(id: .sync, length: 0)
@@ -197,6 +216,9 @@ struct PostgresFrontendMessageEncoder {
 private enum FrontendMessageID: UInt8, Hashable, Sendable {
     case bind = 66 // B
     case close = 67 // C
+    case copyData = 100 // d
+    case copyDone = 99 // c
+    case copyFail = 102 // f
     case describe = 68 // D
     case execute = 69 // E
     case flush = 72 // H

--- a/Tests/IntegrationTests/PSQLIntegrationTests.swift
+++ b/Tests/IntegrationTests/PSQLIntegrationTests.swift
@@ -379,4 +379,33 @@ final class IntegrationTests: XCTestCase {
         }
     }
     
+    func testCopyIntoFrom() async throws {
+        let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 2)
+        defer { XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully()) }
+        let eventLoop = eventLoopGroup.next()
+
+        let conn = try await PostgresConnection.test(on: eventLoop).get()
+        defer { XCTAssertNoThrow(try conn.close().wait()) }
+
+        _ = try? await conn.query("DROP TABLE copy_table", logger: .psqlTest).get()
+        _ = try await conn.query("CREATE TABLE copy_table (id INT, name VARCHAR(100))", logger: .psqlTest).get()
+        try await conn.copyFrom("COPY copy_table FROM STDIN", writeData: { writer in
+            let records: [(id: Int, name: String)] = [
+                (1, "Alice"),
+                (42, "Bob")
+            ]
+            for record in records {
+                var buffer = ByteBuffer()
+                buffer.writeString("\(record.id)\t\(record.name)\n")
+                try await writer.write(buffer)
+            }
+        }, logger: .psqlTest)
+        let rows = try await conn.query("SELECT id, name FROM copy_table").get().rows.map { try $0.decode((Int, String).self) }
+        XCTAssertEqual(rows.count, 2)
+        XCTAssertEqual(rows[0].0, 1)
+        XCTAssertEqual(rows[0].1, "Alice")
+        XCTAssertEqual(rows[1].0, 42)
+        XCTAssertEqual(rows[1].1, "Bob")
+    }
+    
 }

--- a/Tests/PostgresNIOTests/New/Connection State Machine/ExtendedQueryStateMachineTests.swift
+++ b/Tests/PostgresNIOTests/New/Connection State Machine/ExtendedQueryStateMachineTests.swift
@@ -114,7 +114,7 @@ class ExtendedQueryStateMachineTests: XCTestCase {
                        .failQuery(promise, with: psqlError, cleanupContext: .init(action: .close, tasks: [], error: psqlError, closePromise: nil)))
     }
 
-    func testExtendedQueryIsCancelledImmediatly() {
+    func testExtendedQueryIsCancelledImmediately() {
         var state = ConnectionStateMachine.readyForQuery()
 
         let logger = Logger.psqlTest

--- a/Tests/PostgresNIOTests/New/Extensions/PSQLBackendMessageEncoder.swift
+++ b/Tests/PostgresNIOTests/New/Extensions/PSQLBackendMessageEncoder.swift
@@ -28,6 +28,8 @@ struct PSQLBackendMessageEncoder: MessageToByteEncoder {
         case .commandComplete(let string):
             self.encode(messageID: message.id, payload: StringPayload(string), into: &buffer)
             
+        case .copyInResponse(let copyInResponse):
+            self.encode(messageID: message.id, payload: copyInResponse, into: &buffer)
         case .dataRow(let row):
             self.encode(messageID: message.id, payload: row, into: &buffer)
             
@@ -99,6 +101,8 @@ extension PostgresBackendMessage {
             return .closeComplete
         case .commandComplete:
             return .commandComplete
+        case .copyInResponse:
+            return .copyInResponse
         case .dataRow:
             return .dataRow
         case .emptyQueryResponse:
@@ -181,6 +185,16 @@ extension PostgresBackendMessage.BackendKeyData: PSQLMessagePayloadEncodable {
     public func encode(into buffer: inout ByteBuffer) {
         buffer.writeInteger(self.processID)
         buffer.writeInteger(self.secretKey)
+    }
+}
+
+extension PostgresBackendMessage.CopyInResponseMessage: PSQLMessagePayloadEncodable {
+    public func encode(into buffer: inout ByteBuffer) {
+        buffer.writeInteger(Int8(self.format.rawValue))
+        buffer.writeInteger(Int16(self.columnFormats.count))
+        for columnFormat in columnFormats {
+            buffer.writeInteger(Int16(columnFormat.rawValue))
+        }
     }
 }
 

--- a/Tests/PostgresNIOTests/New/PostgresConnectionTests.swift
+++ b/Tests/PostgresNIOTests/New/PostgresConnectionTests.swift
@@ -283,7 +283,7 @@ class PostgresConnectionTests: XCTestCase {
         }
     }
 
-    func testCloseClosesImmediatly() async throws {
+    func testCloseClosesImmediately() async throws {
         let (connection, channel) = try await self.makeTestConnectionWithAsyncTestingChannel()
 
         try await withThrowingTaskGroup(of: Void.self) { [logger] taskGroup async throws -> () in


### PR DESCRIPTION
This is still WIP. To do items include:
- [ ] Test the various error cases, I have mostly focused on the success case so far
- [ ] Test the backpressure support
- [ ] Change the public API to accept the table + columns to copy into as well as options so that we can build the `COPY` query instead of letting the user write it
- [ ] Add an API that allows binary transfer of data

Fixes #290