### PR TITLE
Throw error when `PostgresCopyFromWriter` is escaped

### DIFF
--- a/Sources/PostgresNIO/Connection/PostgresConnection+CopyFrom.swift
+++ b/Sources/PostgresNIO/Connection/PostgresConnection+CopyFrom.swift
@@ -1,3 +1,13 @@
+/// Error thrown when `PostgresCopyFromWriter.write` is called while the backend is not expecting `CopyData` messages.
+/// 
+/// This should only happen if the user explicitly escapes the `PostgresCopyFromWriter` from the `copyFrom` closure and
+/// tries to write data to it when tries to write data after the `copyFrom` call has terminated.
+struct NotInCopyFromModeError: Error, CustomStringConvertible {
+    var description: String {
+        "Writing COPY FROM data when backend is not in COPY mode"
+    }
+}
+
 /// Handle to send data for a `COPY ... FROM STDIN` query to the backend.
 public struct PostgresCopyFromWriter: Sendable {
     private let channelHandler: NIOLoopBound<PostgresChannelHandler>

--- a/Sources/PostgresNIO/Connection/PostgresConnection+CopyFrom.swift
+++ b/Sources/PostgresNIO/Connection/PostgresConnection+CopyFrom.swift
@@ -1,13 +1,3 @@
-/// Error thrown when `PostgresCopyFromWriter.write` is called while the backend is not expecting `CopyData` messages.
-/// 
-/// This should only happen if the user explicitly escapes the `PostgresCopyFromWriter` from the `copyFrom` closure and
-/// tries to write data to it when tries to write data after the `copyFrom` call has terminated.
-struct NotInCopyFromModeError: Error, CustomStringConvertible {
-    var description: String {
-        "Writing COPY FROM data when backend is not in COPY mode"
-    }
-}
-
 /// Handle to send data for a `COPY ... FROM STDIN` query to the backend.
 public struct PostgresCopyFromWriter: Sendable {
     private let channelHandler: NIOLoopBound<PostgresChannelHandler>

--- a/Sources/PostgresNIO/New/Connection State Machine/ConnectionStateMachine.swift
+++ b/Sources/PostgresNIO/New/Connection State Machine/ConnectionStateMachine.swift
@@ -827,7 +827,7 @@ struct ConnectionStateMachine {
     /// should be aborted to avoid unnecessary work.
     mutating func checkBackendCanReceiveCopyData(channelIsWritable: Bool, promise: EventLoopPromise<Void>) -> CheckBackendCanReceiveCopyDataAction {
         guard case .extendedQuery(var queryState, let connectionContext) = self.state else {
-            preconditionFailure("Copy mode is only supported for extended queries")
+            return .failPromise(promise, error: NotInCopyFromModeError())
         }
 
         self.state = .modifying // avoid CoW

--- a/Sources/PostgresNIO/New/Connection State Machine/ConnectionStateMachine.swift
+++ b/Sources/PostgresNIO/New/Connection State Machine/ConnectionStateMachine.swift
@@ -827,7 +827,7 @@ struct ConnectionStateMachine {
     /// should be aborted to avoid unnecessary work.
     mutating func checkBackendCanReceiveCopyData(channelIsWritable: Bool, promise: EventLoopPromise<Void>) -> CheckBackendCanReceiveCopyDataAction {
         guard case .extendedQuery(var queryState, let connectionContext) = self.state else {
-            return .failPromise(promise, error: NotInCopyFromModeError())
+            return .failPromise(promise, error: PSQLError.notInCopyMode)
         }
 
         self.state = .modifying // avoid CoW
@@ -1089,7 +1089,7 @@ extension ConnectionStateMachine {
              .uncleanShutdown,
              .unlistenFailed:
             return true
-        case .queryCancelled:
+        case .queryCancelled, .notInCopyMode:
             return false
         case .server, .listenFailed:
             guard let sqlState = error.serverInfo?[.sqlState] else {

--- a/Sources/PostgresNIO/New/Connection State Machine/ExtendedQueryStateMachine.swift
+++ b/Sources/PostgresNIO/New/Connection State Machine/ExtendedQueryStateMachine.swift
@@ -430,7 +430,7 @@ struct ExtendedQueryStateMachine {
             return .failPromise(promise, error: error)
         }
         guard case .copyingData(.readyToSend) = self.state else {
-            preconditionFailure("Not ready to send data")
+            return .failPromise(promise, error: NotInCopyFromModeError())
         }
         if channelIsWritable {
             return .succeedPromise(promise)

--- a/Sources/PostgresNIO/New/Connection State Machine/ExtendedQueryStateMachine.swift
+++ b/Sources/PostgresNIO/New/Connection State Machine/ExtendedQueryStateMachine.swift
@@ -430,7 +430,7 @@ struct ExtendedQueryStateMachine {
             return .failPromise(promise, error: error)
         }
         guard case .copyingData(.readyToSend) = self.state else {
-            return .failPromise(promise, error: NotInCopyFromModeError())
+            return .failPromise(promise, error: PSQLError.notInCopyMode)
         }
         if channelIsWritable {
             return .succeedPromise(promise)

--- a/Sources/PostgresNIO/New/PSQLError.swift
+++ b/Sources/PostgresNIO/New/PSQLError.swift
@@ -23,6 +23,7 @@ public struct PSQLError: Error, @unchecked Sendable {
             case serverClosedConnection
             case connectionError
             case uncleanShutdown
+            case notInCopyMode
 
             case listenFailed
             case unlistenFailed
@@ -52,6 +53,7 @@ public struct PSQLError: Error, @unchecked Sendable {
         public static let connectionError = Self(.connectionError)
 
         public static let uncleanShutdown = Self(.uncleanShutdown)
+        public static let notInCopyMode = Self(.notInCopyMode)
         public static let poolClosed = Self(.poolClosed)
 
         public static let listenFailed = Self.init(.listenFailed)
@@ -97,6 +99,8 @@ public struct PSQLError: Error, @unchecked Sendable {
                 return "connectionError"
             case .uncleanShutdown:
                 return "uncleanShutdown"
+            case .notInCopyMode:
+                return "notInCopyMode"
             case .poolClosed:
                 return "poolClosed"
             case .listenFailed:
@@ -409,6 +413,8 @@ public struct PSQLError: Error, @unchecked Sendable {
     static let queryCancelled = PSQLError(code: .queryCancelled)
 
     static let uncleanShutdown = PSQLError(code: .uncleanShutdown)
+
+    static let notInCopyMode = PSQLError(code: .notInCopyMode)
 
     static let receivedUnencryptedDataAfterSSLRequest = PSQLError(code: .receivedUnencryptedDataAfterSSLRequest)
 

--- a/Sources/PostgresNIO/Postgres+PSQLCompat.swift
+++ b/Sources/PostgresNIO/Postgres+PSQLCompat.swift
@@ -46,6 +46,8 @@ extension PSQLError {
             return self.underlying ?? self
         case .uncleanShutdown:
             return PostgresError.protocol("Unexpected connection close")
+        case .notInCopyMode:
+            return PostgresError.protocol("Cannot write into copy writer outside of copy mode")
         case .poolClosed:
             return self
         }

--- a/Tests/PostgresNIOTests/New/Connection State Machine/ExtendedQueryStateMachineTests.swift
+++ b/Tests/PostgresNIOTests/New/Connection State Machine/ExtendedQueryStateMachineTests.swift
@@ -295,4 +295,27 @@ class ExtendedQueryStateMachineTests: XCTestCase {
         XCTAssertEqual(state.readyForQueryReceived(.idle), .fireEventReadyForQuery)
     }
 
+    func testCheckBackendCanReceiveCopyDataFailsIfQueryIsNotInCopyMode() {
+        var state = ConnectionStateMachine.readyForQuery()
+
+        let logger = Logger.psqlTest
+        let eventLoop = EmbeddedEventLoop()
+        let queryPromise = eventLoop.makePromise(of: PSQLRowStream.self)
+        queryPromise.fail(PSQLError.uncleanShutdown) // we don't care about the error at all.
+        let query: PostgresQuery = "SELECT version()"
+        let queryContext = ExtendedQueryContext(query: query, logger: logger, promise: queryPromise)
+
+        XCTAssertEqual(state.enqueue(task: .extendedQuery(queryContext)), .sendParseDescribeBindExecuteSync(query))
+
+        // A query is in flight but the backend is not in copy mode, so writing copy data must fail.
+        let writePromise = eventLoop.makePromise(of: Void.self)
+        guard case .failPromise(let promise, let error) = state.checkBackendCanReceiveCopyData(channelIsWritable: true, promise: writePromise) else {
+            return XCTFail("Expected checkBackendCanReceiveCopyData to fail the promise")
+        }
+        XCTAssertEqual((error as? PSQLError)?.code, .notInCopyMode)
+        promise.fail(error)
+        XCTAssertThrowsError(try writePromise.futureResult.wait()) { error in
+            XCTAssertEqual((error as? PSQLError)?.code, .notInCopyMode)
+        }
+    }
 }

--- a/Tests/PostgresNIOTests/New/PostgresConnectionTests.swift
+++ b/Tests/PostgresNIOTests/New/PostgresConnectionTests.swift
@@ -936,6 +936,36 @@ import Synchronization
         }
     }
 
+    @Test func testWritingDataAfterCopyFromHasFinishedThrowsError() async throws {
+        try await self.withAsyncTestingChannel { connection, channel in
+            try await withThrowingTaskGroup(of: Void.self) { taskGroup async throws -> () in
+                taskGroup.addTask {
+                    var escapedWriter: PostgresCopyFromWriter?
+                    try await connection.copyFrom(table: "test", logger: .psqlTest) { writer in
+                        escapedWriter = writer
+                    }
+                    let writer = try #require(escapedWriter)
+                    await #expect(throws: (any Error).self) {
+                        try await writer.write(ByteBuffer(string: "oops"))
+                    }
+                }
+
+                _ = try await channel.waitForUnpreparedRequest()
+
+                try await channel.sendUnpreparedRequestWithNoParametersBindResponse()
+                try await channel.writeInbound(PostgresBackendMessage.copyInResponse(.init(format: .textual, columnFormats: Array(repeating: .textual, count: 2))))
+
+                _ = try await channel.waitForCopyData()
+                try await channel.writeInbound(PostgresBackendMessage.commandComplete("COPY 0"))
+
+                try await channel.waitForPostgresFrontendMessage(\.sync)
+                try await channel.writeInbound(PostgresBackendMessage.readyForQuery(.idle))
+                
+                try await taskGroup.waitForAll()
+            }
+        }
+    }
+
     func withAsyncTestingChannel(_ body: (PostgresConnection, NIOAsyncTestingChannel) async throws -> ()) async throws {
         let eventLoop = NIOAsyncTestingEventLoop()
         let channel = try await NIOAsyncTestingChannel(loop: eventLoop) { channel in

--- a/Tests/PostgresNIOTests/New/PostgresConnectionTests.swift
+++ b/Tests/PostgresNIOTests/New/PostgresConnectionTests.swift
@@ -945,9 +945,10 @@ import Synchronization
                         escapedWriter = writer
                     }
                     let writer = try #require(escapedWriter)
-                    await #expect(throws: (any Error).self) {
+                    let error = await #expect(throws: PSQLError.self) {
                         try await writer.write(ByteBuffer(string: "oops"))
                     }
+                    #expect(error?.code == .notInCopyMode)
                 }
 
                 _ = try await channel.waitForUnpreparedRequest()


### PR DESCRIPTION
When `PostgresCopyFromWriter` is escaped from the `copyFrom` closure (which users really shouldn’t do) and the user tries to write data to it after `copyFrom` has finished, throw an error instead of hitting a `preconditionFailure`.
