### PR TITLE
Support binary data transfer in `COPY FROM`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -56,7 +56,7 @@ let package = Package(
                 .product(name: "NIOFoundationCompat", package: "swift-nio"),
                 .product(name: "ServiceLifecycle", package: "swift-service-lifecycle"),
             ],
-            swiftSettings: swiftSettings
+            swiftSettings: swiftSettings + [.enableExperimentalFeature("Lifetimes")]
         ),
         .target(
             name: "_ConnectionPoolModule",

--- a/Sources/PostgresNIO/Connection/PostgresConnection+CopyFrom.swift
+++ b/Sources/PostgresNIO/Connection/PostgresConnection+CopyFrom.swift
@@ -130,7 +130,17 @@ public struct PostgresBinaryCopyFromWriter: ~Copyable {
         @inlinable
         public mutating func writeColumn(_ column: (some PostgresEncodable)?) throws {
             columns += 1
-            try underlying.pointee.writeColumn(column)
+            try invokeWriteColumn(on: underlying, column)
+        }
+
+        // Needed to work around https://github.com/swiftlang/swift/issues/83309, copying the implementation into 
+        // `writeColumn` causes an assertion failure when thread sanitizer is enabled.
+        @inlinable 
+        func invokeWriteColumn(
+            on writer: UnsafeMutablePointer<PostgresBinaryCopyFromWriter>, 
+            _ column: (some PostgresEncodable)?
+        ) throws {
+            try writer.pointee.writeColumn(column)
         }
     }
 

--- a/Sources/PostgresNIO/Connection/PostgresConnection+CopyFrom.swift
+++ b/Sources/PostgresNIO/Connection/PostgresConnection+CopyFrom.swift
@@ -139,7 +139,7 @@ public struct PostgresBinaryCopyFromWriter: ~Copyable {
         /// Serialize a single column to a row.
         ///
         /// - Important: It is critical that that data type encoded here exactly matches the data type in the
-        ///   database. For example, if the database stores an a 4-bit integer the corresponding `writeColumn` must
+        ///   database. For example, if the database stores an a 4-byte integer the corresponding `writeColumn` must
         ///   be called with an `Int32`. Serializing an integer of a different width will cause a deserialization
         ///   failure in the backend.
         @inlinable
@@ -327,7 +327,7 @@ extension PostgresConnection {
         line: Int = #line,
         writeData: (inout PostgresBinaryCopyFromWriter) async throws -> Void
     )  async throws {
-        try await copyFrom(table: table, columns: columns, format: .binary(PostgresCopyFromFormat.BinaryOptions()), logger: logger) { writer in
+        try await copyFrom(table: table, columns: columns, format: .binary(options), logger: logger) { writer in
             var header = ByteBuffer()
             header.reserveCapacity(19)
             header.writeString("PGCOPY\n")
@@ -343,6 +343,7 @@ extension PostgresConnection {
 
             var binaryWriter = PostgresBinaryCopyFromWriter(underlying: writer, bufferSize: bufferSize)
             try await writeData(&binaryWriter)
+            binaryWriter.buffer.writeInteger(Int16(-1))
             try await binaryWriter.flush()
         }
     }

--- a/Sources/PostgresNIO/Connection/PostgresConnection+CopyFrom.swift
+++ b/Sources/PostgresNIO/Connection/PostgresConnection+CopyFrom.swift
@@ -102,19 +102,19 @@ public struct PostgresCopyFromWriter: Sendable {
 #if compiler(>=6.2)
 /// Handle to send binary data for a `COPY ... FROM STDIN` query to the backend.
 ///
-/// It takes care of serializing `PostgresEncodable` column types into the binary format that Postgres expects.
+/// It takes care of serializing ``PostgresEncodable`` column types into the binary format that Postgres expects.
 public struct PostgresBinaryCopyFromWriter: ~Copyable {
-    /// Handle to serialize columns into a row that is being written by `PostgresBinaryCopyFromWriter`.
+    /// Handle to serialize columns into a row that is being written by ``PostgresBinaryCopyFromWriter``.
     public struct ColumnWriter: ~Escapable, ~Copyable {
-        /// Pointer to the `PostgresBinaryCopyFromWriter` that is gathering the serialized data.
+        /// Pointer to the ``PostgresBinaryCopyFromWriter`` that is gathering the serialized data.
         @usableFromInline
         let underlying: UnsafeMutablePointer<PostgresBinaryCopyFromWriter>
 
-        /// The number of columns that have been written by this `ColumnWriter`.
+        /// The number of columns that have been written by this ``ColumnWriter``.
         @usableFromInline
         var columns: UInt16 = 0
 
-        /// - Warning: Do not call directly, call `withColumnWriter` instead
+        /// > Warning: Do not call this directly; call ``ColumnWriter/withColumnWriter(writingTo:body:)`` instead.
         @usableFromInline
         init(_underlying: UnsafeMutablePointer<PostgresBinaryCopyFromWriter>) {
             self.underlying = _underlying
@@ -126,7 +126,7 @@ public struct PostgresBinaryCopyFromWriter: ~Copyable {
             body: (inout ColumnWriter) throws(E) -> T
         ) throws(E) -> T {
             return try withUnsafeMutablePointer(to: &underlying) { pointerToUnderlying throws(E) in
-                // We can guarantee that `ColumWriter` never outlives `underlying` because `ColumnWriter` is
+                // We can guarantee that `ColumnWriter` never outlives `underlying` because `ColumnWriter` is
                 // `~Escapable` and thus cannot escape the context of the closure to `withUnsafeMutablePointer`.
                 // To model this without resorting to unsafe pointers, we would need to be able to declare an `inout`
                 // reference to `PostgresBinaryCopyFromWriter` as a member of `ColumnWriter`, which isn't possible at
@@ -138,10 +138,10 @@ public struct PostgresBinaryCopyFromWriter: ~Copyable {
 
         /// Serialize a single column to a row.
         ///
-        /// - Important: It is critical that that data type encoded here exactly matches the data type in the
-        ///   database. For example, if the database stores an a 4-byte integer the corresponding `writeColumn` must
-        ///   be called with an `Int32`. Serializing an integer of a different width will cause a deserialization
-        ///   failure in the backend.
+        /// > Important: It is critical that that data type encoded here exactly matches the data type in the
+        /// > database. For example, if the database stores an a 4-byte integer the corresponding `writeColumn` must
+        /// > be called with an `Int32`. Serializing an integer of a different width will cause a deserialization
+        /// > failure in the backend.
         @inlinable
         #if compiler(<6.3)
         @_lifetime(&self)
@@ -162,7 +162,7 @@ public struct PostgresBinaryCopyFromWriter: ~Copyable {
         }
     }
 
-    /// The underlying `PostgresCopyFromWriter` that sends the serialized data to the backend.
+    /// The underlying ``PostgresCopyFromWriter`` that sends the serialized data to the backend.
     @usableFromInline let underlying: PostgresCopyFromWriter
 
     /// The buffer in which we accumulate binary data. Once this buffer exceeds `bufferSize`, we flush it to
@@ -179,7 +179,7 @@ public struct PostgresBinaryCopyFromWriter: ~Copyable {
         self.bufferSize = bufferSize
     }
 
-    /// Serialize a single row to the backend. Call `writeColumn` on `columnWriter` for every column that should be
+    /// Serialize a single row to the backend. Call ``ColumnWriter/writeColumn(_:)`` for every column that should be
     /// included in the row.
     @inlinable
     public mutating func writeRow<Result>(_ body: (_ columnWriter: inout ColumnWriter) throws -> Result) async throws -> Result {
@@ -201,7 +201,7 @@ public struct PostgresBinaryCopyFromWriter: ~Copyable {
         return bodyResult
     }
 
-    /// Serialize a single column to the buffer. Should only be called by `ColumnWriter`.
+    /// Serialize a single column to the buffer. Should only be called by ``ColumnWriter``.
     @inlinable
     mutating func writeColumn(_ column: (some PostgresEncodable)?) throws {
         guard let column else {
@@ -310,8 +310,9 @@ extension PostgresConnection {
     ///   - columns: The name of the columns to copy. If an empty array is passed, all columns are assumed to be copied.
     ///   - bufferSize: How many bytes to accumulate a local buffer before flushing it to the database. Can affect
     ///     performance characteristics of the copy operation.
-    ///   - writeData: Closure that produces the data for the table, to be streamed to the backend. Call `write` on the
-    ///     writer provided by the closure to send data to the backend and return from the closure once all data is sent.
+    ///   - writeData: Closure that produces the data for the table, to be streamed to the backend. Call
+    ///     ``PostgresBinaryCopyFromWriter/writeRow(_:)`` on the writer provided by the closure to send data to the
+    ///     backend and return from the closure once all data is sent.
     ///     Throw an error from the closure to fail the data transfer. The error thrown by the closure will be rethrown
     ///     by the `copyFromBinary` function.
     ///
@@ -358,8 +359,9 @@ extension PostgresConnection {
     ///   - logger: The `Logger` to log into for the operation.
     ///   - file: The file the operation was started in. Used for better error reporting.
     ///   - line: The line the operation was started in. Used for better error reporting.
-    ///   - writeData: Closure that produces the data for the table, to be streamed to the backend. Call `write` on the
-    ///     writer provided by the closure to send data to the backend and return from the closure once all data is sent.
+    ///   - writeData: Closure that produces the data for the table, to be streamed to the backend. Call
+    ///     ``PostgresCopyFromWriter/write(_:)`` on the writer provided by the closure to send data to the backend and
+    ///     return from the closure once all data is sent.
     ///     Throw an error from the closure to fail the data transfer. The error thrown by the closure will be rethrown
     ///     by the `copyFrom` function.
     ///

--- a/Tests/IntegrationTests/PSQLIntegrationTests.swift
+++ b/Tests/IntegrationTests/PSQLIntegrationTests.swift
@@ -487,4 +487,38 @@ final class IntegrationTests: XCTestCase {
             XCTAssertEqual((error as? PSQLError)?.serverInfo?[.sqlState], "42601") // scanner_yyerror
         }
     }
+
+    func testCopyFromBinary() async throws {
+        let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 2)
+        defer { XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully()) }
+        let eventLoop = eventLoopGroup.next()
+
+        let conn = try await PostgresConnection.test(on: eventLoop).get()
+        defer { XCTAssertNoThrow(try conn.close().wait()) }
+
+        _ = try? await conn.query("DROP TABLE copy_table", logger: .psqlTest).get()
+        _ = try await conn.query("CREATE TABLE copy_table (id INT, name VARCHAR(100))", logger: .psqlTest).get()
+
+        try await conn.copyFromBinary(table: "copy_table", columns: ["id", "name"], logger: .psqlTest) { writer in
+            let records: [(id: Int, name: String)] = [
+                (1, "Alice"),
+                (42, "Bob")
+            ]
+            for record in records {
+                try await writer.writeRow { columnWriter in
+                    try columnWriter.writeColumn(Int32(record.id))
+                    try columnWriter.writeColumn(record.name)
+                }
+            }
+        }
+        let rows = try await conn.query("SELECT id, name FROM copy_table").get().rows.map { try $0.decode((Int, String).self) }
+        guard rows.count == 2 else {
+            XCTFail("Expected 2 columns, received \(rows.count)")
+            return
+        }
+        XCTAssertEqual(rows[0].0, 1)
+        XCTAssertEqual(rows[0].1, "Alice")
+        XCTAssertEqual(rows[1].0, 42)
+        XCTAssertEqual(rows[1].1, "Bob")
+    }
 }

--- a/Tests/IntegrationTests/PSQLIntegrationTests.swift
+++ b/Tests/IntegrationTests/PSQLIntegrationTests.swift
@@ -488,6 +488,7 @@ final class IntegrationTests: XCTestCase {
         }
     }
 
+    #if compiler(>=6.2) // copyFromBinary is only available in Swift 6.2+
     func testCopyFromBinary() async throws {
         let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 2)
         defer { XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully()) }
@@ -521,4 +522,5 @@ final class IntegrationTests: XCTestCase {
         XCTAssertEqual(rows[1].0, 42)
         XCTAssertEqual(rows[1].1, "Bob")
     }
+    #endif
 }

--- a/Tests/PostgresNIOTests/New/PostgresConnectionTests.swift
+++ b/Tests/PostgresNIOTests/New/PostgresConnectionTests.swift
@@ -949,6 +949,7 @@ import Synchronization
         }
     }
 
+    #if compiler(>=6.2) // copyFromBinary is only available in Swift 6.2+
     @Test func testCopyFromBinary() async throws {
         try await self.withAsyncTestingChannel { connection, channel in
             try await withThrowingTaskGroup(of: Void.self) { taskGroup async throws -> Void in
@@ -1010,6 +1011,7 @@ import Synchronization
             }
         }
     }
+    #endif
 
     func withAsyncTestingChannel(_ body: (PostgresConnection, NIOAsyncTestingChannel) async throws -> ()) async throws {
         let eventLoop = NIOAsyncTestingEventLoop()

--- a/Tests/PostgresNIOTests/New/PostgresConnectionTests.swift
+++ b/Tests/PostgresNIOTests/New/PostgresConnectionTests.swift
@@ -1085,7 +1085,8 @@ import Synchronization
                     let name: String
                 }
                 var rows: [Row] = []
-                while data.readableBytes > 0 {
+                // Read until we are only left with the trailer
+                while data.readableBytes > 2 {
                     // Number of columns
                     #expect(data.readInteger(as: UInt16.self) == 2)
                     // 'id' column
@@ -1097,6 +1098,9 @@ import Synchronization
                     rows.append(Row(id: try #require(id), name: try #require(name)))
                 }
                 #expect(rows == [Row(id: 1, name: "Alice"), Row(id: 2, name: "Bob")])
+                // Trailer
+                #expect(data.readInteger(as: Int16.self) == -1)
+                
                 try await channel.writeInbound(PostgresBackendMessage.commandComplete("COPY 1"))
 
                 try await channel.waitForPostgresFrontendMessage(\.sync)


### PR DESCRIPTION
My benchmark of transferring the integers from 0 to 1,000,000 both as an integer and as a string was about the same speed as the old text-based transfer. I believe that the binary transfer will start to show significant benefits when transferring binary data, other fields that don't need to be represented as fields and also means that the user doesn't need to worry about escapping their data.

A call to binary transfer data looks as follows

```swift
let records: [(id: Int, name: String)] = [(1, "Alice"), (42, "Bob")]
try await conn.copyFromBinary(table: "copy_table", columns: ["id", "name"], logger: .psqlTest) { writer in
    for record in records {
        try await writer.writeRow { columnWriter in
            try columnWriter.writeColumn(Int32(record.id))
            try columnWriter.writeColumn(record.name)
        }
    }
}
```