### PR TITLE
Fix json platform version warning

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,10 +8,10 @@ let swiftSettings: [SwiftSetting] = [
 let package = Package(
     name: "postgres-nio",
     platforms: [
-        .macOS(.v10_15),
-        .iOS(.v13),
-        .watchOS(.v6),
-        .tvOS(.v13),
+        .macOS(.v11),
+        .iOS(.v16),
+        .watchOS(.v9),
+        .tvOS(.v16),
     ],
     products: [
         .library(name: "PostgresNIO", targets: ["PostgresNIO"]),

--- a/Sources/PostgresNIO/Utilities/PostgresJSONDecoder.swift
+++ b/Sources/PostgresNIO/Utilities/PostgresJSONDecoder.swift
@@ -22,7 +22,6 @@ extension PostgresJSONDecoder {
     }
 }
 
-//@available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
 extension JSONDecoder: PostgresJSONDecoder {}
 
 private let jsonDecoderLocked: NIOLockedValueBox<PostgresJSONDecoder> = NIOLockedValueBox(JSONDecoder())


### PR DESCRIPTION
Build Warning Log

```
Conformance of 'JSONEncoder' to 'Sendable' is only available in macOS 13.0 or newer
```

<img width="894" height="34" alt="Screenshot 2025-09-06 at 14 35 09" src="https://github.com/user-attachments/assets/3e3fc8e9-0a7a-4699-a896-5a94a6320021" />
