### PR TITLE
Add message types to support COPY operations

### DIFF
--- a/Sources/PostgresNIO/New/Connection State Machine/ConnectionStateMachine.swift
+++ b/Sources/PostgresNIO/New/Connection State Machine/ConnectionStateMachine.swift
@@ -752,6 +752,12 @@ struct ConnectionStateMachine {
         return self.modify(with: action)
     }
     
+    mutating func copyInResponseReceived(
+        _ copyInResponse: PostgresBackendMessage.CopyInResponse
+    ) -> ConnectionAction {
+        return self.closeConnectionAndCleanup(.unexpectedBackendMessage(.copyInResponse(copyInResponse)))
+    }
+
     mutating func emptyQueryResponseReceived() -> ConnectionAction {
         guard case .extendedQuery(var queryState, let connectionContext) = self.state, !queryState.isComplete else {
             return self.closeConnectionAndCleanup(.unexpectedBackendMessage(.emptyQueryResponse))

--- a/Sources/PostgresNIO/New/Connection State Machine/ExtendedQueryStateMachine.swift
+++ b/Sources/PostgresNIO/New/Connection State Machine/ExtendedQueryStateMachine.swift
@@ -91,7 +91,7 @@ struct ExtendedQueryStateMachine {
     mutating func cancel() -> Action {
         switch self.state {
         case .initialized:
-            preconditionFailure("Start must be called immediatly after the query was created")
+            preconditionFailure("Start must be called immediately after the query was created")
 
         case .messagesSent(let queryContext),
              .parseCompleteReceived(let queryContext),
@@ -322,6 +322,12 @@ struct ExtendedQueryStateMachine {
         }
     }
     
+    mutating func copyInResponseReceived(
+        _ copyInResponse: PostgresBackendMessage.CopyInResponse
+    ) -> Action {
+        return self.setAndFireError(.unexpectedBackendMessage(.copyInResponse(copyInResponse)))
+    }
+
     mutating func emptyQueryResponseReceived() -> Action {
         guard case .bindCompleteReceived(let queryContext) = self.state else {
             return self.setAndFireError(.unexpectedBackendMessage(.emptyQueryResponse))

--- a/Sources/PostgresNIO/New/Messages/CopyInMessage.swift
+++ b/Sources/PostgresNIO/New/Messages/CopyInMessage.swift
@@ -1,0 +1,44 @@
+extension PostgresBackendMessage {
+    struct CopyInResponse: Hashable {
+        enum Format: Int8 {
+            case textual = 0
+            case binary = 1
+        }
+
+        let format: Format
+        let columnFormats: [Format]
+
+        static func decode(from buffer: inout ByteBuffer) throws -> Self {
+            guard let rawFormat = buffer.readInteger(endianness: .big, as: Int8.self) else {
+                throw PSQLPartialDecodingError.expectedAtLeastNRemainingBytes(1, actual: buffer.readableBytes)
+            }
+            guard let format = Format(rawValue: rawFormat) else {
+                throw PSQLPartialDecodingError.unexpectedValue(value: rawFormat)
+            }
+            
+            guard let numColumns = buffer.readInteger(endianness: .big, as: Int16.self) else {
+                throw PSQLPartialDecodingError.expectedAtLeastNRemainingBytes(2, actual: buffer.readableBytes)
+            }
+            var columnFormatCodes: [Format] = []
+            columnFormatCodes.reserveCapacity(Int(numColumns))
+
+            for _ in 0..<numColumns {
+                guard let rawColumnFormat = buffer.readInteger(endianness: .big, as: Int16.self) else {
+                    throw PSQLPartialDecodingError.expectedAtLeastNRemainingBytes(2, actual: buffer.readableBytes)
+                }
+                guard Int8.min <= rawColumnFormat, rawColumnFormat <= Int8.max, let columnFormat = Format(rawValue: Int8(rawColumnFormat)) else {
+                    throw PSQLPartialDecodingError.unexpectedValue(value: rawColumnFormat)
+                }
+                columnFormatCodes.append(columnFormat)
+            }
+            
+            return CopyInResponse(format: format, columnFormats: columnFormatCodes)
+        }
+    }
+}
+
+extension PostgresBackendMessage.CopyInResponse: CustomDebugStringConvertible {
+    var debugDescription: String {
+        "format: \(format), columnFormats: \(columnFormats)"
+    }
+}

--- a/Sources/PostgresNIO/New/PostgresBackendMessageDecoder.swift
+++ b/Sources/PostgresNIO/New/PostgresBackendMessageDecoder.swift
@@ -189,6 +189,12 @@ struct PSQLPartialDecodingError: Error {
             description: "Expected the integer to be positive or null, but got \(actual).",
             file: file, line: line)
     }
+
+    static func unknownMessageKind(_ messageID: PostgresBackendMessage.ID, file: String = #fileID, line: Int = #line) -> Self {
+        return PSQLPartialDecodingError(
+            description: "Unknown message kind: \(messageID)",
+            file: file, line: line)
+    }
 }
 
 extension ByteBuffer {

--- a/Sources/PostgresNIO/New/PostgresChannelHandler.swift
+++ b/Sources/PostgresNIO/New/PostgresChannelHandler.swift
@@ -136,6 +136,8 @@ final class PostgresChannelHandler: ChannelDuplexHandler {
             action = self.state.closeCompletedReceived()
         case .commandComplete(let commandTag):
             action = self.state.commandCompletedReceived(commandTag)
+        case .copyInResponse(let copyInResponse):
+            action = self.state.copyInResponseReceived(copyInResponse)
         case .dataRow(let dataRow):
             action = self.state.dataRowReceived(dataRow)
         case .emptyQueryResponse:

--- a/Tests/PostgresNIOTests/New/Connection State Machine/ExtendedQueryStateMachineTests.swift
+++ b/Tests/PostgresNIOTests/New/Connection State Machine/ExtendedQueryStateMachineTests.swift
@@ -114,7 +114,7 @@ class ExtendedQueryStateMachineTests: XCTestCase {
                        .failQuery(promise, with: psqlError, cleanupContext: .init(action: .close, tasks: [], error: psqlError, closePromise: nil)))
     }
 
-    func testExtendedQueryIsCancelledImmediatly() {
+    func testExtendedQueryIsCancelledImmediately() {
         var state = ConnectionStateMachine.readyForQuery()
 
         let logger = Logger.psqlTest

--- a/Tests/PostgresNIOTests/New/Extensions/PSQLBackendMessageEncoder.swift
+++ b/Tests/PostgresNIOTests/New/Extensions/PSQLBackendMessageEncoder.swift
@@ -28,6 +28,8 @@ struct PSQLBackendMessageEncoder: MessageToByteEncoder {
         case .commandComplete(let string):
             self.encode(messageID: message.id, payload: StringPayload(string), into: &buffer)
             
+        case .copyInResponse(let copyInResponse):
+            self.encode(messageID: message.id, payload: copyInResponse, into: &buffer)
         case .dataRow(let row):
             self.encode(messageID: message.id, payload: row, into: &buffer)
             
@@ -99,6 +101,8 @@ extension PostgresBackendMessage {
             return .closeComplete
         case .commandComplete:
             return .commandComplete
+        case .copyInResponse:
+            return .copyInResponse
         case .dataRow:
             return .dataRow
         case .emptyQueryResponse:
@@ -181,6 +185,16 @@ extension PostgresBackendMessage.BackendKeyData: PSQLMessagePayloadEncodable {
     public func encode(into buffer: inout ByteBuffer) {
         buffer.writeInteger(self.processID)
         buffer.writeInteger(self.secretKey)
+    }
+}
+
+extension PostgresBackendMessage.CopyInResponse: PSQLMessagePayloadEncodable {
+    public func encode(into buffer: inout ByteBuffer) {
+        buffer.writeInteger(Int8(self.format.rawValue))
+        buffer.writeInteger(Int16(self.columnFormats.count))
+        for columnFormat in columnFormats {
+            buffer.writeInteger(Int16(columnFormat.rawValue))
+        }
     }
 }
 

--- a/Tests/PostgresNIOTests/New/Extensions/PSQLFrontendMessageDecoder.swift
+++ b/Tests/PostgresNIOTests/New/Extensions/PSQLFrontendMessageDecoder.swift
@@ -168,6 +168,18 @@ extension PostgresFrontendMessage {
                 )
             )
 
+        case .copyData:
+            return .copyData(CopyData(data: buffer))
+
+        case .copyDone:
+            return .copyDone
+
+        case .copyFail:
+            guard let message = buffer.readNullTerminatedString() else {
+                throw PSQLPartialDecodingError.fieldNotDecodable(type: String.self)
+            }
+            return .copyFail(CopyFail(message: message))
+
         case .close:
             preconditionFailure("TODO: Unimplemented")
 

--- a/Tests/PostgresNIOTests/New/Extensions/PostgresFrontendMessage.swift
+++ b/Tests/PostgresNIOTests/New/Extensions/PostgresFrontendMessage.swift
@@ -36,6 +36,14 @@ enum PostgresFrontendMessage: Equatable {
         let secretKey: Int32
     }
 
+    struct CopyData: Hashable {
+        var data: ByteBuffer
+    }
+
+    struct CopyFail: Hashable {
+        var message: String
+    }
+
     enum Close: Hashable {
         case preparedStatement(String)
         case portal(String)
@@ -170,6 +178,9 @@ enum PostgresFrontendMessage: Equatable {
 
     case bind(Bind)
     case cancel(Cancel)
+    case copyData(CopyData)
+    case copyDone
+    case copyFail(CopyFail)
     case close(Close)
     case describe(Describe)
     case execute(Execute)
@@ -186,6 +197,9 @@ enum PostgresFrontendMessage: Equatable {
     enum ID: UInt8, Equatable {
         
         case bind
+        case copyData
+        case copyDone
+        case copyFail
         case close
         case describe
         case execute
@@ -201,12 +215,18 @@ enum PostgresFrontendMessage: Equatable {
             switch rawValue {
             case UInt8(ascii: "B"):
                 self = .bind
+            case UInt8(ascii: "c"):
+                self = .copyDone
             case UInt8(ascii: "C"):
                 self = .close
+            case UInt8(ascii: "d"):
+                self = .copyData
             case UInt8(ascii: "D"):
                 self = .describe
             case UInt8(ascii: "E"):
                 self = .execute
+            case UInt8(ascii: "f"):
+                self = .copyFail
             case UInt8(ascii: "H"):
                 self = .flush
             case UInt8(ascii: "P"):
@@ -230,6 +250,12 @@ enum PostgresFrontendMessage: Equatable {
             switch self {
             case .bind:
                 return UInt8(ascii: "B")
+            case .copyData:
+                return UInt8(ascii: "d")
+            case .copyDone:
+                return UInt8(ascii: "c")
+            case .copyFail:
+                return UInt8(ascii: "f")
             case .close:
                 return UInt8(ascii: "C")
             case .describe:
@@ -263,6 +289,12 @@ extension PostgresFrontendMessage {
             return .bind
         case .cancel:
             preconditionFailure("Cancel messages don't have an identifier")
+        case .copyData:
+            return .copyData
+        case .copyDone:
+            return .copyDone
+        case .copyFail:
+            return .copyFail
         case .close:
             return .close
         case .describe:

--- a/Tests/PostgresNIOTests/New/Messages/CopyTests.swift
+++ b/Tests/PostgresNIOTests/New/Messages/CopyTests.swift
@@ -1,0 +1,147 @@
+import XCTest
+import NIOCore
+import NIOTestUtils
+@testable import PostgresNIO
+
+class CopyTests: XCTestCase {
+    func testDecodeCopyInResponseMessage() throws {
+        let expected: [PostgresBackendMessage] = [
+            .copyInResponse(.init(format: .textual, columnFormats: [.textual, .textual])),
+            .copyInResponse(.init(format: .binary, columnFormats: [.binary, .binary])),
+            .copyInResponse(.init(format: .binary, columnFormats: [.textual, .binary]))
+        ]
+
+        var buffer = ByteBuffer()
+
+        for message in expected {
+            guard case .copyInResponse(let message) = message else {
+                return XCTFail("Expected only to get copyInResponse here!")
+            }
+            buffer.writeBackendMessage(id: .copyInResponse ) { buffer in
+                buffer.writeInteger(Int8(message.format.rawValue))
+                buffer.writeInteger(Int16(message.columnFormats.count))
+                for columnFormat in message.columnFormats {
+                    buffer.writeInteger(UInt16(columnFormat.rawValue))
+                }
+            }
+        }
+        try ByteToMessageDecoderVerifier.verifyDecoder(
+            inputOutputPairs: [(buffer, expected)],
+            decoderFactory: { PostgresBackendMessageDecoder(hasAlreadyReceivedBytes: true) }
+        )
+    }
+
+    func testDecodeFailureBecauseOfEmptyMessage() {
+        var buffer = ByteBuffer()
+        buffer.writeBackendMessage(id: .copyInResponse) { _ in}
+        
+        XCTAssertThrowsError(
+            try ByteToMessageDecoderVerifier.verifyDecoder(
+                inputOutputPairs: [(buffer, [])],
+                decoderFactory: { PostgresBackendMessageDecoder(hasAlreadyReceivedBytes: true) }
+            )
+        ) {
+            XCTAssert($0 is PostgresMessageDecodingError)
+        }
+    }
+
+
+    func testDecodeFailureBecauseOfInvalidFormat() {
+        var buffer = ByteBuffer()
+        buffer.writeBackendMessage(id: .copyInResponse) { buffer in
+            buffer.writeInteger(Int8(20))  // Only 0 and 1 are valid formats
+        }
+        
+        XCTAssertThrowsError(
+            try ByteToMessageDecoderVerifier.verifyDecoder(
+                inputOutputPairs: [(buffer, [])],
+                decoderFactory: { PostgresBackendMessageDecoder(hasAlreadyReceivedBytes: true) }
+            )
+        ) {
+            XCTAssert($0 is PostgresMessageDecodingError)
+        }
+    }
+
+    func testDecodeFailureBecauseOfMissingColumnNumber() {
+        var buffer = ByteBuffer()
+        buffer.writeBackendMessage(id: .copyInResponse) { buffer in
+            buffer.writeInteger(Int8(0))
+        }
+        
+        XCTAssertThrowsError(
+            try ByteToMessageDecoderVerifier.verifyDecoder(
+                inputOutputPairs: [(buffer, [])],
+                decoderFactory: { PostgresBackendMessageDecoder(hasAlreadyReceivedBytes: true) }
+            )
+        ) {
+            XCTAssert($0 is PostgresMessageDecodingError)
+        }
+    }
+
+
+    func testDecodeFailureBecauseOfMissingColumns() {
+        var buffer = ByteBuffer()
+        buffer.writeBackendMessage(id: .copyInResponse) { buffer in
+            buffer.writeInteger(Int8(0))
+            buffer.writeInteger(Int16(20))  // 20 columns promised, none given
+        }
+        
+        XCTAssertThrowsError(
+            try ByteToMessageDecoderVerifier.verifyDecoder(
+                inputOutputPairs: [(buffer, [])],
+                decoderFactory: { PostgresBackendMessageDecoder(hasAlreadyReceivedBytes: true) }
+            )
+        ) {
+            XCTAssert($0 is PostgresMessageDecodingError)
+        }
+    }
+
+    func testDecodeFailureBecauseOfInvalidColumnFormat() {
+        var buffer = ByteBuffer()
+        buffer.writeBackendMessage(id: .copyInResponse) { buffer in
+            buffer.writeInteger(Int8(0))
+            buffer.writeInteger(Int16(1))
+            buffer.writeInteger(Int8(20))  // Only 0 and 1 are valid formats
+        }
+        
+        XCTAssertThrowsError(
+            try ByteToMessageDecoderVerifier.verifyDecoder(
+                inputOutputPairs: [(buffer, [])],
+                decoderFactory: { PostgresBackendMessageDecoder(hasAlreadyReceivedBytes: true) }
+            )
+        ) {
+            XCTAssert($0 is PostgresMessageDecodingError)
+        }
+    }
+
+    func testEncodeCopyDataHeader() {
+        var encoder = PostgresFrontendMessageEncoder(buffer: .init())
+        encoder.copyDataHeader(dataLength: 3)
+        var byteBuffer = encoder.flushBuffer()
+
+        XCTAssertEqual(byteBuffer.readableBytes, 5)
+        XCTAssertEqual(PostgresFrontendMessage.ID.copyData.rawValue, byteBuffer.readInteger(as: UInt8.self))
+        XCTAssertEqual(byteBuffer.readInteger(as: Int32.self), 7)
+    }
+
+    func testEncodeCopyDone() {
+        var encoder = PostgresFrontendMessageEncoder(buffer: .init())
+        encoder.copyDone()
+        var byteBuffer = encoder.flushBuffer()
+
+        XCTAssertEqual(byteBuffer.readableBytes, 5)
+        XCTAssertEqual(PostgresFrontendMessage.ID.copyDone.rawValue, byteBuffer.readInteger(as: UInt8.self))
+        XCTAssertEqual(byteBuffer.readInteger(as: Int32.self), 4)
+    }
+
+    func testEncodeCopyFail() {
+        var encoder = PostgresFrontendMessageEncoder(buffer: .init())
+        encoder.copyFail(message: "Oh, no :(")
+        var byteBuffer = encoder.flushBuffer()
+
+        XCTAssertEqual(byteBuffer.readableBytes, 15)
+        XCTAssertEqual(PostgresFrontendMessage.ID.copyFail.rawValue, byteBuffer.readInteger(as: UInt8.self))
+        XCTAssertEqual(byteBuffer.readInteger(as: Int32.self), 14)
+        XCTAssertEqual(byteBuffer.readNullTerminatedString(), "Oh, no :(")
+    }
+}


### PR DESCRIPTION
This adds the infrastrucutre to decode messages needed for COPY operations. It does not implement the handling support itself yet. That will be added by #566.
