### PR TITLE
Improve tests, remove state shortcuts

### DIFF
--- a/Sources/PostgresNIO/New/Connection State Machine/ConnectionStateMachine.swift
+++ b/Sources/PostgresNIO/New/Connection State Machine/ConnectionStateMachine.swift
@@ -161,14 +161,6 @@ struct ConnectionStateMachine {
         self.requireBackendKeyData = requireBackendKeyData
     }
 
-    #if DEBUG
-    /// for testing purposes only
-    init(_ state: State, requireBackendKeyData: Bool = true) {
-        self.state = state
-        self.requireBackendKeyData = requireBackendKeyData
-    }
-    #endif
-
     enum TLSConfiguration {
         case disable
         case prefer

--- a/Sources/PostgresNIO/New/PostgresChannelHandler.swift
+++ b/Sources/PostgresNIO/New/PostgresChannelHandler.swift
@@ -171,7 +171,7 @@ final class PostgresChannelHandler: ChannelDuplexHandler {
             promise.succeed()
         case .failPromise(let promise, error: let error):
             promise.fail(error)
-}
+        }
     }
 
     /// Cancel the currently executing operation, if it is cancellable.

--- a/Sources/PostgresNIO/New/PostgresChannelHandler.swift
+++ b/Sources/PostgresNIO/New/PostgresChannelHandler.swift
@@ -38,24 +38,6 @@ final class PostgresChannelHandler: ChannelDuplexHandler {
         self.logger = logger
         self.decoder = NIOSingleStepByteToMessageProcessor(PostgresBackendMessageDecoder())
     }
-    
-    #if DEBUG
-    /// for testing purposes only
-    init(
-        configuration: PostgresConnection.InternalConfiguration,
-        eventLoop: any EventLoop,
-        state: ConnectionStateMachine = .init(.initialized),
-        logger: Logger = .psqlNoOpLogger,
-        configureSSLCallback: ((any Channel, PostgresChannelHandler) throws -> Void)?
-    ) {
-        self.state = state
-        self.eventLoop = eventLoop
-        self.configuration = configuration
-        self.configureSSLCallback = configureSSLCallback
-        self.logger = logger
-        self.decoder = NIOSingleStepByteToMessageProcessor(PostgresBackendMessageDecoder())
-    }
-    #endif
 
     // MARK: Handler lifecycle
     

--- a/Tests/PostgresNIOTests/New/Connection State Machine/ConnectionStateMachineTests.swift
+++ b/Tests/PostgresNIOTests/New/Connection State Machine/ConnectionStateMachineTests.swift
@@ -59,9 +59,9 @@ import NIOSSL
         #expect(state.sslUnsupportedReceived() == .provideAuthenticationContext)
     }
         
-    @Test func testParameterStatusReceivedAndBackendKeyAfterAuthenticated() {
-        var state = ConnectionStateMachine(.authenticated(nil, [:]))
-        
+    @Test func testParameterStatusReceivedAndBackendKeyAfterAuthenticated() throws {
+        var state = try ConnectionStateMachine.makeAuthenticatedIdle()
+
         #expect(state.parameterStatusReceived(.init(parameter: "DateStyle", value: "ISO, MDY")) == .wait)
         #expect(state.parameterStatusReceived(.init(parameter: "application_name", value: "")) == .wait)
         #expect(state.parameterStatusReceived(.init(parameter: "server_encoding", value: "UTF8")) == .wait)
@@ -78,9 +78,9 @@ import NIOSSL
         #expect(state.readyForQueryReceived(.idle) == .fireEventReadyForQuery)
     }
     
-    @Test func testBackendKeyAndParameterStatusReceivedAfterAuthenticated() {
-        var state = ConnectionStateMachine(.authenticated(nil, [:]))
-        
+    @Test func testBackendKeyAndParameterStatusReceivedAfterAuthenticated() throws {
+        var state = try ConnectionStateMachine.makeAuthenticatedIdle()
+
         #expect(state.backendKeyDataReceived(.init(processID: 2730, secretKey: 882037977)) == .wait)
 
         #expect(state.parameterStatusReceived(.init(parameter: "DateStyle", value: "ISO, MDY")) == .wait)
@@ -98,9 +98,9 @@ import NIOSSL
         #expect(state.readyForQueryReceived(.idle) == .fireEventReadyForQuery)
     }
     
-    @Test func testReadyForQueryReceivedWithoutBackendKeyAfterAuthenticated() {
-        var state = ConnectionStateMachine(.authenticated(nil, [:]), requireBackendKeyData: true)
-        
+    @Test func testReadyForQueryReceivedWithoutBackendKeyAfterAuthenticated() throws {
+        var state = try ConnectionStateMachine.makeAuthenticatedIdle()
+
         #expect(state.parameterStatusReceived(.init(parameter: "DateStyle", value: "ISO, MDY")) == .wait)
         #expect(state.parameterStatusReceived(.init(parameter: "application_name", value: "")) == .wait)
         #expect(state.parameterStatusReceived(.init(parameter: "server_encoding", value: "UTF8")) == .wait)
@@ -117,9 +117,9 @@ import NIOSSL
                        .closeConnectionAndCleanup(.init(action: .close, tasks: [], error: PSQLError.unexpectedBackendMessage(.readyForQuery(.idle)), closePromise: nil)))
     }
     
-    @Test func testReadyForQueryReceivedWithoutUnneededBackendKeyAfterAuthenticated() {
-        var state = ConnectionStateMachine(.authenticated(nil, [:]), requireBackendKeyData: false)
-        
+    @Test func testReadyForQueryReceivedWithoutUnneededBackendKeyAfterAuthenticated() throws {
+        var state = try ConnectionStateMachine.makeAuthenticatedIdle(requireBackendKeyData: false)
+
         #expect(state.parameterStatusReceived(.init(parameter: "DateStyle", value: "ISO, MDY")) == .wait)
         #expect(state.parameterStatusReceived(.init(parameter: "application_name", value: "")) == .wait)
         #expect(state.parameterStatusReceived(.init(parameter: "server_encoding", value: "UTF8")) == .wait)
@@ -135,16 +135,18 @@ import NIOSSL
         #expect(state.readyForQueryReceived(.idle) == .fireEventReadyForQuery)
     }
     
-    @Test func testErrorIsIgnoredWhenClosingConnection() {
+    @Test func testErrorIsIgnoredWhenClosingConnection() throws {
         // test ignore unclean shutdown when closing connection
-        var stateIgnoreChannelError = ConnectionStateMachine(.closing(nil))
+        var stateIgnoreChannelError = try ConnectionStateMachine.makeReadyForQuery()
+        #expect(.closeConnection(nil) == stateIgnoreChannelError.gracefulClose(nil))
 
         #expect(stateIgnoreChannelError.errorHappened(.connectionError(underlying: NIOSSLError.uncleanShutdown)) == .wait)
         #expect(stateIgnoreChannelError.closed() == .fireChannelInactive)
 
         // test ignore any other error when closing connection
         
-        var stateIgnoreErrorMessage = ConnectionStateMachine(.closing(nil))
+        var stateIgnoreErrorMessage = try ConnectionStateMachine.makeReadyForQuery()
+        #expect(.closeConnection(nil) == stateIgnoreErrorMessage.gracefulClose(nil))
         #expect(stateIgnoreErrorMessage.errorReceived(.init(fields: [:])) == .wait)
         #expect(stateIgnoreErrorMessage.closed() == .fireChannelInactive)
     }

--- a/Tests/PostgresNIOTests/New/Connection State Machine/ExtendedQueryStateMachineTests.swift
+++ b/Tests/PostgresNIOTests/New/Connection State Machine/ExtendedQueryStateMachineTests.swift
@@ -5,10 +5,9 @@ import Logging
 @testable import PostgresNIO
 
 @Suite struct ExtendedQueryStateMachineTests {
-    
-    @Test func testExtendedQueryWithoutDataRowsHappyPath() {
-        var state = ConnectionStateMachine.readyForQuery()
-        
+    @Test func testExtendedQueryWithoutDataRowsHappyPath() throws {
+        var state = try ConnectionStateMachine.makeReadyForQuery()
+
         let logger = Logger.psqlTest
         let promise = EmbeddedEventLoop().makePromise(of: PSQLRowStream.self)
         promise.fail(PSQLError.uncleanShutdown) // we don't care about the error at all.
@@ -24,9 +23,9 @@ import Logging
         #expect(state.readyForQueryReceived(.idle) == .fireEventReadyForQuery)
     }
     
-    @Test func testExtendedQueryWithDataRowsHappyPath() {
-        var state = ConnectionStateMachine.readyForQuery()
-        
+    @Test func testExtendedQueryWithDataRowsHappyPath() throws {
+        var state = try ConnectionStateMachine.makeReadyForQuery()
+
         let logger = Logger.psqlTest
         let promise = EmbeddedEventLoop().makePromise(of: PSQLRowStream.self)
         promise.fail(PSQLError.uncleanShutdown) // we don't care about the error at all.
@@ -78,8 +77,8 @@ import Logging
         #expect(state.readyForQueryReceived(.idle) == .fireEventReadyForQuery)
     }
 
-    @Test func testExtendedQueryWithNoQuery() {
-        var state = ConnectionStateMachine.readyForQuery()
+    @Test func testExtendedQueryWithNoQuery() throws {
+        var state = try ConnectionStateMachine.makeReadyForQuery()
 
         let logger = Logger.psqlTest
         let promise = EmbeddedEventLoop().makePromise(of: PSQLRowStream.self)
@@ -96,9 +95,9 @@ import Logging
         #expect(state.readyForQueryReceived(.idle) == .fireEventReadyForQuery)
     }
 
-    @Test func testReceiveTotallyUnexpectedMessageInQuery() {
-        var state = ConnectionStateMachine.readyForQuery()
-        
+    @Test func testReceiveTotallyUnexpectedMessageInQuery() throws {
+        var state = try ConnectionStateMachine.makeReadyForQuery()
+
         let logger = Logger.psqlTest
         let promise = EmbeddedEventLoop().makePromise(of: PSQLRowStream.self)
         promise.fail(PSQLError.uncleanShutdown) // we don't care about the error at all.
@@ -114,8 +113,8 @@ import Logging
                        .failQuery(promise, with: psqlError, cleanupContext: .init(action: .close, tasks: [], error: psqlError, closePromise: nil)))
     }
 
-    @Test func testExtendedQueryIsCancelledImmediately() {
-        var state = ConnectionStateMachine.readyForQuery()
+    @Test func testExtendedQueryIsCancelledImmediately() throws {
+        var state = try ConnectionStateMachine.makeReadyForQuery()
 
         let logger = Logger.psqlTest
         let promise = EmbeddedEventLoop().makePromise(of: PSQLRowStream.self)
@@ -158,8 +157,8 @@ import Logging
         #expect(state.readyForQueryReceived(.idle) == .fireEventReadyForQuery)
     }
 
-    @Test func testExtendedQueryIsCancelledWithReadPending() {
-        var state = ConnectionStateMachine.readyForQuery()
+    @Test func testExtendedQueryIsCancelledWithReadPending() throws {
+        var state = try ConnectionStateMachine.makeReadyForQuery()
 
         let logger = Logger.psqlTest
         let promise = EmbeddedEventLoop().makePromise(of: PSQLRowStream.self)
@@ -200,8 +199,8 @@ import Logging
         #expect(state.readyForQueryReceived(.idle) == .fireEventReadyForQuery)
     }
 
-    @Test func testCancelQueryAfterServerError() {
-        var state = ConnectionStateMachine.readyForQuery()
+    @Test func testCancelQueryAfterServerError() throws {
+        var state = try ConnectionStateMachine.makeReadyForQuery()
 
         let logger = Logger.psqlTest
         let promise = EmbeddedEventLoop().makePromise(of: PSQLRowStream.self)
@@ -254,8 +253,8 @@ import Logging
         #expect(state.readyForQueryReceived(.idle) == .fireEventReadyForQuery)
     }
 
-    @Test func testQueryErrorDoesNotKillConnection() {
-        var state = ConnectionStateMachine.readyForQuery()
+    @Test func testQueryErrorDoesNotKillConnection() throws {
+        var state = try ConnectionStateMachine.makeReadyForQuery()
 
         let logger = Logger.psqlTest
         let promise = EmbeddedEventLoop().makePromise(of: PSQLRowStream.self)
@@ -275,8 +274,8 @@ import Logging
         #expect(state.readyForQueryReceived(.idle) == .fireEventReadyForQuery)
     }
 
-    @Test func testQueryErrorAfterCancelDoesNotKillConnection() {
-        var state = ConnectionStateMachine.readyForQuery()
+    @Test func testQueryErrorAfterCancelDoesNotKillConnection() throws {
+        var state = try ConnectionStateMachine.makeReadyForQuery()
 
         let logger = Logger.psqlTest
         let promise = EmbeddedEventLoop().makePromise(of: PSQLRowStream.self)
@@ -294,5 +293,4 @@ import Logging
 
         #expect(state.readyForQueryReceived(.idle) == .fireEventReadyForQuery)
     }
-
 }

--- a/Tests/PostgresNIOTests/New/Connection State Machine/PrepareStatementStateMachineTests.swift
+++ b/Tests/PostgresNIOTests/New/Connection State Machine/PrepareStatementStateMachineTests.swift
@@ -1,11 +1,11 @@
-import XCTest
+import Testing
 import NIOEmbedded
 @testable import PostgresNIO
 
-class PrepareStatementStateMachineTests: XCTestCase {
-    func testCreatePreparedStatementReturningRowDescription() {
-        var state = ConnectionStateMachine.readyForQuery()
-        
+@Suite struct PrepareStatementStateMachineTests {
+    @Test func testCreatePreparedStatementReturningRowDescription() throws {
+        var state = try ConnectionStateMachine.makeReadyForQuery()
+
         let promise = EmbeddedEventLoop().makePromise(of: RowDescription?.self)
         promise.fail(PSQLError.uncleanShutdown) // we don't care about the error at all.
         
@@ -15,23 +15,23 @@ class PrepareStatementStateMachineTests: XCTestCase {
             name: name, query: query, bindingDataTypes: [], logger: .psqlTest, promise: promise
         )
 
-        XCTAssertEqual(state.enqueue(task: .extendedQuery(prepareStatementContext)),
+        #expect(state.enqueue(task: .extendedQuery(prepareStatementContext)) ==
                        .sendParseDescribeSync(name: name, query: query, bindingDataTypes: []))
-        XCTAssertEqual(state.parseCompleteReceived(), .wait)
-        XCTAssertEqual(state.parameterDescriptionReceived(.init(dataTypes: [.int8])), .wait)
-        
+        #expect(state.parseCompleteReceived() == .wait)
+        #expect(state.parameterDescriptionReceived(.init(dataTypes: [.int8])) == .wait)
+
         let columns: [RowDescription.Column] = [
             .init(name: "id", tableOID: 0, columnAttributeNumber: 0, dataType: .int8, dataTypeSize: 8, dataTypeModifier: -1, format: .binary)
         ]
         
-        XCTAssertEqual(state.rowDescriptionReceived(.init(columns: columns)),
+        #expect(state.rowDescriptionReceived(.init(columns: columns)) ==
                        .succeedPreparedStatementCreation(promise, with: .init(columns: columns)))
-        XCTAssertEqual(state.readyForQueryReceived(.idle), .fireEventReadyForQuery)
+        #expect(state.readyForQueryReceived(.idle) == .fireEventReadyForQuery)
     }
     
-    func testCreatePreparedStatementReturningNoData() {
-        var state = ConnectionStateMachine.readyForQuery()
-        
+    @Test func testCreatePreparedStatementReturningNoData() throws {
+        var state = try ConnectionStateMachine.makeReadyForQuery()
+
         let promise = EmbeddedEventLoop().makePromise(of: RowDescription?.self)
         promise.fail(PSQLError.uncleanShutdown) // we don't care about the error at all.
         
@@ -41,18 +41,18 @@ class PrepareStatementStateMachineTests: XCTestCase {
             name: name, query: query, bindingDataTypes: [], logger: .psqlTest, promise: promise
         )
 
-        XCTAssertEqual(state.enqueue(task: .extendedQuery(prepareStatementContext)),
+        #expect(state.enqueue(task: .extendedQuery(prepareStatementContext)) ==
                        .sendParseDescribeSync(name: name, query: query, bindingDataTypes: []))
-        XCTAssertEqual(state.parseCompleteReceived(), .wait)
-        XCTAssertEqual(state.parameterDescriptionReceived(.init(dataTypes: [.int8])), .wait)
-        
-        XCTAssertEqual(state.noDataReceived(),
+        #expect(state.parseCompleteReceived() == .wait)
+        #expect(state.parameterDescriptionReceived(.init(dataTypes: [.int8])) == .wait)
+
+        #expect(state.noDataReceived() ==
                        .succeedPreparedStatementCreation(promise, with: nil))
-        XCTAssertEqual(state.readyForQueryReceived(.idle), .fireEventReadyForQuery)
+        #expect(state.readyForQueryReceived(.idle) == .fireEventReadyForQuery)
     }
     
-    func testErrorReceivedAfter() {
-        var state = ConnectionStateMachine.readyForQuery()
+    @Test func testErrorReceivedAfter() throws {
+        var state = try ConnectionStateMachine.makeReadyForQuery()
 
         let promise = EmbeddedEventLoop().makePromise(of: RowDescription?.self)
         promise.fail(PSQLError.uncleanShutdown) // we don't care about the error at all.
@@ -63,16 +63,16 @@ class PrepareStatementStateMachineTests: XCTestCase {
             name: name, query: query, bindingDataTypes: [], logger: .psqlTest, promise: promise
         )
 
-        XCTAssertEqual(state.enqueue(task: .extendedQuery(prepareStatementContext)),
+        #expect(state.enqueue(task: .extendedQuery(prepareStatementContext)) ==
                        .sendParseDescribeSync(name: name, query: query, bindingDataTypes: []))
-        XCTAssertEqual(state.parseCompleteReceived(), .wait)
-        XCTAssertEqual(state.parameterDescriptionReceived(.init(dataTypes: [.int8])), .wait)
+        #expect(state.parseCompleteReceived() == .wait)
+        #expect(state.parameterDescriptionReceived(.init(dataTypes: [.int8])) == .wait)
 
-        XCTAssertEqual(state.noDataReceived(),
+        #expect(state.noDataReceived() ==
                        .succeedPreparedStatementCreation(promise, with: nil))
-        XCTAssertEqual(state.readyForQueryReceived(.idle), .fireEventReadyForQuery)
+        #expect(state.readyForQueryReceived(.idle) == .fireEventReadyForQuery)
 
-        XCTAssertEqual(state.authenticationMessageReceived(.ok),
+        #expect(state.authenticationMessageReceived(.ok) ==
                        .closeConnectionAndCleanup(.init(action: .close, tasks: [], error: .unexpectedBackendMessage(.authentication(.ok)), closePromise: nil)))
     }
 }

--- a/Tests/PostgresNIOTests/New/Connection State Machine/PreparedStatementStateMachineTests.swift
+++ b/Tests/PostgresNIOTests/New/Connection State Machine/PreparedStatementStateMachineTests.swift
@@ -1,9 +1,9 @@
-import XCTest
+import Testing
 import NIOEmbedded
 @testable import PostgresNIO
 
-class PreparedStatementStateMachineTests: XCTestCase {
-    func testPrepareAndExecuteStatement() {
+@Suite struct PreparedStatementStateMachineTests {
+    @Test func testPrepareAndExecuteStatement() {
         let eventLoop = EmbeddedEventLoop()
         var stateMachine = PreparedStatementStateMachine()
 
@@ -11,22 +11,22 @@ class PreparedStatementStateMachineTests: XCTestCase {
         // Initial lookup, the statement hasn't been prepared yet
         let lookupAction = stateMachine.lookup(preparedStatement: firstPreparedStatement)
         guard case .preparing = stateMachine.preparedStatements["test"] else {
-            XCTFail("State machine in the wrong state")
+            Issue.record("State machine in the wrong state")
             return
         }
         guard case .prepareStatement = lookupAction else {
-            XCTFail("State machine returned the wrong action")
+            Issue.record("State machine returned the wrong action")
             return
         }
 
         // Once preparation is complete we transition to a prepared state
         let preparationCompleteAction = stateMachine.preparationComplete(name: "test", rowDescription: nil)
         guard case .prepared(nil) = stateMachine.preparedStatements["test"] else {
-            XCTFail("State machine in the wrong state")
+            Issue.record("State machine in the wrong state")
             return
         }
-        XCTAssertEqual(preparationCompleteAction.statements.count, 1)
-        XCTAssertNil(preparationCompleteAction.rowDescription)
+        #expect(preparationCompleteAction.statements.count == 1)
+        #expect(preparationCompleteAction.rowDescription == nil)
         firstPreparedStatement.promise.succeed(PSQLRowStream(
             source: .noRows(.success(.tag("tag"))),
             eventLoop: eventLoop,
@@ -38,11 +38,11 @@ class PreparedStatementStateMachineTests: XCTestCase {
         // The statement is already preparead, lookups tell us to execute it
         let secondLookupAction = stateMachine.lookup(preparedStatement: secondPreparedStatement)
         guard case .prepared(nil) = stateMachine.preparedStatements["test"] else {
-            XCTFail("State machine in the wrong state")
+            Issue.record("State machine in the wrong state")
             return
         }
         guard case .executeStatement(nil) = secondLookupAction else {
-            XCTFail("State machine returned the wrong action")
+            Issue.record("State machine returned the wrong action")
             return
         }
         secondPreparedStatement.promise.succeed(PSQLRowStream(
@@ -52,7 +52,7 @@ class PreparedStatementStateMachineTests: XCTestCase {
         ))
     }
 
-    func testPrepareAndExecuteStatementWithError() {
+    @Test func testPrepareAndExecuteStatementWithError() {
         let eventLoop = EmbeddedEventLoop()
         var stateMachine = PreparedStatementStateMachine()
 
@@ -60,11 +60,11 @@ class PreparedStatementStateMachineTests: XCTestCase {
         // Initial lookup, the statement hasn't been prepared yet
         let lookupAction = stateMachine.lookup(preparedStatement: firstPreparedStatement)
         guard case .preparing = stateMachine.preparedStatements["test"] else {
-            XCTFail("State machine in the wrong state")
+            Issue.record("State machine in the wrong state")
             return
         }
         guard case .prepareStatement = lookupAction else {
-            XCTFail("State machine returned the wrong action")
+            Issue.record("State machine returned the wrong action")
             return
         }
 
@@ -75,10 +75,10 @@ class PreparedStatementStateMachineTests: XCTestCase {
             error: error
         )
         guard case .error = stateMachine.preparedStatements["test"] else {
-            XCTFail("State machine in the wrong state")
+            Issue.record("State machine in the wrong state")
             return
         }
-        XCTAssertEqual(preparationCompleteAction.statements.count, 1)
+        #expect(preparationCompleteAction.statements.count == 1)
         firstPreparedStatement.promise.fail(error)
 
         // Create a new prepared statement
@@ -86,17 +86,17 @@ class PreparedStatementStateMachineTests: XCTestCase {
         // Ensure that we don't try again to prepare a statement we know will fail
         let secondLookupAction = stateMachine.lookup(preparedStatement: secondPreparedStatement)
         guard case .error = stateMachine.preparedStatements["test"] else {
-            XCTFail("State machine in the wrong state")
+            Issue.record("State machine in the wrong state")
             return
         }
         guard case .returnError = secondLookupAction else {
-            XCTFail("State machine returned the wrong action")
+            Issue.record("State machine returned the wrong action")
             return
         }
         secondPreparedStatement.promise.fail(error)
     }
 
-    func testBatchStatementPreparation() {
+    @Test func testBatchStatementPreparation() {
         let eventLoop = EmbeddedEventLoop()
         var stateMachine = PreparedStatementStateMachine()
 
@@ -104,11 +104,11 @@ class PreparedStatementStateMachineTests: XCTestCase {
         // Initial lookup, the statement hasn't been prepared yet
         let lookupAction = stateMachine.lookup(preparedStatement: firstPreparedStatement)
         guard case .preparing = stateMachine.preparedStatements["test"] else {
-            XCTFail("State machine in the wrong state")
+            Issue.record("State machine in the wrong state")
             return
         }
         guard case .prepareStatement = lookupAction else {
-            XCTFail("State machine returned the wrong action")
+            Issue.record("State machine returned the wrong action")
             return
         }
 
@@ -116,11 +116,11 @@ class PreparedStatementStateMachineTests: XCTestCase {
         let secondPreparedStatement = self.makePreparedStatementContext(eventLoop: eventLoop)
         let secondLookupAction = stateMachine.lookup(preparedStatement: secondPreparedStatement)
         guard case .preparing = stateMachine.preparedStatements["test"] else {
-            XCTFail("State machine in the wrong state")
+            Issue.record("State machine in the wrong state")
             return
         }
         guard case .waitForAlreadyInFlightPreparation = secondLookupAction else {
-            XCTFail("State machine returned the wrong action")
+            Issue.record("State machine returned the wrong action")
             return
         }
 
@@ -128,11 +128,11 @@ class PreparedStatementStateMachineTests: XCTestCase {
         // The action tells us to execute both the pending statements.
         let preparationCompleteAction = stateMachine.preparationComplete(name: "test", rowDescription: nil)
         guard case .prepared(nil) = stateMachine.preparedStatements["test"] else {
-            XCTFail("State machine in the wrong state")
+            Issue.record("State machine in the wrong state")
             return
         }
-        XCTAssertEqual(preparationCompleteAction.statements.count, 2)
-        XCTAssertNil(preparationCompleteAction.rowDescription)
+        #expect(preparationCompleteAction.statements.count == 2)
+        #expect(preparationCompleteAction.rowDescription == nil)
 
         firstPreparedStatement.promise.succeed(PSQLRowStream(
             source: .noRows(.success(.tag("tag"))),

--- a/Tests/PostgresNIOTests/New/Data/UUID+PSQLCodableTests.swift
+++ b/Tests/PostgresNIOTests/New/Data/UUID+PSQLCodableTests.swift
@@ -1,45 +1,47 @@
-import XCTest
+import struct Foundation.UUID
+import Testing
 import NIOCore
 @testable import PostgresNIO
 
-class UUID_PSQLCodableTests: XCTestCase {
-
-    func testRoundTrip() {
+@Suite struct UUID_PSQLCodableTests {
+    @Test func testRoundTrip() {
         for _ in 0..<100 {
             let uuid = UUID()
             var buffer = ByteBuffer()
 
             uuid.encode(into: &buffer, context: .default)
 
-            XCTAssertEqual(UUID.psqlType, .uuid)
-            XCTAssertEqual(UUID.psqlFormat, .binary)
-            XCTAssertEqual(buffer.readableBytes, 16)
+            #expect(UUID.psqlType == .uuid)
+            #expect(UUID.psqlFormat == .binary)
+            #expect(buffer.readableBytes == 16)
             var byteIterator = buffer.readableBytesView.makeIterator()
 
-            XCTAssertEqual(byteIterator.next(), uuid.uuid.0)
-            XCTAssertEqual(byteIterator.next(), uuid.uuid.1)
-            XCTAssertEqual(byteIterator.next(), uuid.uuid.2)
-            XCTAssertEqual(byteIterator.next(), uuid.uuid.3)
-            XCTAssertEqual(byteIterator.next(), uuid.uuid.4)
-            XCTAssertEqual(byteIterator.next(), uuid.uuid.5)
-            XCTAssertEqual(byteIterator.next(), uuid.uuid.6)
-            XCTAssertEqual(byteIterator.next(), uuid.uuid.7)
-            XCTAssertEqual(byteIterator.next(), uuid.uuid.8)
-            XCTAssertEqual(byteIterator.next(), uuid.uuid.9)
-            XCTAssertEqual(byteIterator.next(), uuid.uuid.10)
-            XCTAssertEqual(byteIterator.next(), uuid.uuid.11)
-            XCTAssertEqual(byteIterator.next(), uuid.uuid.12)
-            XCTAssertEqual(byteIterator.next(), uuid.uuid.13)
-            XCTAssertEqual(byteIterator.next(), uuid.uuid.14)
-            XCTAssertEqual(byteIterator.next(), uuid.uuid.15)
+            #expect(byteIterator.next() == uuid.uuid.0)
+            #expect(byteIterator.next() == uuid.uuid.1)
+            #expect(byteIterator.next() == uuid.uuid.2)
+            #expect(byteIterator.next() == uuid.uuid.3)
+            #expect(byteIterator.next() == uuid.uuid.4)
+            #expect(byteIterator.next() == uuid.uuid.5)
+            #expect(byteIterator.next() == uuid.uuid.6)
+            #expect(byteIterator.next() == uuid.uuid.7)
+            #expect(byteIterator.next() == uuid.uuid.8)
+            #expect(byteIterator.next() == uuid.uuid.9)
+            #expect(byteIterator.next() == uuid.uuid.10)
+            #expect(byteIterator.next() == uuid.uuid.11)
+            #expect(byteIterator.next() == uuid.uuid.12)
+            #expect(byteIterator.next() == uuid.uuid.13)
+            #expect(byteIterator.next() == uuid.uuid.14)
+            #expect(byteIterator.next() == uuid.uuid.15)
 
             var decoded: UUID?
-            XCTAssertNoThrow(decoded = try UUID(from: &buffer, type: .uuid, format: .binary, context: .default))
-            XCTAssertEqual(decoded, uuid)
+            #expect(throws: Never.self) {
+                decoded = try UUID(from: &buffer, type: .uuid, format: .binary, context: .default)
+            }
+            #expect(decoded == uuid)
         }
     }
 
-    func testDecodeFromString() {
+    @Test func testDecodeFromString() {
         let options: [(PostgresFormat, PostgresDataType)] = [
             (.binary, .text),
             (.binary, .varchar),
@@ -57,8 +59,10 @@ class UUID_PSQLCodableTests: XCTestCase {
             for (format, dataType) in options {
                 var loopBuffer = lowercaseBuffer
                 var decoded: UUID?
-                XCTAssertNoThrow(decoded = try UUID(from: &loopBuffer, type: dataType, format: format, context: .default))
-                XCTAssertEqual(decoded, uuid)
+                #expect(throws: Never.self) {
+                    decoded = try UUID(from: &loopBuffer, type: dataType, format: format, context: .default)
+                }
+                #expect(decoded == uuid)
             }
 
             // use lowercase
@@ -68,13 +72,16 @@ class UUID_PSQLCodableTests: XCTestCase {
             for (format, dataType) in options {
                 var loopBuffer = uppercaseBuffer
                 var decoded: UUID?
-                XCTAssertNoThrow(decoded = try UUID(from: &loopBuffer, type: dataType, format: format, context: .default))
-                XCTAssertEqual(decoded, uuid)
+                #expect(throws: Never.self) {
+                    decoded = try UUID(from: &loopBuffer, type: dataType, format: format, context: .default)
+                }
+                #expect(decoded == uuid)
+
             }
         }
     }
 
-    func testDecodeFailureFromBytes() {
+    @Test func testDecodeFailureFromBytes() {
         let uuid = UUID()
         var buffer = ByteBuffer()
 
@@ -82,12 +89,13 @@ class UUID_PSQLCodableTests: XCTestCase {
         // this makes only 15 bytes readable. this should lead to an error
         buffer.moveReaderIndex(forwardBy: 1)
 
-        XCTAssertThrowsError(try UUID(from: &buffer, type: .uuid, format: .binary, context: .default)) { error in
-            XCTAssertEqual(error as? PostgresDecodingError.Code, .failure)
+        let error = #expect(throws: PostgresDecodingError.Code.self) {
+            try UUID(from: &buffer, type: .uuid, format: .binary, context: .default)
         }
+        #expect(error == .failure)
     }
 
-    func testDecodeFailureFromString() {
+    @Test func testDecodeFailureFromString() {
         let uuid = UUID()
         var buffer = ByteBuffer()
         buffer.writeString(uuid.uuidString)
@@ -98,13 +106,14 @@ class UUID_PSQLCodableTests: XCTestCase {
 
         for dataType in dataTypes {
             var loopBuffer = buffer
-            XCTAssertThrowsError(try UUID(from: &loopBuffer, type: dataType, format: .binary, context: .default)) {
-                XCTAssertEqual($0 as? PostgresDecodingError.Code, .failure)
+            let error = #expect(throws: PostgresDecodingError.Code.self) {
+                try UUID(from: &loopBuffer, type: dataType, format: .binary, context: .default)
             }
+            #expect(error == .failure)
         }
     }
 
-    func testDecodeFailureFromInvalidPostgresType() {
+    @Test func testDecodeFailureFromInvalidPostgresType() {
         let uuid = UUID()
         var buffer = ByteBuffer()
         buffer.writeString(uuid.uuidString)
@@ -113,9 +122,10 @@ class UUID_PSQLCodableTests: XCTestCase {
 
         for dataType in dataTypes {
             var copy = buffer
-            XCTAssertThrowsError(try UUID(from: &copy, type: dataType, format: .binary, context: .default)) {
-                XCTAssertEqual($0 as? PostgresDecodingError.Code, .typeMismatch)
+            let error = #expect(throws: PostgresDecodingError.Code.self) {
+                try UUID(from: &copy, type: dataType, format: .binary, context: .default)
             }
+            #expect(error == .typeMismatch)
         }
     }
 }

--- a/Tests/PostgresNIOTests/New/Data/UUID+PSQLCodableTests.swift
+++ b/Tests/PostgresNIOTests/New/Data/UUID+PSQLCodableTests.swift
@@ -81,6 +81,7 @@ import NIOCore
         }
     }
 
+    #if compiler(>=6.1)
     @Test func testDecodeFailureFromBytes() {
         let uuid = UUID()
         var buffer = ByteBuffer()
@@ -128,4 +129,5 @@ import NIOCore
             #expect(error == .typeMismatch)
         }
     }
+    #endif
 }

--- a/Tests/PostgresNIOTests/New/Extensions/ConnectionAction+TestUtils.swift
+++ b/Tests/PostgresNIOTests/New/Extensions/ConnectionAction+TestUtils.swift
@@ -18,6 +18,8 @@ extension PostgresNIO.ConnectionStateMachine.ConnectionAction: Swift.Equatable {
             return true
         case (.establishSSLConnection, establishSSLConnection):
             return true
+        case (.closeConnection(let lhs), .closeConnection(let rhs)):
+            return lhs?.futureResult === rhs?.futureResult
         case (.closeConnectionAndCleanup(let lhs), .closeConnectionAndCleanup(let rhs)):
             return lhs == rhs
         case (.sendPasswordMessage(let lhsMethod, let lhsAuthContext), sendPasswordMessage(let rhsMethod, let rhsAuthContext)):
@@ -68,14 +70,73 @@ extension PostgresNIO.ConnectionStateMachine.ConnectionAction.CleanUpContext: Sw
 }
 
 extension ConnectionStateMachine {
-    static func readyForQuery(transactionState: PostgresBackendMessage.TransactionState = .idle) -> Self {
-        let connectionContext = Self.createConnectionContext(transactionState: transactionState)
-        return ConnectionStateMachine(.readyForQuery(connectionContext))
+    struct UnexpectedAction: Error {
+        var actual: ConnectionStateMachine.ConnectionAction
+        var expected: ConnectionStateMachine.ConnectionAction
     }
-    
-    static func createConnectionContext(transactionState: PostgresBackendMessage.TransactionState = .idle) -> ConnectionContext {
-        let backendKeyData = BackendKeyData(processID: 2730, secretKey: 882037977)
-        
+
+    static func makeAuthenticatedIdle(
+        username: String = "test",
+        password: String? = "abc123",
+        database: String = "test",
+        additionalParameters: [(String, String)] = [],
+        salt: UInt32 = 0x00_01_02_03,
+        requireBackendKeyData: Bool = true
+    ) throws(UnexpectedAction) -> ConnectionStateMachine {
+        let authContext = AuthContext(
+            username: username,
+            password: password,
+            database: database,
+            additionalParameters: additionalParameters
+        )
+        var state = ConnectionStateMachine(requireBackendKeyData: requireBackendKeyData)
+        let connectedAction = state.connected(tls: .require)
+        guard connectedAction == .sendSSLRequest else {
+            throw UnexpectedAction(actual: connectedAction, expected: .sendSSLRequest)
+        }
+        let sslSupportedReceivedAction = state.sslSupportedReceived(unprocessedBytes: 0)
+        guard sslSupportedReceivedAction == .establishSSLConnection else {
+            throw UnexpectedAction(actual: sslSupportedReceivedAction, expected: .establishSSLConnection)
+        }
+        let sslHandlerAddedAction = state.sslHandlerAdded()
+        guard sslHandlerAddedAction == .wait else {
+            throw UnexpectedAction(actual: sslHandlerAddedAction, expected: .wait)
+        }
+        let sslEstablishedAction = state.sslEstablished()
+        guard sslEstablishedAction == .provideAuthenticationContext else {
+            throw UnexpectedAction(actual: sslEstablishedAction, expected: .provideAuthenticationContext)
+        }
+        let provideAuthContextAction = state.provideAuthenticationContext(authContext)
+        guard provideAuthContextAction == .sendStartupMessage(authContext) else {
+            throw UnexpectedAction(actual: provideAuthContextAction, expected: .sendStartupMessage(authContext))
+        }
+        let authenticationMessageReceivedAction = state.authenticationMessageReceived(.md5(salt: salt))
+        guard authenticationMessageReceivedAction == .sendPasswordMessage(.md5(salt: salt), authContext) else {
+            throw UnexpectedAction(actual: authenticationMessageReceivedAction, expected: .sendPasswordMessage(.md5(salt: salt), authContext))
+        }
+        let authenticationCompleteAction = state.authenticationMessageReceived(.ok)
+        guard authenticationCompleteAction == .wait else {
+            throw UnexpectedAction(actual: authenticationCompleteAction, expected: .wait)
+        }
+
+        return state
+    }
+
+    static func makeReadyForQuery(
+        username: String = "test",
+        password: String? = "abc123",
+        database: String = "test",
+        additionalParameters: [(String, String)] = [],
+        salt: UInt32 = 0x00_01_02_03
+    ) throws(UnexpectedAction) -> ConnectionStateMachine {
+        var state = try Self.makeAuthenticatedIdle(
+            username: username,
+            password: password,
+            database: database,
+            additionalParameters: additionalParameters,
+            salt: salt
+        )
+
         let paramaters = [
             "DateStyle": "ISO, MDY",
             "application_name": "",
@@ -89,12 +150,25 @@ extension ConnectionStateMachine {
             "IntervalStyle": "postgres",
             "standard_conforming_strings": "on"
         ]
-        
-        return ConnectionContext(
-            backendKeyData: backendKeyData,
-            parameters: paramaters,
-            transactionState: transactionState
-        )
+
+        for (name, value) in paramaters {
+            let parameterStatusReceivedAction = state.parameterStatusReceived(.init(parameter: name, value: value))
+            guard parameterStatusReceivedAction == .wait else {
+                throw UnexpectedAction(actual: parameterStatusReceivedAction, expected: .wait)
+            }
+        }
+
+        let parameterStatusReceivedAction = state.backendKeyDataReceived(.init(processID: 2730, secretKey: 882037977))
+        guard parameterStatusReceivedAction == .wait else {
+            throw UnexpectedAction(actual: parameterStatusReceivedAction, expected: .wait)
+        }
+
+        let readyForQueryReceivedAction = state.readyForQueryReceived(.idle)
+        guard readyForQueryReceivedAction == .fireEventReadyForQuery else {
+            throw UnexpectedAction(actual: readyForQueryReceivedAction, expected: .fireEventReadyForQuery)
+        }
+
+        return state
     }
 }
 

--- a/Tests/PostgresNIOTests/New/PostgresChannelHandlerTests.swift
+++ b/Tests/PostgresNIOTests/New/PostgresChannelHandlerTests.swift
@@ -18,7 +18,12 @@ class PostgresChannelHandlerTests: XCTestCase {
     
     func testHandlerAddedWithoutSSL() {
         let config = self.testConnectionConfiguration()
-        let handler = PostgresChannelHandler(configuration: config, eventLoop: self.eventLoop, configureSSLCallback: nil)
+        let handler = PostgresChannelHandler(
+            configuration: config,
+            eventLoop: self.eventLoop,
+            logger: .psqlNoOpLogger,
+            configureSSLCallback: nil
+        )
         let embedded = EmbeddedChannel(handlers: [
             ReverseByteToMessageHandler(PSQLFrontendMessageDecoder()),
             ReverseMessageToByteHandler(PSQLBackendMessageEncoder()),
@@ -48,7 +53,11 @@ class PostgresChannelHandlerTests: XCTestCase {
         var config = self.testConnectionConfiguration()
         XCTAssertNoThrow(config.tls = .require(try NIOSSLContext(configuration: .makeClientConfiguration())))
         var addSSLCallbackIsHit = false
-        let handler = PostgresChannelHandler(configuration: config, eventLoop: self.eventLoop) { channel, _ in
+        let handler = PostgresChannelHandler(
+            configuration: config,
+            eventLoop: self.eventLoop,
+            logger: .psqlNoOpLogger
+        ) { channel, _ in
             addSSLCallbackIsHit = true
         }
         let embedded = EmbeddedChannel(handlers: [
@@ -84,7 +93,11 @@ class PostgresChannelHandlerTests: XCTestCase {
         var config = self.testConnectionConfiguration()
         XCTAssertNoThrow(config.tls = .require(try NIOSSLContext(configuration: .makeClientConfiguration())))
         var addSSLCallbackIsHit = false
-        let handler = PostgresChannelHandler(configuration: config, eventLoop: self.eventLoop) { channel, _ in
+        let handler = PostgresChannelHandler(
+            configuration: config,
+            eventLoop: self.eventLoop,
+            logger: .psqlNoOpLogger
+        ) { channel, _ in
             addSSLCallbackIsHit = true
         }
         let eventHandler = TestEventHandler()
@@ -114,7 +127,11 @@ class PostgresChannelHandlerTests: XCTestCase {
     func testSSLUnsupportedClosesConnection() throws {
         let config = self.testConnectionConfiguration(tls: .require(try NIOSSLContext(configuration: .makeClientConfiguration())))
         
-        let handler = PostgresChannelHandler(configuration: config, eventLoop: self.eventLoop) { channel, _ in
+        let handler = PostgresChannelHandler(
+            configuration: config,
+            eventLoop: self.eventLoop,
+            logger: .psqlNoOpLogger
+        ) { channel, _ in
             XCTFail("This callback should never be exectuded")
             throw PSQLError.sslUnsupported
         }
@@ -149,14 +166,19 @@ class PostgresChannelHandlerTests: XCTestCase {
             password: config.password,
             database: config.database
         )
-        let state = ConnectionStateMachine(.waitingToStartAuthentication)
-        let handler = PostgresChannelHandler(configuration: config, eventLoop: self.eventLoop, state: state, configureSSLCallback: nil)
+//        let state = ConnectionStateMachine(.waitingToStartAuthentication)
+        let handler = PostgresChannelHandler(
+            configuration: config,
+            eventLoop: self.eventLoop,
+            logger: .psqlNoOpLogger,
+            configureSSLCallback: nil
+        )
         let embedded = EmbeddedChannel(handlers: [
             ReverseByteToMessageHandler(PSQLFrontendMessageDecoder()),
             handler
         ], loop: self.eventLoop)
+        XCTAssertNoThrow(embedded.connect(to: try .init(ipAddress: "0.0.0.0", port: 5432), promise: nil))
 
-        embedded.triggerUserOutboundEvent(PSQLOutgoingEvent.authenticate(authContext), promise: nil)
         XCTAssertEqual(try embedded.readOutbound(as: PostgresFrontendMessage.self), .startup(.versionThree(parameters: authContext.toStartupParameters())))
         let salt: UInt32 = 0x00_01_02_03
 
@@ -176,24 +198,33 @@ class PostgresChannelHandlerTests: XCTestCase {
             password: config.password,
             database: config.database
         )
-        let state = ConnectionStateMachine(.waitingToStartAuthentication)
-        let handler = PostgresChannelHandler(configuration: config, eventLoop: self.eventLoop, state: state, configureSSLCallback: nil)
+        let handler = PostgresChannelHandler(
+            configuration: config,
+            eventLoop: self.eventLoop,
+            logger: .psqlNoOpLogger,
+            configureSSLCallback: nil
+        )
         let embedded = EmbeddedChannel(handlers: [
             ReverseByteToMessageHandler(PSQLFrontendMessageDecoder()),
             ReverseMessageToByteHandler(PSQLBackendMessageEncoder()),
             handler
         ], loop: self.eventLoop)
 
-        embedded.triggerUserOutboundEvent(PSQLOutgoingEvent.authenticate(authContext), promise: nil)
+        XCTAssertNoThrow(try embedded.connect(to: .init(ipAddress: "1.2.3.4", port: 5678)).wait())
         XCTAssertEqual(try embedded.readOutbound(as: PostgresFrontendMessage.self), .startup(.versionThree(parameters: authContext.toStartupParameters())))
-        
+
         XCTAssertNoThrow(try embedded.writeInbound(PostgresBackendMessage.authentication(.plaintext)))
         XCTAssertEqual(try embedded.readOutbound(as: PostgresFrontendMessage.self), .password(.init(value: password)))
     }
 
     func testHandlerThatSendsMultipleWrongMessages() {
         let config = self.testConnectionConfiguration()
-        let handler = PostgresChannelHandler(configuration: config, eventLoop: self.eventLoop, configureSSLCallback: nil)
+        let handler = PostgresChannelHandler(
+            configuration: config,
+            eventLoop: self.eventLoop,
+            logger: .psqlNoOpLogger,
+            configureSSLCallback: nil
+        )
         let embedded = EmbeddedChannel(handlers: [
             ReverseByteToMessageHandler(PSQLFrontendMessageDecoder()),
             handler

--- a/Tests/PostgresNIOTests/New/PostgresChannelHandlerTests.swift
+++ b/Tests/PostgresNIOTests/New/PostgresChannelHandlerTests.swift
@@ -166,7 +166,6 @@ class PostgresChannelHandlerTests: XCTestCase {
             password: config.password,
             database: config.database
         )
-//        let state = ConnectionStateMachine(.waitingToStartAuthentication)
         let handler = PostgresChannelHandler(
             configuration: config,
             eventLoop: self.eventLoop,


### PR DESCRIPTION
We used a shortcut, where we set the initial state in tests directly. This pr changes this, that we always move the state machine into the expected state through events.