### PR TITLE
add Sendable to fix warning

### DIFF
--- a/Sources/PostgresNIO/New/Data/Range+PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/Data/Range+PostgresCodable.swift
@@ -88,6 +88,8 @@ struct PostgresRange<Bound> {
     }
 }
 
+extension PostgresRange: Sendable where Bound: Sendable {}
+
 /// Used by Postgres to represent certain range properties
 @usableFromInline
 struct PostgresRangeFlag {

--- a/Sources/PostgresNIO/New/VariadicGenerics.swift
+++ b/Sources/PostgresNIO/New/VariadicGenerics.swift
@@ -116,7 +116,7 @@ extension PostgresRow {
 extension AsyncSequence where Element == PostgresRow {
     // --- snip TODO: Remove once bug is fixed, that disallows tuples of one
     @inlinable
-    public func decode<Column: PostgresDecodable>(
+    public func decode<Column: PostgresDecodable & Sendable>(
         _: Column.Type,
         context: PostgresDecodingContext<some PostgresJSONDecoder>,
         file: String = #fileID,
@@ -128,7 +128,7 @@ extension AsyncSequence where Element == PostgresRow {
     }
 
     @inlinable
-    public func decode<Column: PostgresDecodable>(
+    public func decode<Column: PostgresDecodable & Sendable>(
         _: Column.Type,
         file: String = #fileID,
         line: Int = #line
@@ -137,7 +137,7 @@ extension AsyncSequence where Element == PostgresRow {
     }
     // --- snap TODO: Remove once bug is fixed, that disallows tuples of one
 
-    public func decode<each Column: PostgresDecodable>(
+    public func decode<each Column: PostgresDecodable & Sendable>(
         _ columnType: (repeat each Column).Type,
         context: PostgresDecodingContext<some PostgresJSONDecoder>,
         file: String = #fileID,
@@ -148,7 +148,7 @@ extension AsyncSequence where Element == PostgresRow {
         }
     }
 
-    public func decode<each Column: PostgresDecodable>(
+    public func decode<each Column: PostgresDecodable & Sendable>(
         _ columnType: (repeat each Column).Type,
         file: String = #fileID,
         line: Int = #line


### PR DESCRIPTION
Build Warning Log

```
Capture of non-Sendable type 'Column.Type' in an isolated closure
```

<img width="1003" height="192" alt="Screenshot 2025-09-06 at 14 36 18" src="https://github.com/user-attachments/assets/e5bc571c-d609-493c-9ddb-481ca378e71b" />
