### PR TITLE
Rethrow error thrown from `withAsyncTestingChannel` closure

### DIFF
--- a/Tests/PostgresNIOTests/New/PostgresConnectionTests.swift
+++ b/Tests/PostgresNIOTests/New/PostgresConnectionTests.swift
@@ -964,7 +964,8 @@ import Synchronization
         do {
             try await body(connection, channel)
         } catch {
-
+            try await connection.close()
+            throw error
         }
 
         try await connection.close()

--- a/Tests/PostgresNIOTests/New/PostgresConnectionTests.swift
+++ b/Tests/PostgresNIOTests/New/PostgresConnectionTests.swift
@@ -1098,7 +1098,7 @@ import Synchronization
         do {
             try await body(connection, channel)
         } catch {
-            try await connection.close()
+            try? await connection.close()
             throw error
         }
 


### PR DESCRIPTION
Currently, when the closure of `withAsyncTestingChannel` throws, the error is just swallowed silently and the test passes. Actually rethrow it so the test fails
