### PR TITLE
Include the channel name in `PostgresNotification`s.

### DIFF
--- a/Sources/PostgresNIO/New/NotificationListener.swift
+++ b/Sources/PostgresNIO/New/NotificationListener.swift
@@ -1,6 +1,6 @@
 import NIOCore
 
-// This object is @unchecked Sendable, since we syncronize state on the EL
+// This object is @unchecked Sendable, since we synchronize state on the EL
 final class NotificationListener: @unchecked Sendable {
     let eventLoop: EventLoop
 
@@ -86,7 +86,7 @@ final class NotificationListener: @unchecked Sendable {
         case .streamInitialized, .done:
             fatalError("Invalid state: \(self.state)")
         case .streamListening(let continuation):
-            continuation.yield(.init(payload: backendMessage.payload))
+            continuation.yield(.init(channel: backendMessage.channel, payload: backendMessage.payload))
 
         case .closure(let postgresListenContext, let closure):
             let message = PostgresMessage.NotificationResponse(

--- a/Sources/PostgresNIO/New/PostgresNotificationSequence.swift
+++ b/Sources/PostgresNIO/New/PostgresNotificationSequence.swift
@@ -1,5 +1,6 @@
 
 public struct PostgresNotification: Sendable {
+    public let channel: String
     public let payload: String
 }
 


### PR DESCRIPTION
When using the old-style `PostgresConnection.addListener(channel:handler:)` API, the closure would receive `PostgresMessage.NotificationResponse` structures, which contained both the notification payload and the channel name. However, when using the modern Concurrency-based `PostgresConnection.listen(_:)` API, the resulting `PostgresNotificationSequence` carries `PostgresNotification` structs, which include only the payload. This PR adds the channel name to `PostgresNotification`, keeping API compatibility (although the change is technically `semver-minor` due to the addition of a new public property).

This is step one of better support for listening on multiple channels on the same connection, which is currently possible but awkward at best. With this change, one can now distinguish multiple channels using the Concurrency-based API, which was not possible before, although issuing additional `LISTEN` queries to receive multiple channels did work. Step two of this support will involve making the API able to issue the `LISTEN` and `UNLISTEN` queries for multiple channels on its own. Calling `PostgresConnection.listen(_:)` twice (or more) on the same connection is, of course, worse than useless—even if you merge the resulting sequences, each sequence will receive its own copy of each notification for both channels. I could also have implemented this PR by having each `NotificationListener` filter notifications and only deliver the ones for its own channel, but that makes matters much, much more painful for callers who then have to multiplex multiple async sequences, and `swift-async-algorithms`'s `merge(_:_:)` is both limited in arity and a lot less efficient than just receiving all channels' notifications on a single sequence.