### PR TITLE
Log connection failed events at info level

### DIFF
--- a/Sources/PostgresNIO/Pool/PostgresClientMetrics.swift
+++ b/Sources/PostgresNIO/Pool/PostgresClientMetrics.swift
@@ -19,7 +19,7 @@ final class PostgresClientMetrics: ConnectionPoolObservabilityDelegate {
     /// A connection attempt failed with the given error. After some period of
     /// time ``startedConnecting(id:)`` may be called again.
     func connectFailed(id: ConnectionID, error: Error) {
-        self.logger.debug("Connection creation failed", metadata: [
+        self.logger.info("Connection creation failed", metadata: [
             .connectionID: "\(id)",
             .error: "\(String(reflecting: error))"
         ])


### PR DESCRIPTION
According to the logging best practices [001: Choosing log levels](https://swiftpackageindex.com/apple/swift-log/main/documentation/logging/001-choosingloglevels#For-libraries) it is okay for libraries to chose the `info` log level "[...] for things that went wrong but can’t be communicated through other means like throwing from a method".

Postgres connection errors are currently not surfaced and retried forever. To provide better visibility for these cases we bump the log level from `debug` to `info` in this case.