### PR TITLE
Don't log misleading errors when the client closes a connection

### DIFF
--- a/Sources/PostgresNIO/New/PostgresChannelHandler.swift
+++ b/Sources/PostgresNIO/New/PostgresChannelHandler.swift
@@ -567,8 +567,13 @@ final class PostgresChannelHandler: ChannelDuplexHandler {
         _ cleanup: ConnectionStateMachine.ConnectionAction.CleanUpContext,
         context: ChannelHandlerContext
     ) {
-        self.logger.debug("Cleaning up and closing connection.", metadata: [.error: "\(cleanup.error)"])
-        
+        // Don't log a misleading error if the client closed the connection.
+        if cleanup.error.code == .clientClosedConnection {
+            self.logger.debug("Cleaning up and closing connection.")
+        } else {
+            self.logger.debug("Cleaning up and closing connection.", metadata: [.error: "\(cleanup.error)"])
+        }
+
         // 1. fail all tasks
         cleanup.tasks.forEach { task in
             task.failWithError(cleanup.error)


### PR DESCRIPTION
Currently, we unconditionally include `.clientClosedConnection` errors in the logging for connection closure. Even though this is a `debug`-level log, this error is unnecessarily noisy and potentially misleading, since nothing has actually gone wrong. This PR no longer includes `.clientClosedConnection` errors in the log metadata for normal connection termination.