### PR TITLE
Add distributed tracing support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -31,6 +31,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-atomics.git", from: "1.2.0"),
         .package(url: "https://github.com/apple/swift-collections.git", from: "1.0.4"),
+        .package(url: "https://github.com/apple/swift-distributed-tracing.git", from: "1.3.0"),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.81.0"),
         .package(url: "https://github.com/apple/swift-nio-transport-services.git", from: "1.19.0"),
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.25.0"),
@@ -57,6 +58,7 @@ let package = Package(
                 .product(name: "NIOSSL", package: "swift-nio-ssl"),
                 .product(name: "NIOFoundationCompat", package: "swift-nio"),
                 .product(name: "ServiceLifecycle", package: "swift-service-lifecycle"),
+                .product(name: "Tracing", package: "swift-distributed-tracing"),
             ],
             swiftSettings: swiftSettings
         ),
@@ -82,6 +84,7 @@ let package = Package(
             name: "PostgresNIOTests",
             dependencies: [
                 .target(name: "PostgresNIO"),
+                .product(name: "InMemoryTracing", package: "swift-distributed-tracing"),
                 .product(name: "NIOEmbedded", package: "swift-nio"),
                 .product(name: "NIOTestUtils", package: "swift-nio"),
             ],
@@ -103,6 +106,7 @@ let package = Package(
             name: "IntegrationTests",
             dependencies: [
                 .target(name: "PostgresNIO"),
+                .product(name: "InMemoryTracing", package: "swift-distributed-tracing"),
                 .product(name: "NIOTestUtils", package: "swift-nio"),
             ],
             swiftSettings: swiftSettings

--- a/README.md
+++ b/README.md
@@ -154,6 +154,72 @@ While this looks at first glance like a classic case of [SQL injection](https://
 
 Some queries do not receive any rows from the server (most often `INSERT`, `UPDATE`, and `DELETE` queries with no `RETURNING` clause, not to mention most DDL queries). To support this, the [`query(_:logger:)`] method is marked `@discardableResult`, so that the compiler does not issue a warning if the return value is not used. 
 
+## Tracing
+
+PostgresNIO can emit distributed tracing spans for database operations, but tracing is disabled by default.
+
+After bootstrapping your tracer, opt in through either `PostgresClient.Configuration.Options` or `PostgresConnection.Configuration.Options`:
+
+```swift
+import PostgresNIO
+import Tracing
+
+InstrumentationSystem.bootstrap(MyTracer())
+
+var config = PostgresClient.Configuration(
+  host: "localhost",
+  port: 5432,
+  username: "my_username",
+  password: "my_password",
+  database: "my_database",
+  tls: .disable
+)
+
+config.options.tracing.isEnabled = true
+```
+
+By default, PostgresNIO uses the bootstrapped global tracer when tracing is enabled. You can override that for tests or specialized setups:
+
+```swift
+config.options.tracing.tracer = myTracer
+```
+
+`db.query.text` uses a safe default and is only attached when PostgresNIO can treat the SQL as parameterized or when PostgresNIO generated the SQL itself and can provide a sanitized tracing form. Raw non-parameterized user SQL is omitted by default. If you want raw SQL text on every span, opt in explicitly:
+
+```swift
+config.options.tracing.queryTextPolicy = .recordAll
+```
+
+By default, statement metadata only uses exact low-cardinality information for operations whose semantics are already known to PostgresNIO, such as explicit `prepare`, explicit `deallocate`, and `copyFrom`. Generic query execution typically falls back to a target-based span name such as the database namespace.
+
+If you want SQL verb grouping like `SELECT`, `INSERT`, or `UPDATE` on generic query spans for backends such as Datadog, opt in explicitly:
+
+```swift
+config.options.tracing.statementMetadataPolicy = .inferred
+```
+
+If you do not want optional statement metadata at all, disable it:
+
+```swift
+config.options.tracing.statementMetadataPolicy = .disabled
+```
+
+Tracing errors keep a privacy-preserving default description. If you want PostgresNIO to attach the primary server error message to failed spans, opt in explicitly:
+
+```swift
+config.options.tracing.errorDetailsPolicy = .message
+```
+
+If you want the full debug description on failed spans, including enriched query context and source locations when available, opt in explicitly:
+
+```swift
+config.options.tracing.errorDetailsPolicy = .debugDescription
+```
+
+Use `.debugDescription` only when that additional visibility is acceptable for your deployment and data handling requirements.
+
+The first tracing release instruments `query`, prepared statement execution, explicit `prepare`, explicit `deallocate`, `copyFrom`, and `withTransaction`. It does not currently emit spans for connection establishment, authentication, pool maintenance, or `LISTEN` / `NOTIFY`.
+
 ## Security
 
 Please see [SECURITY.md] for details on the security process.

--- a/Sources/PostgresNIO/Connection/PostgresConnection+Configuration.swift
+++ b/Sources/PostgresNIO/Connection/PostgresConnection+Configuration.swift
@@ -90,6 +90,9 @@ extension PostgresConnection {
             /// startup message that the client sends to the server.
             public var additionalStartupParameters: [(String, String)]
 
+            /// Distributed tracing options for this connection.
+            public var tracing: PostgresTracingConfiguration
+
             /// Create an options structure with default values.
             ///
             /// Most users should not need to adjust the defaults.
@@ -98,6 +101,7 @@ extension PostgresConnection {
                 self.tlsServerName = nil
                 self.requireBackendKeyData = true
                 self.additionalStartupParameters = []
+                self.tracing = .init()
             }
         }
         

--- a/Sources/PostgresNIO/Connection/PostgresConnection+CopyFrom.swift
+++ b/Sources/PostgresNIO/Connection/PostgresConnection+CopyFrom.swift
@@ -131,34 +131,57 @@ public struct PostgresCopyFromFormat: Sendable {
 ///
 /// - Warning: The table and column names are inserted into the `COPY FROM` query as passed and might thus be
 ///   susceptible to SQL injection. Ensure no untrusted data is contained in these strings.
+private struct CopyFromQueries: Sendable {
+    let executionQuery: PostgresQuery
+    let safeTracingText: String?
+}
+
 private func buildCopyFromQuery(
     table: String,
     columns: [String] = [],
-    format: PostgresCopyFromFormat
-) -> PostgresQuery {
-    var query = """
+    format: PostgresCopyFromFormat,
+    includeSafeTracingText: Bool
+) -> CopyFromQueries {
+    func append(_ fragment: String, to value: inout String?) {
+        value?.append(fragment)
+    }
+
+    var executionQuery = """
         COPY "\(table)"
         """
+    var safeTracingText = includeSafeTracingText ? executionQuery : nil
     if !columns.isEmpty {
-        query += "("
-        query += columns.map { #""\#($0)""# }.joined(separator: ",")
-        query += ")"
+        let columnList = columns.map { #""\#($0)""# }.joined(separator: ",")
+        executionQuery += "("
+        executionQuery += columnList
+        executionQuery += ")"
+        append("(\(columnList))", to: &safeTracingText)
     }
-    query += " FROM STDIN"
-    var queryOptions: [String] = []
+    executionQuery += " FROM STDIN"
+    append(" FROM STDIN", to: &safeTracingText)
+    var executionQueryOptions: [String] = []
+    var safeTracingOptions: [String]? = includeSafeTracingText ? [] : nil
     switch format.format {
     case .text(let options):
-        queryOptions.append("FORMAT text")
+        executionQueryOptions.append("FORMAT text")
+        safeTracingOptions?.append("FORMAT text")
         if let delimiter = options.delimiter {
             // Set the delimiter as a Unicode code point. This avoids the possibility of SQL injection.
-            queryOptions.append("DELIMITER U&'\\\(String(format: "%04x", delimiter.value))'")
+            executionQueryOptions.append("DELIMITER U&'\\\(String(format: "%04x", delimiter.value))'")
+            safeTracingOptions?.append("DELIMITER ?")
         }
     }
-    precondition(!queryOptions.isEmpty)
-    query += " WITH ("
-    query += queryOptions.map { "\($0)" }.joined(separator: ",")
-    query += ")"
-    return "\(unescaped: query)"
+    precondition(!executionQueryOptions.isEmpty)
+    executionQuery += " WITH ("
+    executionQuery += executionQueryOptions.joined(separator: ",")
+    executionQuery += ")"
+    if let safeTracingOptions {
+        append(" WITH (\(safeTracingOptions.joined(separator: ",")))", to: &safeTracingText)
+    }
+    return .init(
+        executionQuery: "\(unescaped: executionQuery)",
+        safeTracingText: safeTracingText
+    )
 }
 
 extension PostgresConnection {
@@ -187,11 +210,74 @@ extension PostgresConnection {
         line: Int = #line,
         writeData: (PostgresCopyFromWriter) async throws -> Void
     )  async throws {
+        let copyQuery = buildCopyFromQuery(
+            table: table,
+            columns: columns,
+            format: format,
+            includeSafeTracingText: self.shouldBuildSafeLibraryGeneratedQueryText
+        )
+        let span = self.makeTraceSpan(
+            for: .libraryQuery(
+                copyQuery.executionQuery,
+                safeQueryText: copyQuery.safeTracingText ?? copyQuery.executionQuery.sql,
+                exactSummary: .init(
+                    operationName: "COPY",
+                    querySummary: nil,
+                    collectionName: table,
+                    storedProcedureName: nil
+                )
+            ),
+            file: file,
+            line: UInt(line)
+        )
+        if let span {
+            do {
+                try await self.copyFromUntraced(
+                    copyQuery: copyQuery.executionQuery,
+                    logger: logger,
+                    writeData: writeData
+                )
+                span.succeed()
+            } catch {
+                let tracedError = enrichTracingError(
+                    error,
+                    query: copyQuery.executionQuery,
+                    file: file,
+                    line: line
+                )
+                span.fail(tracedError)
+                throw tracedError
+            }
+            return
+        }
+
+        do {
+            try await self.copyFromUntraced(
+                copyQuery: copyQuery.executionQuery,
+                logger: logger,
+                writeData: writeData
+            )
+        } catch {
+            throw enrichTracingError(
+                error,
+                query: copyQuery.executionQuery,
+                file: file,
+                line: line
+            )
+        }
+    }
+
+    private func copyFromUntraced(
+        copyQuery: PostgresQuery,
+        logger: Logger,
+        writeData: (PostgresCopyFromWriter) async throws -> Void
+    ) async throws {
         var logger = logger
         logger[postgresMetadataKey: .connectionID] = "\(self.id)"
+
         let writer: PostgresCopyFromWriter = try await withCheckedThrowingContinuation { continuation in
             let context = ExtendedQueryContext(
-                copyFromQuery: buildCopyFromQuery(table: table, columns: columns, format: format),
+                copyFromQuery: copyQuery,
                 triggerCopy: continuation,
                 logger: logger
             )

--- a/Sources/PostgresNIO/Connection/PostgresConnection.swift
+++ b/Sources/PostgresNIO/Connection/PostgresConnection.swift
@@ -1,11 +1,13 @@
 import Atomics
 import NIOCore
+import NIOConcurrencyHelpers
 import NIOPosix
 #if canImport(Network)
 import NIOTransportServices
 #endif
 import NIOSSL
 import Logging
+import Tracing
 
 /// A Postgres connection. Use it to run queries against a Postgres server.
 ///
@@ -47,11 +49,25 @@ public final class PostgresConnection: @unchecked Sendable {
     public let id: ID
 
     private var _logger: Logger
+    private let tracingConfiguration: PostgresTracingConfiguration?
+    private let tracingConnectionInfo: PostgresTracingConnectionInfo?
+    private let traceContextOverride: NIOLockedValueBox<ServiceContext?>?
 
-    init(channel: any Channel, connectionID: ID, logger: Logger) {
+    init(
+        channel: any Channel,
+        connectionID: ID,
+        logger: Logger,
+        tracingConfiguration: PostgresTracingConfiguration?,
+        tracingConnectionInfo: PostgresTracingConnectionInfo?
+    ) {
         self.channel = channel
         self.id = connectionID
         self._logger = logger
+        self.tracingConfiguration = tracingConfiguration
+        self.tracingConnectionInfo = tracingConnectionInfo
+        self.traceContextOverride = tracingConfiguration.map { _ in
+            NIOLockedValueBox<ServiceContext?>(nil)
+        }
     }
     deinit {
         assert(self.isClosed, "PostgresConnection deinitialized before being closed.")
@@ -176,7 +192,17 @@ public final class PostgresConnection: @unchecked Sendable {
             }
 
             return connectFuture.flatMap { channel -> EventLoopFuture<PostgresConnection> in
-                let connection = PostgresConnection(channel: channel, connectionID: connectionID, logger: logger)
+                let tracingConfiguration = configuration.options.tracing.isEnabled ? configuration.options.tracing : nil
+                let tracingConnectionInfo = tracingConfiguration.map { _ in
+                    PostgresTracingConnectionInfo(configuration: configuration)
+                }
+                let connection = PostgresConnection(
+                    channel: channel,
+                    connectionID: connectionID,
+                    logger: logger,
+                    tracingConfiguration: tracingConfiguration,
+                    tracingConnectionInfo: tracingConnectionInfo
+                )
                 return connection.start(configuration: configuration).map { _ in connection }
             }.flatMapErrorThrowing { error -> PostgresConnection in
                 switch error {
@@ -204,6 +230,175 @@ public final class PostgresConnection: @unchecked Sendable {
         }
 
         fatalError("No matching bootstrap found")
+    }
+
+    func makeTraceSpan(
+        for operation: @autoclosure () -> PostgresTraceOperation,
+        parentContext: ServiceContext? = nil,
+        function: String = #function,
+        file: String = #fileID,
+        line: UInt = #line
+    ) -> PostgresTraceSpan? {
+        guard let configuration = self.tracingConfiguration,
+              let connectionInfo = self.tracingConnectionInfo,
+              let tracer = configuration.resolvedTracer
+        else {
+            return nil
+        }
+
+        let resolvedParentContext = parentContext
+            ?? self.traceContextOverride?.withLockedValue { $0 }
+            ?? ServiceContext.current
+
+        return operation().makeSpan(
+            tracer: tracer,
+            configuration: configuration,
+            connectionInfo: connectionInfo,
+            parentContext: resolvedParentContext,
+            function: function,
+            file: file,
+            line: line
+        )
+    }
+
+    func makeQueryTraceSpan(
+        for query: PostgresQuery,
+        parentContext: ServiceContext? = nil,
+        function: String = #function,
+        file: String = #fileID,
+        line: UInt = #line
+    ) -> PostgresTraceSpan? {
+        self.makeTraceSpan(
+            for: .userQuery(query),
+            parentContext: parentContext,
+            function: function,
+            file: file,
+            line: line
+        )
+    }
+
+    func makePreparedExecutionTraceSpan(
+        sql: String,
+        bindCount: Int,
+        parentContext: ServiceContext? = nil,
+        function: String = #function,
+        file: String = #fileID,
+        line: UInt = #line
+    ) -> PostgresTraceSpan? {
+        self.makeTraceSpan(
+            for: .preparedExecution(sql: sql, bindCount: bindCount),
+            parentContext: parentContext,
+            function: function,
+            file: file,
+            line: line
+        )
+    }
+
+    func makePrepareTraceSpan(
+        sql: String,
+        parentContext: ServiceContext? = nil,
+        function: String = #function,
+        file: String = #fileID,
+        line: UInt = #line
+    ) -> PostgresTraceSpan? {
+        self.makeTraceSpan(
+            for: .prepare(sql: sql),
+            parentContext: parentContext,
+            function: function,
+            file: file,
+            line: line
+        )
+    }
+
+    func withTraceContextOverride<T>(
+        _ context: ServiceContext?,
+        _ body: () async throws -> sending T
+    ) async rethrows -> sending T {
+        guard let traceContextOverride = self.traceContextOverride else {
+            return try await body()
+        }
+
+        let previous = traceContextOverride.withLockedValue { value -> ServiceContext? in
+            let previous = value
+            value = context
+            return previous
+        }
+        defer {
+            traceContextOverride.withLockedValue {
+                $0 = previous
+            }
+        }
+        return try await body()
+    }
+
+    var shouldCreateTraceSpans: Bool {
+        guard let configuration = self.tracingConfiguration,
+              let _ = self.tracingConnectionInfo,
+              let _ = configuration.resolvedTracer
+        else {
+            return false
+        }
+        return true
+    }
+
+    var shouldBuildSafeLibraryGeneratedQueryText: Bool {
+        self.shouldCreateTraceSpans && self.tracingConfiguration?.queryTextPolicy == .safe
+    }
+
+    private func traceFuture<Value>(
+        _ future: EventLoopFuture<Value>,
+        span: PostgresTraceSpan?
+    ) -> EventLoopFuture<Value> {
+        guard let span else {
+            return future
+        }
+        future.whenComplete { result in
+            switch result {
+            case .success:
+                span.succeed()
+            case .failure(let error):
+                span.fail(error)
+            }
+        }
+        return future
+    }
+
+    /// Internal pool-maintenance query path that deliberately bypasses distributed tracing.
+    func runMaintenanceQuery(
+        _ query: PostgresQuery,
+        logger: Logger,
+        file: String = #fileID,
+        line: Int = #line
+    ) async throws {
+        let future = self.queryStream(query, logger: logger).flatMap { rowStream in
+            rowStream.all().flatMapThrowing { rows -> PostgresQueryResult in
+                guard let metadata = PostgresQueryMetadata(string: rowStream.commandTag) else {
+                    throw PSQLError.invalidCommandTag(rowStream.commandTag)
+                }
+                return PostgresQueryResult(metadata: metadata, rows: rows)
+            }
+        }.enrichPSQLError(query: query, file: file, line: line)
+        _ = try await future.get()
+    }
+
+    func tracedDeallocate(
+        _ statementName: String,
+        logger: Logger,
+        file: String = #fileID,
+        line: Int = #line
+    ) -> EventLoopFuture<Void> {
+        var logger = logger
+        logger[postgresMetadataKey: .connectionID] = "\(self.id)"
+
+        let span = self.makeTraceSpan(
+            for: .deallocate(statementName: statementName),
+            file: file,
+            line: UInt(line)
+        )
+        return self.traceFuture(
+            self.close(.preparedStatement(statementName), logger: logger),
+            span: span
+        )
     }
 
     // MARK: Query
@@ -415,26 +610,32 @@ extension PostgresConnection {
     ) async throws -> PostgresRowSequence {
         var logger = logger
         logger[postgresMetadataKey: .connectionID] = "\(self.id)"
-
-        guard query.binds.count <= Int(UInt16.max) else {
-            throw PSQLError(code: .tooManyParameters, query: query, file: file, line: line)
-        }
-        let promise = self.channel.eventLoop.makePromise(of: PSQLRowStream.self)
-        let context = ExtendedQueryContext(
-            query: query,
-            logger: logger,
-            promise: promise
-        )
-
-        self.channel.write(HandlerTask.extendedQuery(context), promise: nil)
-
+        let span = self.makeQueryTraceSpan(for: query, file: file, line: UInt(line))
         do {
-            return try await promise.futureResult.map({ $0.asyncSequence() }).get()
-        } catch var error as PSQLError {
-            error.file = file
-            error.line = line
-            error.query = query
-            throw error // rethrow with more metadata
+            guard query.binds.count <= Int(UInt16.max) else {
+                throw PSQLError(code: .tooManyParameters, query: query, file: file, line: line)
+            }
+            let promise = self.channel.eventLoop.makePromise(of: PSQLRowStream.self)
+            let context = ExtendedQueryContext(
+                query: query,
+                logger: logger,
+                promise: promise
+            )
+
+            self.channel.write(HandlerTask.extendedQuery(context), promise: nil)
+
+            let responseFuture = promise.futureResult.flatMapThrowing { rowStream in
+                if let span {
+                    rowStream.installTracing(span, managesLifecycle: true)
+                }
+                return rowStream.asyncSequence()
+            }
+
+            return try await responseFuture.get()
+        } catch {
+            let tracedError = enrichTracingError(error, query: query, file: file, line: line)
+            span?.fail(tracedError)
+            throw tracedError
         }
     }
 
@@ -503,6 +704,12 @@ extension PostgresConnection {
         line: Int = #line
     ) async throws -> AsyncThrowingMapSequence<PostgresRowSequence, Row> where Row == Statement.Row {
         let bindings = try preparedStatement.makeBindings()
+        let span = self.makePreparedExecutionTraceSpan(
+            sql: Statement.sql,
+            bindCount: bindings.count,
+            file: file,
+            line: UInt(line)
+        )
         let promise = self.channel.eventLoop.makePromise(of: PSQLRowStream.self)
         let task = HandlerTask.executePreparedStatement(.init(
             name: Statement.name,
@@ -513,19 +720,23 @@ extension PostgresConnection {
             promise: promise
         ))
         self.channel.write(task, promise: nil)
+        let responseFuture = promise.futureResult.flatMapThrowing { rowStream in
+            if let span {
+                rowStream.installTracing(span, managesLifecycle: true)
+            }
+            return rowStream.asyncSequence()
+        }
         do {
-            return try await promise.futureResult
-                .map { $0.asyncSequence() }
-                .get()
-                .map { try preparedStatement.decodeRow($0) }
-        } catch var error as PSQLError {
-            error.file = file
-            error.line = line
-            error.query = .init(
-                unsafeSQL: Statement.sql,
-                binds: bindings
+            return try await responseFuture.get().map { try preparedStatement.decodeRow($0) }
+        } catch {
+            let tracedError = enrichTracingError(
+                error,
+                query: .init(unsafeSQL: Statement.sql, binds: bindings),
+                file: file,
+                line: line
             )
-            throw error // rethrow with more metadata
+            span?.fail(tracedError)
+            throw tracedError
         }
     }
 
@@ -538,6 +749,12 @@ extension PostgresConnection {
         line: Int = #line
     ) async throws -> String where Statement.Row == () {
         let bindings = try preparedStatement.makeBindings()
+        let span = self.makePreparedExecutionTraceSpan(
+            sql: Statement.sql,
+            bindCount: bindings.count,
+            file: file,
+            line: UInt(line)
+        )
         let promise = self.channel.eventLoop.makePromise(of: PSQLRowStream.self)
         let task = HandlerTask.executePreparedStatement(.init(
             name: Statement.name,
@@ -548,18 +765,20 @@ extension PostgresConnection {
             promise: promise
         ))
         self.channel.write(task, promise: nil)
+        let responseFuture = promise.futureResult.map { $0.commandTag }
         do {
-            return try await promise.futureResult
-                .map { $0.commandTag }
-                .get()
-        } catch var error as PSQLError {
-            error.file = file
-            error.line = line
-            error.query = .init(
-                unsafeSQL: Statement.sql,
-                binds: bindings
+            let commandTag = try await responseFuture.get()
+            span?.succeed()
+            return commandTag
+        } catch {
+            let tracedError = enrichTracingError(
+                error,
+                query: .init(unsafeSQL: Statement.sql, binds: bindings),
+                file: file,
+                line: line
             )
-            throw error // rethrow with more metadata
+            span?.fail(tracedError)
+            throw tracedError
         }
     }
 
@@ -580,6 +799,42 @@ extension PostgresConnection {
     ///              The connection must stay in the transaction mode. Otherwise this method will throw!
     /// - Returns: The closure's return value.
     public func withTransaction<Result>(
+        logger: Logger,
+        file: String = #file,
+        line: Int = #line,
+        isolation: isolated (any Actor)? = #isolation,
+        _ process: (PostgresConnection) async throws -> sending Result
+    ) async throws -> sending Result {
+        let span = self.makeTraceSpan(for: .transaction, file: file, line: UInt(line))
+        guard let span else {
+            return try await self._withTransactionUntraced(
+                logger: logger,
+                file: file,
+                line: line,
+                isolation: isolation,
+                process
+            )
+        }
+
+        return try await self.withTraceContextOverride(span.context) {
+            do {
+                let result = try await self._withTransactionUntraced(
+                    logger: logger,
+                    file: file,
+                    line: line,
+                    isolation: isolation,
+                    process
+                )
+                span.succeed()
+                return result
+            } catch {
+                span.fail(error)
+                throw error
+            }
+        }
+    }
+
+    func _withTransactionUntraced<Result>(
         logger: Logger,
         file: String = #file,
         line: Int = #line,
@@ -634,7 +889,8 @@ extension PostgresConnection {
         file: String = #fileID,
         line: Int = #line
     ) -> EventLoopFuture<PostgresQueryResult> {
-        self.queryStream(query, logger: logger).flatMap { rowStream in
+        let span = self.makeQueryTraceSpan(for: query, file: file, line: UInt(line))
+        let future = self.queryStream(query, logger: logger).flatMap { rowStream in
             rowStream.all().flatMapThrowing { rows -> PostgresQueryResult in
                 guard let metadata = PostgresQueryMetadata(string: rowStream.commandTag) else {
                     throw PSQLError.invalidCommandTag(rowStream.commandTag)
@@ -642,6 +898,7 @@ extension PostgresConnection {
                 return PostgresQueryResult(metadata: metadata, rows: rows)
             }
         }.enrichPSQLError(query: query, file: file, line: line)
+        return self.traceFuture(future, span: span)
     }
 
     /// Run a query on the Postgres server the connection is connected to and iterate the rows in a callback.
@@ -663,14 +920,19 @@ extension PostgresConnection {
         line: Int = #line,
         _ onRow: @escaping @Sendable (PostgresRow) throws -> ()
     ) -> EventLoopFuture<PostgresQueryMetadata> {
-        self.queryStream(query, logger: logger).flatMap { rowStream in
-            rowStream.onRow(onRow).flatMapThrowing { () -> PostgresQueryMetadata in
+        let span = self.makeQueryTraceSpan(for: query, file: file, line: UInt(line))
+        let future: EventLoopFuture<PostgresQueryMetadata> = self.queryStream(query, logger: logger).flatMap { rowStream in
+            if let span {
+                rowStream.installTracing(span, managesLifecycle: false)
+            }
+            return rowStream.onRow(onRow).flatMapThrowing { () -> PostgresQueryMetadata in
                 guard let metadata = PostgresQueryMetadata(string: rowStream.commandTag) else {
                     throw PSQLError.invalidCommandTag(rowStream.commandTag)
                 }
                 return metadata
             }
         }.enrichPSQLError(query: query, file: file, line: line)
+        return self.traceFuture(future, span: span)
     }
 }
 
@@ -685,27 +947,66 @@ extension PostgresConnection: PostgresDatabase {
             preconditionFailure("\(#function) requires an instance of PostgresCommands. This will be a compile-time error in the future.")
         }
 
-        let resultFuture: EventLoopFuture<Void>
-
         switch command {
         case .query(let query, let onMetadata, let onRow):
-            resultFuture = self.queryStream(query, logger: logger).flatMap { stream in
+            let span = self.makeQueryTraceSpan(for: query)
+            let resultFuture = self.queryStream(query, logger: logger).flatMap { stream in
+                if let span {
+                    stream.installTracing(span, managesLifecycle: false)
+                }
                 return stream.onRow(onRow).map { _ in
-                    onMetadata(PostgresQueryMetadata(string: stream.commandTag)!)
+                    let metadata = PostgresQueryMetadata(string: stream.commandTag)!
+                    if let span {
+                        span.withContext {
+                            onMetadata(metadata)
+                        }
+                    } else {
+                        onMetadata(metadata)
+                    }
                 }
             }
+            return self.traceFuture(
+                resultFuture.flatMapErrorThrowing { error in
+                    throw error.asAppropriatePostgresError
+                },
+                span: span
+            )
 
         case .queryAll(let query, let onResult):
-            resultFuture = self.queryStream(query, logger: logger).flatMap { rows in
+            let span = self.makeQueryTraceSpan(for: query)
+            let resultFuture = self.queryStream(query, logger: logger).flatMap { rows in
                 return rows.all().map { allrows in
-                    onResult(.init(metadata: PostgresQueryMetadata(string: rows.commandTag)!, rows: allrows))
+                    let result = PostgresQueryResult(
+                        metadata: PostgresQueryMetadata(string: rows.commandTag)!,
+                        rows: allrows
+                    )
+                    if let span {
+                        span.withContext {
+                            onResult(result)
+                        }
+                    } else {
+                        onResult(result)
+                    }
                 }
             }
+            return self.traceFuture(
+                resultFuture.flatMapErrorThrowing { error in
+                    throw error.asAppropriatePostgresError
+                },
+                span: span
+            )
 
         case .prepareQuery(let request):
-            resultFuture = self.prepareStatement(request.query, with: request.name, logger: logger).map {
+            let span = self.makePrepareTraceSpan(sql: request.query)
+            let resultFuture = self.prepareStatement(request.query, with: request.name, logger: logger).map {
                 request.prepared = PreparedQuery(underlying: $0, database: self)
             }
+            return self.traceFuture(
+                resultFuture.flatMapErrorThrowing { error in
+                    throw error.asAppropriatePostgresError
+                },
+                span: span
+            )
 
         case .executePreparedStatement(let preparedQuery, let binds, let onRow):
             var bindings = PostgresBindings(capacity: binds.count)
@@ -717,13 +1018,22 @@ extension PostgresConnection: PostgresDatabase {
                 rowDescription: preparedQuery.underlying.rowDescription
             )
 
-            resultFuture = self.execute(statement, logger: logger).flatMap { rows in
+            let span = self.makePreparedExecutionTraceSpan(
+                sql: preparedQuery.underlying.query,
+                bindCount: binds.count
+            )
+            let resultFuture = self.execute(statement, logger: logger).flatMap { rows in
+                if let span {
+                    rows.installTracing(span, managesLifecycle: false)
+                }
                 return rows.onRow(onRow)
             }
-        }
-
-        return resultFuture.flatMapErrorThrowing { error in
-            throw error.asAppropriatePostgresError
+            return self.traceFuture(
+                resultFuture.flatMapErrorThrowing { error in
+                    throw error.asAppropriatePostgresError
+                },
+                span: span
+            )
         }
     }
 

--- a/Sources/PostgresNIO/Connection/PostgresDatabase+PreparedQuery.swift
+++ b/Sources/PostgresNIO/Connection/PostgresDatabase+PreparedQuery.swift
@@ -53,7 +53,7 @@ public struct PreparedQuery: Sendable {
     }
 
     public func deallocate() -> EventLoopFuture<Void> {
-        self.underlying.connection.close(.preparedStatement(self.underlying.name), logger: self.database.logger)
+        self.underlying.connection.tracedDeallocate(self.underlying.name, logger: self.database.logger)
     }
 }
 

--- a/Sources/PostgresNIO/Docs.docc/index.md
+++ b/Sources/PostgresNIO/Docs.docc/index.md
@@ -42,6 +42,7 @@ configure ``PostgresConnection`` to use `Network.framework` as the underlying tr
 
 - <doc:coding>
 - <doc:prepared-statement>
+- <doc:tracing>
 - <doc:listen>
 
 ### Errors

--- a/Sources/PostgresNIO/Docs.docc/tracing.md
+++ b/Sources/PostgresNIO/Docs.docc/tracing.md
@@ -1,0 +1,167 @@
+# Tracing
+
+Emit distributed tracing spans for Postgres operations with ``PostgresConnection`` and ``PostgresClient``.
+
+## Overview
+
+PostgresNIO supports opt-in distributed tracing using [swift-distributed-tracing](https://github.com/apple/swift-distributed-tracing). When enabled, PostgresNIO creates database client spans that follow OpenTelemetry database conventions as closely as possible without adding another semantic-conventions dependency.
+
+Tracing is disabled by default. Once enabled, PostgresNIO uses the bootstrapped global tracer from `InstrumentationSystem.tracer` unless you provide an explicit tracer override in ``PostgresTracingConfiguration``.
+
+## Enable Tracing
+
+Bootstrap your tracer provider first, then enable tracing in the connection or client options:
+
+```swift
+import PostgresNIO
+import Tracing
+
+InstrumentationSystem.bootstrap(MyTracer())
+
+var clientConfiguration = PostgresClient.Configuration(
+    host: "localhost",
+    port: 5432,
+    username: "username",
+    password: "password",
+    database: "my_database",
+    tls: .disable
+)
+clientConfiguration.options.tracing.isEnabled = true
+
+var connectionConfiguration = PostgresConnection.Configuration(
+    host: "localhost",
+    port: 5432,
+    username: "username",
+    password: "password",
+    database: "my_database",
+    tls: .disable
+)
+connectionConfiguration.options.tracing.isEnabled = true
+```
+
+To override the tracer used by a specific client or connection, assign ``PostgresTracingConfiguration/tracer`` directly:
+
+```swift
+clientConfiguration.options.tracing.tracer = myTracer
+```
+
+## Query Text Policy
+
+``PostgresTracingConfiguration`` defaults `db.query.text` to a safe policy.
+
+- Parameterized SQL is recorded by default when PostgresNIO has actual bind values for the query.
+- Library-generated SQL, such as the generated `COPY` statement used by `copyFrom`, may be recorded with a sanitized tracing form.
+- Raw non-parameterized SQL strings are not attached unless you opt in.
+
+If you want PostgresNIO to attach raw SQL text to all traced operations, set:
+
+```swift
+clientConfiguration.options.tracing.queryTextPolicy = .recordAll
+```
+
+Use `.recordAll` only when raw query text is acceptable for your deployment and data handling requirements.
+
+## Statement Metadata Policy
+
+``PostgresTracingConfiguration`` defaults statement metadata to an exact mode.
+
+- Exact metadata is emitted only when PostgresNIO already knows the operation from the higher-level API surface, such as explicit `prepare`, explicit `deallocate`, and `copyFrom`.
+- Generic `query` and prepared execution spans do not derive `db.operation.name` from SQL text by default.
+- Generic span names therefore usually fall back to the database namespace when available.
+
+If you want compatibility with backends that benefit from SQL verb grouping on generic queries, opt in to heuristic SQL keyword inference:
+
+```swift
+clientConfiguration.options.tracing.statementMetadataPolicy = .inferred
+```
+
+This infers `db.operation.name` from the first keyword of the SQL text (for example `SELECT`, `INSERT`, `UPDATE`) and uses that to build the span name. It is intended for observability compatibility, not exact semantic understanding.
+
+If you do not want optional statement metadata at all, disable it:
+
+```swift
+clientConfiguration.options.tracing.statementMetadataPolicy = .disabled
+```
+
+When disabled, PostgresNIO omits `db.operation.name` and `db.query.summary`. Generic span names still fall back to the namespace or server target when available.
+
+## Error Details Policy
+
+``PostgresTracingConfiguration`` defaults recorded tracing exceptions to a safe error description.
+
+- `PSQLError` keeps its generic privacy-preserving description by default.
+- `error.type` and `db.response.status_code` are still attached to the span when available.
+- More detailed exception messages are opt-in.
+
+If you want PostgresNIO to attach the primary PostgreSQL server error message to failed spans, set:
+
+```swift
+clientConfiguration.options.tracing.errorDetailsPolicy = .message
+```
+
+If you want PostgresNIO to attach `String(reflecting: error)` to failed spans, set:
+
+```swift
+clientConfiguration.options.tracing.errorDetailsPolicy = .debugDescription
+```
+
+`.debugDescription` may include sensitive information such as server detail strings, query context, and source locations, so it should only be enabled when that additional visibility is acceptable for your deployment.
+
+## Emitted Spans
+
+This release traces:
+
+- `query`
+- prepared statement execution
+- explicit `prepare`
+- explicit `deallocate`
+- `copyFrom`
+- `withTransaction`
+
+`PostgresClient` starts spans before leasing a pooled connection, so queue wait is included in the measured duration. `PostgresConnection` starts spans when the operation is invoked.
+
+Async query spans stay open until the returned ``PostgresRowSequence`` is fully consumed or terminated early. Callback-based row handlers restore the span's `ServiceContext` while your callback runs so that logs and child spans created there attach to the database span.
+
+Managed transactions produce an additional INTERNAL wrapper span named `postgres.transaction`. The `BEGIN`, inner query spans, and `COMMIT` or `ROLLBACK` spans are children of that wrapper span.
+
+## Span Names And Attributes
+
+Span names follow this order:
+
+- `db.query.summary` when exact summary metadata is available
+- `{db.operation.name} {target}` when operation metadata is available and a target is known
+- `{target}` for generic query spans without operation metadata
+- `postgresql` only when no better target is available
+
+The target prefers `db.collection.name`, then `db.stored_procedure.name`, then `db.namespace`, and finally `server.address:server.port`.
+
+Common attributes include:
+
+- `db.system.name = "postgresql"`
+- `db.namespace`
+- `db.query.text`
+- `db.operation.name` — exact by default, or heuristically inferred from SQL when ``PostgresTracingConfiguration/StatementMetadataPolicy/inferred`` is enabled
+- `db.query.summary` — only for exact operations whose low-cardinality summary is already known
+- `server.address`
+- `server.port`
+- `network.peer.address`
+- `network.peer.port`
+
+On failures, PostgresNIO marks the span as an error and records:
+
+- `db.response.status_code` from SQLSTATE when available
+- `error.type` from SQLSTATE or the canonical client-side error type
+- an exception message according to ``PostgresTracingConfiguration/ErrorDetailsPolicy``
+
+PostgresNIO does not record query parameter values in this version.
+
+## Exclusions
+
+The first tracing version intentionally does not create spans for:
+
+- connection establishment
+- authentication
+- pool maintenance
+- `LISTEN` / `NOTIFY`
+
+Those areas can be added later without changing the opt-in tracing configuration surface.

--- a/Sources/PostgresNIO/New/PSQLRowStream.swift
+++ b/Sources/PostgresNIO/New/PSQLRowStream.swift
@@ -1,3 +1,4 @@
+import Atomics
 import NIOCore
 import Logging
 
@@ -46,6 +47,10 @@ final class PSQLRowStream: @unchecked Sendable {
     internal let rowDescription: [RowDescription.Column]
     private let lookupTable: [String: Int]
     private var downstreamState: DownstreamState
+    private var tracing: (span: PostgresTraceSpan, managesLifecycle: Bool)?
+    // Set to true (on the event loop) when CommandComplete arrives for the async sequence path.
+    // Read from any thread in didTerminate() to end the span synchronously before the event loop hop.
+    private let asyncSequenceCompletedSuccessfully = ManagedAtomic(false)
     
     init(
         source: Source,
@@ -66,6 +71,7 @@ final class PSQLRowStream: @unchecked Sendable {
         }
         
         self.downstreamState = .waitingForConsumer(bufferState)
+        self.tracing = nil
         
         self.eventLoop = eventLoop
         self.logger = logger
@@ -76,6 +82,22 @@ final class PSQLRowStream: @unchecked Sendable {
             lookup[column.name] = index
         }
         self.lookupTable = lookup
+    }
+
+    deinit {
+        if let tracing = self.tracing, tracing.managesLifecycle {
+            switch self.downstreamState {
+            case .consumed(.success):
+                tracing.span.succeed()
+            default:
+                tracing.span.fail(CancellationError())
+            }
+        }
+    }
+
+    func installTracing(_ span: PostgresTraceSpan, managesLifecycle: Bool) {
+        self.eventLoop.preconditionInEventLoop()
+        self.tracing = (span, managesLifecycle)
     }
     
     // MARK: Async Sequence
@@ -105,12 +127,14 @@ final class PSQLRowStream: @unchecked Sendable {
 
         case .finished(let buffer, let summary):
             _ = source.yield(contentsOf: buffer)
+            self.asyncSequenceCompletedSuccessfully.store(true, ordering: .relaxed)
             source.finish()
             onFinish()
             self.downstreamState = .consumed(.success(summary))
 
         case .failure(let error):
             source.finish(error)
+            self.failTracingIfNeeded(error)
             self.downstreamState = .consumed(.failure(error))
         }
         
@@ -155,6 +179,7 @@ final class PSQLRowStream: @unchecked Sendable {
         case .asyncSequence(_, let dataSource, let onFinish):
             self.downstreamState = .consumed(.failure(CancellationError()))
             dataSource.cancel(for: self)
+            self.failTracingIfNeeded(CancellationError())
             onFinish()
 
         case .consumed:
@@ -238,7 +263,9 @@ final class PSQLRowStream: @unchecked Sendable {
                         lookupTable: self.lookupTable,
                         columns: self.rowDescription
                     )
-                    try onRow(row)
+                    try self.withTracingContext {
+                        try onRow(row)
+                    }
                 }
                 
                 buffer.removeAll()
@@ -261,7 +288,9 @@ final class PSQLRowStream: @unchecked Sendable {
                         lookupTable: self.lookupTable,
                         columns: self.rowDescription
                     )
-                    try onRow(row)
+                    try self.withTracingContext {
+                        try onRow(row)
+                    }
                 }
                 
                 self.downstreamState = .consumed(.success(summary))
@@ -306,7 +335,9 @@ final class PSQLRowStream: @unchecked Sendable {
                         lookupTable: self.lookupTable,
                         columns: self.rowDescription
                     )
-                    try onRow(row)
+                    try self.withTracingContext {
+                        try onRow(row)
+                    }
                 }
                 // immediately request more
                 dataSource.request(for: self)
@@ -359,14 +390,17 @@ final class PSQLRowStream: @unchecked Sendable {
             
         case .iteratingRows(_, let promise, _):
             self.downstreamState = .consumed(.success(.tag(commandTag)))
+            self.finishTracingIfNeeded()
             promise.succeed(())
             
         case .waitingForAll(let rows, let promise, _):
             self.downstreamState = .consumed(.success(.tag(commandTag)))
+            self.finishTracingIfNeeded()
             promise.succeed(rows)
 
         case .asyncSequence(let source, _, let onFinish):
             self.downstreamState = .consumed(.success(.tag(commandTag)))
+            self.asyncSequenceCompletedSuccessfully.store(true, ordering: .relaxed)
             source.finish()
             onFinish()
 
@@ -379,20 +413,24 @@ final class PSQLRowStream: @unchecked Sendable {
         switch self.downstreamState {
         case .waitingForConsumer(.streaming):
             self.downstreamState = .waitingForConsumer(.failure(error))
+            self.failTracingIfNeeded(error)
             
         case .waitingForConsumer(.finished), .waitingForConsumer(.failure), .consumed(.success(.emptyResponse)):
             preconditionFailure("How can we get another end, if an end was already signalled?")
             
         case .iteratingRows(_, let promise, _):
             self.downstreamState = .consumed(.failure(error))
+            self.failTracingIfNeeded(error)
             promise.fail(error)
             
         case .waitingForAll(_, let promise, _):
             self.downstreamState = .consumed(.failure(error))
+            self.failTracingIfNeeded(error)
             promise.fail(error)
 
         case .asyncSequence(let consumer, _, let onFinish):
             self.downstreamState = .consumed(.failure(error))
+            self.failTracingIfNeeded(error)
             consumer.finish(error)
             onFinish()
 
@@ -416,6 +454,29 @@ final class PSQLRowStream: @unchecked Sendable {
             break
         }
     }
+
+    private func withTracingContext<T>(_ body: () throws -> T) rethrows -> T {
+        guard let tracing = self.tracing else {
+            return try body()
+        }
+        return try tracing.span.withContext {
+            try body()
+        }
+    }
+
+    private func finishTracingIfNeeded() {
+        guard let tracing = self.tracing, tracing.managesLifecycle else {
+            return
+        }
+        tracing.span.succeed()
+    }
+
+    private func failTracingIfNeeded(_ error: any Error) {
+        guard let tracing = self.tracing, tracing.managesLifecycle else {
+            return
+        }
+        tracing.span.fail(error)
+    }
     
     var commandTag: String {
         guard case .consumed(.success(let consumed)) = self.downstreamState else {
@@ -436,7 +497,36 @@ extension PSQLRowStream: NIOAsyncSequenceProducerDelegate {
     }
 
     func didTerminate() {
-        self.cancel()
+        // End the span synchronously, before the event loop hop, so it closes the moment the
+        // consumer's `for try await` loop exits preventing overlap with the next sequential query.
+        if let tracing = self.tracing, tracing.managesLifecycle {
+            if self.asyncSequenceCompletedSuccessfully.load(ordering: .relaxed) {
+                tracing.span.succeed()
+            } else {
+                tracing.span.fail(CancellationError())
+            }
+        }
+
+        if self.eventLoop.inEventLoop {
+            self.didTerminate0()
+        } else {
+            self.eventLoop.execute {
+                self.didTerminate0()
+            }
+        }
+    }
+
+    private func didTerminate0() {
+        switch self.downstreamState {
+        case .consumed(.success), .consumed(.failure):
+            break
+
+        case .asyncSequence:
+            self.cancel0()
+
+        case .waitingForConsumer, .iteratingRows, .waitingForAll:
+            preconditionFailure("Invalid state: \(self.downstreamState)")
+        }
     }
 }
 

--- a/Sources/PostgresNIO/Pool/ConnectionFactory.swift
+++ b/Sources/PostgresNIO/Pool/ConnectionFactory.swift
@@ -90,6 +90,7 @@ final class ConnectionFactory: Sendable {
         connectionConfig.options.tlsServerName = config.options.tlsServerName
         connectionConfig.options.requireBackendKeyData = config.options.requireBackendKeyData
         connectionConfig.options.additionalStartupParameters = config.options.additionalStartupParameters
+        connectionConfig.options.tracing = config.options.tracing
 
         return connectionConfig
     }

--- a/Sources/PostgresNIO/Pool/PostgresClient.swift
+++ b/Sources/PostgresNIO/Pool/PostgresClient.swift
@@ -3,6 +3,7 @@ import NIOSSL
 import Atomics
 import Logging
 import ServiceLifecycle
+import Tracing
 import _ConnectionPoolModule
 
 /// A Postgres client that is backed by an underlying connection pool. Use ``Configuration`` to change the client's
@@ -135,6 +136,9 @@ public final class PostgresClient: Sendable, ServiceLifecycle.Service {
             /// keep alive query of `SELECT 1;` every `30` seconds.
             public var keepAliveBehavior: KeepAliveBehavior? = KeepAliveBehavior()
 
+            /// Distributed tracing options for this client's database operations.
+            public var tracing: PostgresTracingConfiguration = .init()
+
             /// Create an options structure with default values.
             ///
             /// Most users should not need to adjust the defaults.
@@ -253,6 +257,8 @@ public final class PostgresClient: Sendable, ServiceLifecycle.Service {
     let factory: ConnectionFactory
     let runningAtomic = ManagedAtomic(false)
     let backgroundLogger: Logger
+    let tracingConfiguration: PostgresTracingConfiguration?
+    let tracingConnectionInfo: PostgresTracingConnectionInfo?
 
     /// Creates a new ``PostgresClient``, that does not log any background information.
     ///
@@ -284,6 +290,10 @@ public final class PostgresClient: Sendable, ServiceLifecycle.Service {
         let factory = ConnectionFactory(config: configuration, eventLoopGroup: eventLoopGroup, logger: backgroundLogger)
         self.factory = factory
         self.backgroundLogger = backgroundLogger
+        self.tracingConfiguration = configuration.options.tracing.isEnabled ? configuration.options.tracing : nil
+        self.tracingConnectionInfo = self.tracingConfiguration.map { _ in
+            PostgresTracingConnectionInfo(configuration: configuration)
+        }
 
         self.pool = ConnectionPool(
             configuration: .init(configuration),
@@ -355,8 +365,41 @@ public final class PostgresClient: Sendable, ServiceLifecycle.Service {
         _ closure: (PostgresConnection) async throws -> sending Result
     ) async throws -> sending Result {
         // for 6.0 to compile we need to explicitly forward the isolation.
-        try await self.withConnection(isolation: isolation) { connection in
-            try await connection.withTransaction(logger: logger, file: file, line: line, isolation: isolation, closure)
+        let span = self.makeTraceSpan(for: .transaction, file: file, line: UInt(line))
+        guard let span else {
+            return try await self.withConnection(isolation: isolation) { connection in
+                try await connection._withTransactionUntraced(
+                    logger: logger,
+                    file: file,
+                    line: line,
+                    isolation: isolation,
+                    closure
+                )
+            }
+        }
+
+        do {
+            return try await self.withConnection(isolation: isolation) { connection in
+                try await connection.withTraceContextOverride(span.context) {
+                    do {
+                        let result = try await connection._withTransactionUntraced(
+                            logger: logger,
+                            file: file,
+                            line: line,
+                            isolation: isolation,
+                            closure
+                        )
+                        span.succeed()
+                        return result
+                    } catch {
+                        span.fail(error)
+                        throw error
+                    }
+                }
+            }
+        } catch {
+            span.fail(error)
+            throw error
         }
     }
 
@@ -377,6 +420,7 @@ public final class PostgresClient: Sendable, ServiceLifecycle.Service {
         line: Int = #line
     ) async throws -> PostgresRowSequence {
         let logger = logger ?? Self.loggingDisabled
+        let span = self.makeQueryTraceSpan(for: query, file: file, line: UInt(line))
         do {
             guard query.binds.count <= Int(UInt16.max) else {
                 throw PSQLError(code: .tooManyParameters, query: query, file: file, line: line)
@@ -397,20 +441,24 @@ public final class PostgresClient: Sendable, ServiceLifecycle.Service {
 
             connection.channel.write(HandlerTask.extendedQuery(context), promise: nil)
 
-            promise.futureResult.whenFailure { _ in
+            let responseFuture = promise.futureResult.flatMapThrowing {
+                if let span {
+                    $0.installTracing(span, managesLifecycle: true)
+                }
+                return $0.asyncSequence(onFinish: {
+                    lease.release()
+                })
+            }
+
+            responseFuture.whenFailure { _ in
                 lease.release()
             }
 
-            return try await promise.futureResult.map {
-                $0.asyncSequence(onFinish: {
-                    lease.release()
-                })
-            }.get()
-        } catch var error as PSQLError {
-            error.file = file
-            error.line = line
-            error.query = query
-            throw error // rethrow with more metadata
+            return try await responseFuture.get()
+        } catch {
+            let tracedError = enrichTracingError(error, query: query, file: file, line: line)
+            span?.fail(tracedError)
+            throw tracedError
         }
     }
 
@@ -423,6 +471,12 @@ public final class PostgresClient: Sendable, ServiceLifecycle.Service {
     ) async throws -> AsyncThrowingMapSequence<PostgresRowSequence, Row> where Row == Statement.Row {
         let bindings = try preparedStatement.makeBindings()
         let logger = logger ?? Self.loggingDisabled
+        let span = self.makePreparedExecutionTraceSpan(
+            sql: Statement.sql,
+            bindCount: bindings.count,
+            file: file,
+            line: UInt(line)
+        )
 
         do {
             let lease = try await self.leaseConnection()
@@ -439,22 +493,27 @@ public final class PostgresClient: Sendable, ServiceLifecycle.Service {
             ))
             connection.channel.write(task, promise: nil)
 
-            promise.futureResult.whenFailure { _ in
+            let responseFuture = promise.futureResult.flatMapThrowing {
+                if let span {
+                    $0.installTracing(span, managesLifecycle: true)
+                }
+                return $0.asyncSequence(onFinish: { lease.release() })
+            }
+
+            responseFuture.whenFailure { _ in
                 lease.release()
             }
 
-            return try await promise.futureResult
-                .map { $0.asyncSequence(onFinish: { lease.release() }) }
-                .get()
-                .map { try preparedStatement.decodeRow($0) }
-        } catch var error as PSQLError {
-            error.file = file
-            error.line = line
-            error.query = .init(
-                unsafeSQL: Statement.sql,
-                binds: bindings
+            return try await responseFuture.get().map { try preparedStatement.decodeRow($0) }
+        } catch {
+            let tracedError = enrichTracingError(
+                error,
+                query: .init(unsafeSQL: Statement.sql, binds: bindings),
+                file: file,
+                line: line
             )
-            throw error // rethrow with more metadata
+            span?.fail(tracedError)
+            throw tracedError
         }
     }
 
@@ -491,6 +550,64 @@ public final class PostgresClient: Sendable, ServiceLifecycle.Service {
         return try await self.pool.leaseConnection()
     }
 
+    private func makeTraceSpan(
+        for operation: @autoclosure () -> PostgresTraceOperation,
+        parentContext: ServiceContext? = nil,
+        function: String = #function,
+        file: String = #fileID,
+        line: UInt = #line
+    ) -> PostgresTraceSpan? {
+        guard let configuration = self.tracingConfiguration,
+              let connectionInfo = self.tracingConnectionInfo,
+              let tracer = configuration.resolvedTracer
+        else {
+            return nil
+        }
+
+        return operation().makeSpan(
+            tracer: tracer,
+            configuration: configuration,
+            connectionInfo: connectionInfo,
+            parentContext: parentContext ?? ServiceContext.current,
+            function: function,
+            file: file,
+            line: line
+        )
+    }
+
+    private func makeQueryTraceSpan(
+        for query: PostgresQuery,
+        parentContext: ServiceContext? = nil,
+        function: String = #function,
+        file: String = #fileID,
+        line: UInt = #line
+    ) -> PostgresTraceSpan? {
+        self.makeTraceSpan(
+            for: .userQuery(query),
+            parentContext: parentContext,
+            function: function,
+            file: file,
+            line: line
+        )
+    }
+
+    private func makePreparedExecutionTraceSpan(
+        sql: String,
+        bindCount: Int,
+        parentContext: ServiceContext? = nil,
+        function: String = #function,
+        file: String = #fileID,
+        line: UInt = #line
+    ) -> PostgresTraceSpan? {
+        self.makeTraceSpan(
+            for: .preparedExecution(sql: sql, bindCount: bindCount),
+            parentContext: parentContext,
+            function: function,
+            file: file,
+            line: line
+        )
+    }
+
     /// Returns the default `EventLoopGroup` singleton, automatically selecting the best for the platform.
     ///
     /// This will select the concrete `EventLoopGroup` depending which platform this is running on.
@@ -516,7 +633,7 @@ struct PostgresKeepAliveBehavor: ConnectionKeepAliveBehavior {
     }
 
     func runKeepAlive(for connection: PostgresConnection) async throws {
-        try await connection.query(self.behavior!.query, logger: self.logger).map { _ in }.get()
+        try await connection.runMaintenanceQuery(self.behavior!.query, logger: self.logger)
     }
 }
 

--- a/Sources/PostgresNIO/Tracing/PostgresTracingConfiguration.swift
+++ b/Sources/PostgresNIO/Tracing/PostgresTracingConfiguration.swift
@@ -1,0 +1,111 @@
+import Tracing
+
+/// Configuration for PostgresNIO's distributed tracing support.
+public struct PostgresTracingConfiguration: Sendable {
+    /// Policy for attaching `db.query.text` to database spans.
+    public enum QueryTextPolicy: Sendable {
+        /// Record query text only when PostgresNIO can treat it as parameterized or library-generated.
+        case safe
+
+        /// Record all query text, including raw SQL that may contain literal values.
+        case recordAll
+    }
+
+    /// Policy for attaching optional low-cardinality statement metadata to spans.
+    public enum StatementMetadataPolicy: Sendable {
+        /// Emit exact statement metadata only for operations whose semantics are already known to PostgresNIO.
+        case exact
+
+        /// Heuristically infer statement metadata from SQL text when exact metadata is unavailable.
+        ///
+        /// This keeps compatibility with backends that benefit from SQL verb grouping, but the
+        /// metadata is derived from the query text rather than the higher-level API surface.
+        case inferred
+
+        /// Do not attach optional statement metadata.
+        case disabled
+    }
+
+    /// Policy for attaching potentially sensitive error details to recorded tracing exceptions.
+    public enum ErrorDetailsPolicy: Sendable {
+        /// Preserve the default `Error` description.
+        ///
+        /// For `PSQLError`, this keeps the generic privacy-preserving description.
+        case safe
+
+        /// Attach only the primary server message when PostgresNIO receives a server-side `PSQLError`.
+        ///
+        /// This is often enough to surface useful failures such as `deadlock detected`
+        /// without attaching the full debug representation.
+        case message
+
+        /// Attach `String(reflecting: error)` as the exception message.
+        ///
+        /// This may include sensitive information such as server detail strings, query context,
+        /// and source locations. Use only when that additional visibility is acceptable.
+        case debugDescription
+    }
+
+    @usableFromInline
+    var _tracer: Optional<any Sendable>
+
+    /// Whether tracing is enabled for this PostgresNIO instance.
+    public var isEnabled: Bool
+
+    /// Query text recording policy for database spans.
+    public var queryTextPolicy: QueryTextPolicy
+
+    /// How PostgresNIO should attach optional low-cardinality statement metadata to spans.
+    public var statementMetadataPolicy: StatementMetadataPolicy
+
+    /// How much detail PostgresNIO should attach to recorded tracing exceptions.
+    public var errorDetailsPolicy: ErrorDetailsPolicy
+
+    /// Create a tracing configuration.
+    ///
+    /// - Parameters:
+    ///   - isEnabled: Whether tracing is enabled. Defaults to `false`.
+    ///   - queryTextPolicy: Query text policy. Defaults to `.safe`.
+    ///   - statementMetadataPolicy: Optional statement metadata policy. Defaults to `.exact`.
+    ///   - errorDetailsPolicy: Error details policy. Defaults to `.safe`.
+    public init(
+        isEnabled: Bool = false,
+        queryTextPolicy: QueryTextPolicy = .safe,
+        statementMetadataPolicy: StatementMetadataPolicy = .exact,
+        errorDetailsPolicy: ErrorDetailsPolicy = .safe
+    ) {
+        self._tracer = nil
+        self.isEnabled = isEnabled
+        self.queryTextPolicy = queryTextPolicy
+        self.statementMetadataPolicy = statementMetadataPolicy
+        self.errorDetailsPolicy = errorDetailsPolicy
+    }
+
+    /// Tracer that should be used by PostgresNIO.
+    ///
+    /// If `nil`, PostgresNIO uses ``InstrumentationSystem/tracer`` when tracing is enabled.
+    public var tracer: (any Tracer)? {
+        get {
+            guard let _tracer else {
+                return nil
+            }
+            return _tracer as! (any Tracer)?
+        }
+        set {
+            self._tracer = newValue
+        }
+    }
+}
+
+extension PostgresTracingConfiguration {
+    @usableFromInline
+    var resolvedTracer: (any Tracer)? {
+        guard self.isEnabled else {
+            return nil
+        }
+        if let _tracer {
+            return _tracer as! (any Tracer)?
+        }
+        return InstrumentationSystem.tracer
+    }
+}

--- a/Sources/PostgresNIO/Tracing/PostgresTracingSupport.swift
+++ b/Sources/PostgresNIO/Tracing/PostgresTracingSupport.swift
@@ -1,0 +1,536 @@
+import Atomics
+import Logging
+import NIOCore
+import Tracing
+
+struct PostgresTracingConnectionInfo: Sendable {
+    static let dbSystemName = "postgresql"
+
+    let namespace: String?
+    let serverAddress: String?
+    let serverPort: Int?
+    let peerAddress: String?
+    let peerPort: Int?
+
+    init(configuration: PostgresConnection.InternalConfiguration) {
+        self.namespace = Self.namespace(database: configuration.database, username: configuration.username)
+
+        switch configuration.connection {
+        case .resolved(let address):
+            let parts = Self.socketAddressComponents(address)
+            self.serverAddress = parts.address
+            self.serverPort = parts.port
+            self.peerAddress = parts.address
+            self.peerPort = parts.port
+
+        case .unresolvedTCP(let host, let port):
+            self.serverAddress = host
+            self.serverPort = port
+            self.peerAddress = host
+            self.peerPort = port
+
+        case .unresolvedUDS(let path):
+            self.serverAddress = path
+            self.serverPort = nil
+            self.peerAddress = path
+            self.peerPort = nil
+
+        case .bootstrapped(let channel):
+            let parts = channel.remoteAddress.map(Self.socketAddressComponents)
+            self.serverAddress = parts?.address
+            self.serverPort = parts?.port
+            self.peerAddress = parts?.address
+            self.peerPort = parts?.port
+        }
+    }
+
+    @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
+    init(configuration: PostgresClient.Configuration) {
+        self.namespace = Self.namespace(database: configuration.database, username: configuration.username)
+
+        switch configuration.endpointInfo {
+        case .connectTCP(let host, let port):
+            self.serverAddress = host
+            self.serverPort = port
+            self.peerAddress = host
+            self.peerPort = port
+
+        case .bindUnixDomainSocket(let path):
+            self.serverAddress = path
+            self.serverPort = nil
+            self.peerAddress = path
+            self.peerPort = nil
+        }
+    }
+
+    private static func namespace(database: String?, username: String?) -> String? {
+        if let database, !database.isEmpty {
+            return database
+        }
+        return username
+    }
+
+    private static func socketAddressComponents(_ address: SocketAddress) -> (address: String, port: Int?) {
+        let raw = String(describing: address)
+        if let port = address.port {
+            let suffix = ":\(port)"
+            if raw.hasSuffix(suffix) {
+                return (String(raw.dropLast(suffix.count)), port)
+            }
+            return (raw, port)
+        }
+        return (raw, nil)
+    }
+}
+
+enum PostgresTraceOperation: Sendable {
+    case query(PostgresQuery, safeQueryText: String?, exactSummary: PostgresTraceSummary?)
+    case prepare(sql: String)
+    case executePrepared(sql: String, bindCount: Int)
+    case deallocate(statementName: String)
+    case transaction
+
+    var isTransaction: Bool {
+        if case .transaction = self {
+            return true
+        } else {
+            return false
+        }
+    }
+}
+
+extension PostgresTraceOperation {
+    static func userQuery(_ query: PostgresQuery) -> Self {
+        .query(query, safeQueryText: nil, exactSummary: nil)
+    }
+
+    static func libraryQuery(
+        _ query: PostgresQuery,
+        safeQueryText: String,
+        exactSummary: PostgresTraceSummary? = nil
+    ) -> Self {
+        .query(query, safeQueryText: safeQueryText, exactSummary: exactSummary)
+    }
+
+    static func preparedExecution(sql: String, bindCount: Int) -> Self {
+        .executePrepared(sql: sql, bindCount: bindCount)
+    }
+}
+
+struct PostgresTraceSummary: Sendable {
+    let operationName: String?
+    let querySummary: String?
+    let collectionName: String?
+    let storedProcedureName: String?
+
+    static let none = Self(
+        operationName: nil,
+        querySummary: nil,
+        collectionName: nil,
+        storedProcedureName: nil
+    )
+
+    static let prepare = Self(
+        operationName: "PREPARE",
+        querySummary: "PREPARE",
+        collectionName: nil,
+        storedProcedureName: nil
+    )
+
+    static let deallocate = Self(
+        operationName: "DEALLOCATE",
+        querySummary: "DEALLOCATE",
+        collectionName: nil,
+        storedProcedureName: nil
+    )
+
+    static func make(
+        for operation: PostgresTraceOperation,
+        policy: PostgresTracingConfiguration.StatementMetadataPolicy
+    ) -> Self {
+        switch policy {
+        case .exact:
+            return self.makeExact(for: operation)
+        case .inferred:
+            return self.makeInferred(for: operation)
+        case .disabled:
+            return .none
+        }
+    }
+
+    private static func makeExact(for operation: PostgresTraceOperation) -> Self {
+        switch operation {
+        case .query(_, _, let exactSummary):
+            return exactSummary ?? .none
+
+        case .executePrepared:
+            return .none
+
+        case .prepare:
+            return .prepare
+
+        case .deallocate:
+            return .deallocate
+
+        case .transaction:
+            return .none
+        }
+    }
+
+    private static func makeInferred(for operation: PostgresTraceOperation) -> Self {
+        switch operation {
+        case .query(let query, _, let exactSummary):
+            return exactSummary ?? Self.inferredFromSQL(query.sql)
+
+        case .executePrepared(let sql, _):
+            return Self.inferredFromSQL(sql)
+
+        case .prepare:
+            return .prepare
+
+        case .deallocate:
+            return .deallocate
+
+        case .transaction:
+            return .none
+        }
+    }
+
+    private static func inferredFromSQL(_ sql: String) -> Self {
+        let operationName = sql
+            .drop(while: \.isWhitespace)
+            .prefix(while: \.isLetter)
+            .uppercased()
+        guard !operationName.isEmpty else {
+            return .none
+        }
+        return .init(operationName: operationName, querySummary: nil, collectionName: nil, storedProcedureName: nil)
+    }
+}
+
+struct PostgresTraceMetadata: Sendable {
+    let spanName: String
+    let spanKind: SpanKind
+    let attributes: SpanAttributes
+
+    init(
+        operation: PostgresTraceOperation,
+        configuration: PostgresTracingConfiguration,
+        connectionInfo: PostgresTracingConnectionInfo
+    ) {
+        let summary = PostgresTraceSummary.make(
+            for: operation,
+            policy: configuration.statementMetadataPolicy
+        )
+        var attributes: SpanAttributes = [:]
+        attributes["db.system.name"] = PostgresTracingConnectionInfo.dbSystemName
+        // Also emit the legacy experimental attribute so backends like Datadog that have
+        // not yet migrated to the stable db.system.name attribute can still classify the
+        // span as a database span and show the database icon.
+        attributes["db.system"] = PostgresTracingConnectionInfo.dbSystemName
+
+        if let namespace = connectionInfo.namespace {
+            attributes["db.namespace"] = namespace
+        }
+        if let serverAddress = connectionInfo.serverAddress {
+            attributes["server.address"] = serverAddress
+        }
+        if let serverPort = connectionInfo.serverPort {
+            attributes["server.port"] = serverPort
+        }
+        if let peerAddress = connectionInfo.peerAddress {
+            attributes["network.peer.address"] = peerAddress
+        }
+        if let peerPort = connectionInfo.peerPort {
+            attributes["network.peer.port"] = peerPort
+        }
+        if let operationName = summary.operationName {
+            attributes["db.operation.name"] = operationName
+        }
+        if let querySummary = summary.querySummary, !operation.isTransaction {
+            attributes["db.query.summary"] = querySummary
+        }
+        if let collectionName = summary.collectionName {
+            attributes["db.collection.name"] = collectionName
+        }
+        if let storedProcedureName = summary.storedProcedureName {
+            attributes["db.stored_procedure.name"] = storedProcedureName
+        }
+        if let queryText = Self.queryText(for: operation, policy: configuration.queryTextPolicy) {
+            attributes["db.query.text"] = queryText
+        }
+
+        switch operation {
+        case .transaction:
+            self.spanName = "postgres.transaction"
+            self.spanKind = .internal
+        default:
+            self.spanName = Self.spanName(summary: summary, connectionInfo: connectionInfo)
+            self.spanKind = .client
+        }
+        self.attributes = attributes
+    }
+
+    private static func spanName(
+        summary: PostgresTraceSummary,
+        connectionInfo: PostgresTracingConnectionInfo
+    ) -> String {
+        if let querySummary = summary.querySummary {
+            return querySummary
+        }
+
+        let target = Self.target(summary: summary, connectionInfo: connectionInfo)
+        if let operationName = summary.operationName {
+            if let target {
+                return "\(operationName) \(target)"
+            }
+            return operationName
+        }
+
+        return target ?? PostgresTracingConnectionInfo.dbSystemName
+    }
+
+    private static func target(
+        summary: PostgresTraceSummary,
+        connectionInfo: PostgresTracingConnectionInfo
+    ) -> String? {
+        if let collectionName = summary.collectionName {
+            return collectionName
+        }
+        if let storedProcedureName = summary.storedProcedureName {
+            return storedProcedureName
+        }
+        if let namespace = connectionInfo.namespace {
+            return namespace
+        }
+        if let serverAddress = connectionInfo.serverAddress {
+            if let serverPort = connectionInfo.serverPort {
+                return "\(serverAddress):\(serverPort)"
+            }
+            return serverAddress
+        }
+        return nil
+    }
+
+    private static func queryText(
+        for operation: PostgresTraceOperation,
+        policy: PostgresTracingConfiguration.QueryTextPolicy
+    ) -> String? {
+        let sql: String?
+        let safeQueryText: String?
+        let isParameterized: Bool
+
+        switch operation {
+        case .query(let query, let sanitizedQueryText, _):
+            sql = query.sql
+            safeQueryText = sanitizedQueryText
+            isParameterized = query.binds.count > 0
+        case .prepare(let statement):
+            sql = statement
+            safeQueryText = nil
+            isParameterized = false
+        case .executePrepared(let statement, let bindCount):
+            sql = statement
+            safeQueryText = nil
+            isParameterized = bindCount > 0
+        case .deallocate, .transaction:
+            sql = nil
+            safeQueryText = nil
+            isParameterized = false
+        }
+
+        guard let sql else {
+            return nil
+        }
+
+        switch policy {
+        case .safe:
+            if isParameterized {
+                return sql
+            }
+            return safeQueryText
+        case .recordAll:
+            return sql
+        }
+    }
+}
+
+final class PostgresTraceSpan: @unchecked Sendable {
+    private let span: any Span
+    private let errorDetailsPolicy: PostgresTracingConfiguration.ErrorDetailsPolicy
+    private let isFinished = ManagedAtomic(false)
+
+    init(
+        span: any Span,
+        errorDetailsPolicy: PostgresTracingConfiguration.ErrorDetailsPolicy
+    ) {
+        self.span = span
+        self.errorDetailsPolicy = errorDetailsPolicy
+    }
+
+    var context: ServiceContext {
+        self.span.context
+    }
+
+    func withContext<T>(_ body: () throws -> T) rethrows -> T {
+        try ServiceContext.$current.withValue(self.span.context) {
+            try body()
+        }
+    }
+
+    func succeed() {
+        guard self.finishIfNeeded() else {
+            return
+        }
+        self.span.end()
+    }
+
+    func fail(_ error: any Error) {
+        guard self.finishIfNeeded() else {
+            return
+        }
+        self.span.updateAttributes { attributes in
+            if let psqlError = error as? PSQLError,
+               let sqlState = psqlError.serverInfo?[.sqlState] {
+                attributes["db.response.status_code"] = sqlState
+                attributes["error.type"] = sqlState
+            } else {
+                attributes["error.type"] = Self.errorType(for: error)
+            }
+        }
+        self.span.recordError(
+            error,
+            attributes: Self.errorAttributes(for: error, policy: self.errorDetailsPolicy)
+        )
+        self.span.setStatus(.init(code: .error))
+        self.span.end()
+    }
+
+    private func finishIfNeeded() -> Bool {
+        self.isFinished.compareExchange(
+            expected: false,
+            desired: true,
+            ordering: .relaxed
+        ).exchanged
+    }
+
+    private static func errorType(for error: any Error) -> String {
+        if let postgresError = error as? PSQLError {
+            return postgresError.code.description
+        }
+        return String(reflecting: type(of: error))
+    }
+
+    private static func errorAttributes(
+        for error: any Error,
+        policy: PostgresTracingConfiguration.ErrorDetailsPolicy
+    ) -> SpanAttributes {
+        guard let exceptionMessage = self.exceptionMessage(for: error, policy: policy) else {
+            return [:]
+        }
+        return ["exception.message": .string(exceptionMessage)]
+    }
+
+    private static func exceptionMessage(
+        for error: any Error,
+        policy: PostgresTracingConfiguration.ErrorDetailsPolicy
+    ) -> String? {
+        switch policy {
+        case .safe:
+            return nil
+
+        case .message:
+            if let psqlError = error as? PSQLError,
+               let message = psqlError.serverInfo?[.message],
+               !message.isEmpty {
+                return message
+            }
+            return nil
+
+        case .debugDescription:
+            return String(reflecting: error)
+        }
+    }
+}
+
+func enrichTracingError(
+    _ error: any Error,
+    query: PostgresQuery? = nil,
+    file: String,
+    line: Int
+) -> any Error {
+    guard var psqlError = error as? PSQLError else {
+        return error
+    }
+
+    psqlError.file = file
+    psqlError.line = line
+    if let query {
+        psqlError.query = query
+    }
+    return psqlError
+}
+
+private extension Span {
+    func updateAttributes(_ update: (inout SpanAttributes) -> Void) {
+        var attributes = self.attributes
+        update(&attributes)
+        self.attributes = attributes
+    }
+}
+
+extension PostgresTraceOperation {
+    func makeSpan(
+        tracer: any Tracer,
+        configuration: PostgresTracingConfiguration,
+        connectionInfo: PostgresTracingConnectionInfo,
+        parentContext: ServiceContext?,
+        function: String = #function,
+        file fileID: String = #fileID,
+        line: UInt = #line
+    ) -> PostgresTraceSpan {
+        let metadata = PostgresTraceMetadata(
+            operation: self,
+            configuration: configuration,
+            connectionInfo: connectionInfo
+        )
+        let span = tracer.startSpan(
+            metadata.spanName,
+            context: parentContext ?? .topLevel,
+            ofKind: metadata.spanKind,
+            function: function,
+            file: fileID,
+            line: line
+        )
+        span.attributes = metadata.attributes
+        return PostgresTraceSpan(
+            span: span,
+            errorDetailsPolicy: configuration.errorDetailsPolicy
+        )
+    }
+
+    func makeSpan(
+        configuration: PostgresTracingConfiguration?,
+        connectionInfo: PostgresTracingConnectionInfo,
+        parentContext: ServiceContext?,
+        function: String = #function,
+        file fileID: String = #fileID,
+        line: UInt = #line
+    ) -> PostgresTraceSpan? {
+        guard let configuration,
+              let tracer = configuration.resolvedTracer
+        else {
+            return nil
+        }
+
+        return self.makeSpan(
+            tracer: tracer,
+            configuration: configuration,
+            connectionInfo: connectionInfo,
+            parentContext: parentContext,
+            function: function,
+            file: fileID,
+            line: line
+        )
+    }
+}

--- a/Tests/IntegrationTests/PostgresClientTracingTests.swift
+++ b/Tests/IntegrationTests/PostgresClientTracingTests.swift
@@ -1,0 +1,265 @@
+@_spi(ConnectionPool) import PostgresNIO
+import InMemoryTracing
+import Logging
+import NIOPosix
+import Testing
+import Tracing
+
+@Suite(.serialized) struct PostgresClientTracingTests {
+    @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
+    @Test func testQueryTracingIncludesLeaseWait() async throws {
+        let tracer = InMemoryTracer()
+        var rawLogger = Logger(label: "PostgresClientTracingTests")
+        rawLogger.logLevel = .debug
+        let logger = rawLogger
+
+        try await self.withEventLoopGroup { eventLoopGroup in
+            try await self.verifyDatabaseAccess(on: eventLoopGroup)
+
+            var config = PostgresClient.Configuration.makeTestConfiguration()
+            config.options.minimumConnections = 0
+            config.options.maximumConnections = 1
+            config.options.tracing = .init(isEnabled: true, queryTextPolicy: .recordAll)
+            config.options.tracing.tracer = tracer
+
+            let client = PostgresClient(configuration: config, eventLoopGroup: eventLoopGroup, backgroundLogger: logger)
+
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                group.addTask {
+                    await client.run()
+                }
+
+                let firstTask = Task {
+                    let rows = try await client.query("SELECT pg_sleep(0.3);", logger: logger)
+                    for try await _ in rows {}
+                }
+
+                try await Task.sleep(for: .milliseconds(50))
+
+                let secondTask = Task {
+                    let rows = try await client.query("SELECT 1;", logger: logger)
+                    for try await _ in rows {}
+                }
+
+                try await firstTask.value
+                try await secondTask.value
+
+                group.cancelAll()
+            }
+        }
+
+        let sleepSpan = try #require(tracer.finishedSpans.first(where: {
+            $0.attributes.stringValue(for: "db.query.text") == "SELECT pg_sleep(0.3);"
+        }))
+        let secondSpan = try #require(tracer.finishedSpans.first(where: {
+            $0.attributes.stringValue(for: "db.query.text") == "SELECT 1;"
+        }))
+
+        #expect(sleepSpan.kind == SpanKind.client)
+        #expect(secondSpan.kind == SpanKind.client)
+
+        let duration = secondSpan.endInstant.nanosecondsSinceEpoch - secondSpan.startInstant.nanosecondsSinceEpoch
+        #expect(duration >= 200_000_000)
+    }
+
+    @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
+    @Test func testTransactionTracingParentsDatabaseSpans() async throws {
+        let tracer = InMemoryTracer()
+        var rawLogger = Logger(label: "PostgresClientTracingTests")
+        rawLogger.logLevel = .debug
+        let logger = rawLogger
+
+        try await self.withEventLoopGroup { eventLoopGroup in
+            try await self.verifyDatabaseAccess(on: eventLoopGroup)
+
+            var config = PostgresClient.Configuration.makeTestConfiguration()
+            config.options.tracing = .init(isEnabled: true, queryTextPolicy: .recordAll)
+            config.options.tracing.tracer = tracer
+
+            let client = PostgresClient(configuration: config, eventLoopGroup: eventLoopGroup, backgroundLogger: logger)
+
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                group.addTask {
+                    await client.run()
+                }
+
+                try await client.withTransaction(logger: logger) { transaction in
+                    let rows = try await transaction.query("SELECT 1;", logger: logger)
+                    for try await _ in rows {}
+                }
+
+                group.cancelAll()
+            }
+        }
+
+        let transactionSpan = try #require(tracer.finishedSpans.first(where: { $0.operationName == "postgres.transaction" }))
+        let beginSpan = try #require(tracer.finishedSpans.first(where: {
+            $0.attributes.stringValue(for: "db.query.text") == "BEGIN;"
+        }))
+        let selectSpan = try #require(tracer.finishedSpans.first(where: {
+            $0.attributes.stringValue(for: "db.query.text") == "SELECT 1;"
+        }))
+        let commitSpan = try #require(tracer.finishedSpans.first(where: {
+            $0.attributes.stringValue(for: "db.query.text") == "COMMIT;"
+        }))
+
+        #expect(transactionSpan.kind == .internal)
+        #expect(beginSpan.parentSpanID == transactionSpan.spanID)
+        #expect(selectSpan.parentSpanID == transactionSpan.spanID)
+        #expect(commitSpan.parentSpanID == transactionSpan.spanID)
+    }
+
+    @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
+    @Test func testTransactionTracingFailsWhenLeaseFails() async throws {
+        let tracer = InMemoryTracer()
+        var rawLogger = Logger(label: "PostgresClientTracingTests")
+        rawLogger.logLevel = .debug
+        let logger = rawLogger
+
+        try await self.withEventLoopGroup { eventLoopGroup in
+            try await self.verifyDatabaseAccess(on: eventLoopGroup)
+
+            var config = PostgresClient.Configuration.makeTestConfiguration()
+            config.options.tracing = .init(isEnabled: true, queryTextPolicy: .recordAll)
+            config.options.tracing.tracer = tracer
+
+            let client = PostgresClient(configuration: config, eventLoopGroup: eventLoopGroup, backgroundLogger: logger)
+
+            await withTaskGroup(of: Void.self) { group in
+                group.addTask {
+                    await client.run()
+                }
+
+                group.cancelAll()
+                try? await Task.sleep(for: .milliseconds(10))
+
+                do {
+                    try await client.withTransaction(logger: logger) { _ in
+                        ()
+                    }
+                    Issue.record("Expected `withTransaction` to throw after client shutdown")
+                } catch {
+                    // expected
+                }
+            }
+        }
+
+        let transactionSpan = try #require(tracer.finishedSpans.first(where: { $0.operationName == "postgres.transaction" }))
+        #expect(transactionSpan.kind == .internal)
+        #expect(transactionSpan.status?.code == .error)
+        #expect(transactionSpan.attributes["error.type"] != nil)
+    }
+
+    @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
+    @Test func testKeepAliveQueriesAreNotTraced() async throws {
+        let tracer = InMemoryTracer()
+        var rawLogger = Logger(label: "PostgresClientTracingTests")
+        rawLogger.logLevel = .debug
+        let logger = rawLogger
+        let keepAliveValue = "postgresnio-keepalive-tracing"
+        let keepAliveQuery = PostgresQuery(
+            unsafeSQL: "SELECT set_config('application_name', 'postgresnio-keepalive-tracing', false);"
+        )
+        let resetQuery = PostgresQuery(
+            unsafeSQL: "SELECT set_config('application_name', 'postgresnio-user-query', false);"
+        )
+        let verifyQuery = PostgresQuery(
+            unsafeSQL: "SELECT current_setting('application_name');"
+        )
+
+        try await self.withEventLoopGroup { eventLoopGroup in
+            try await self.verifyDatabaseAccess(on: eventLoopGroup)
+
+            var config = PostgresClient.Configuration.makeTestConfiguration()
+            config.options.minimumConnections = 1
+            config.options.maximumConnections = 1
+            config.options.keepAliveBehavior = .init(
+                frequency: .milliseconds(100),
+                query: keepAliveQuery
+            )
+            config.options.tracing = .init(isEnabled: true, queryTextPolicy: .recordAll)
+            config.options.tracing.tracer = tracer
+
+            let client = PostgresClient(configuration: config, eventLoopGroup: eventLoopGroup, backgroundLogger: logger)
+
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                group.addTask {
+                    await client.run()
+                }
+
+                let resetRows = try await client.query(resetQuery, logger: logger).decode(String.self)
+                for try await _ in resetRows {}
+
+                #expect(try await self.waitForFinishedSpan(withQueryText: resetQuery.sql, in: tracer))
+                tracer.clearFinishedSpans()
+
+                try await Task.sleep(for: .milliseconds(250))
+
+                let rows = try await client.query(verifyQuery, logger: logger)
+
+                var values = [String]()
+                for try await value in rows.decode(String.self) {
+                    values.append(value)
+                }
+
+                #expect(try await self.waitForFinishedSpan(withQueryText: verifyQuery.sql, in: tracer))
+
+                #expect(values == [keepAliveValue])
+                #expect(tracer.finishedSpans.count == 1)
+                #expect(tracer.finishedSpans.first?.attributes.stringValue(for: "db.query.text") == verifyQuery.sql)
+                #expect(tracer.finishedSpans.contains(where: {
+                    $0.attributes.stringValue(for: "db.query.text") == keepAliveQuery.sql
+                }) == false)
+
+                group.cancelAll()
+            }
+        }
+    }
+
+    private func verifyDatabaseAccess(on eventLoopGroup: MultiThreadedEventLoopGroup) async throws {
+        let connection = try await PostgresConnection.test(on: eventLoopGroup.next()).get()
+        try await connection.close()
+    }
+
+    private func withEventLoopGroup<T>(
+        _ body: (MultiThreadedEventLoopGroup) async throws -> T
+    ) async throws -> T {
+        let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 2)
+        do {
+            let result = try await body(eventLoopGroup)
+            try await eventLoopGroup.shutdownGracefully()
+            return result
+        } catch {
+            try? await eventLoopGroup.shutdownGracefully()
+            throw error
+        }
+    }
+
+    private func waitForFinishedSpan(
+        withQueryText queryText: String,
+        in tracer: InMemoryTracer
+    ) async throws -> Bool {
+        for _ in 0..<50 {
+            if tracer.finishedSpans.contains(where: {
+                $0.attributes.stringValue(for: "db.query.text") == queryText
+            }) {
+                return true
+            }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        return false
+    }
+}
+
+private extension SpanAttributes {
+    func stringValue(for key: String) -> String? {
+        switch self[key]?.toSpanAttribute() {
+        case .string(let value):
+            return value
+        case .stringConvertible(let value):
+            return String(describing: value)
+        default:
+            return nil
+        }
+    }
+}

--- a/Tests/PostgresNIOTests/New/PostgresConnectionTracingTests.swift
+++ b/Tests/PostgresNIOTests/New/PostgresConnectionTracingTests.swift
@@ -1,0 +1,382 @@
+import InMemoryTracing
+import Logging
+import NIOCore
+import NIOEmbedded
+import Testing
+import Tracing
+@testable import PostgresNIO
+
+@Suite struct PostgresConnectionTracingTests {
+    let logger = Logger(label: "PostgresConnectionTracingTests")
+
+    @Test func testAsyncQuerySpanEndsAfterSequenceConsumption() async throws {
+        let tracer = InMemoryTracer()
+
+        try await self.withTracingConnection(tracer: tracer) { connection, channel in
+            let queryTask = Task {
+                try await connection.query("SELECT 1;", logger: self.logger)
+            }
+
+            let request = try await channel.waitForUnpreparedRequest()
+            #expect(request.parse.query == "SELECT 1;")
+
+            try await channel.sendUnpreparedRequestResponseStart(columns: [Self.intColumn(name: "value")])
+
+            let rows: PostgresRowSequence = try await queryTask.value
+            #expect(tracer.finishedSpans.isEmpty)
+
+            try await channel.writeInbound(PostgresBackendMessage.dataRow([Int(1)]))
+            try await channel.testingEventLoop.executeInContext { channel.read() }
+            try await channel.writeInbound(PostgresBackendMessage.commandComplete("SELECT 1"))
+            try await channel.testingEventLoop.executeInContext { channel.read() }
+            try await channel.writeInbound(PostgresBackendMessage.readyForQuery(.idle))
+
+            // Span is still open: CommandComplete arrived but the sequence hasn't been consumed yet.
+            #expect(tracer.finishedSpans.isEmpty)
+
+            // Consume the sequence — span ends synchronously when the iterator is torn down,
+            // before control returns to the caller. This follows the OTel semantic that the span
+            // covers the full operation "as observed by the caller", including row-fetch time.
+            var iterator = rows.decode(Int.self).makeAsyncIterator()
+            #expect(try await iterator.next() == 1)
+            #expect(try await iterator.next() == nil)
+
+            let span = try #require(tracer.finishedSpans.first)
+            #expect(span.operationName == "database")
+            #expect(span.kind == .client)
+            #expect(span.status == nil)
+            #expect(span.attributes.stringValue(for: "db.system.name") == "postgresql")
+            #expect(span.attributes.stringValue(for: "db.system") == "postgresql")
+            #expect(span.attributes.stringValue(for: "db.query.text") == "SELECT 1;")
+        }
+    }
+
+    @Test func testAsyncQuerySpanFailsWhenSequenceIsDroppedEarly() async throws {
+        let tracer = InMemoryTracer()
+
+        try await self.withTracingConnection(tracer: tracer) { connection, channel in
+            let queryTask = Task {
+                try await connection.query("SELECT 1;", logger: self.logger)
+            }
+
+            _ = try await channel.waitForUnpreparedRequest()
+            try await channel.sendUnpreparedRequestResponseStart(columns: [Self.intColumn(name: "value")])
+
+            var rows: PostgresRowSequence? = try await queryTask.value
+            do {
+                let iterator = rows?.makeAsyncIterator()
+                withExtendedLifetime(iterator) {
+                    rows = nil
+                }
+            }
+            try await Task.sleep(for: .milliseconds(10))
+
+            let span = try #require(tracer.finishedSpans.first)
+            #expect(span.operationName == "database")
+            #expect(span.status?.code == .error)
+            #expect(span.attributes.stringValue(for: "error.type") == "Swift.CancellationError")
+            #expect(span.attributes.stringValue(for: "db.query.text") == "SELECT 1;")
+        }
+    }
+
+    @Test func testAsyncQuerySpanFailsWhenServerSendsErrorDuringIteration() async throws {
+        let tracer = InMemoryTracer()
+
+        try await self.withTracingConnection(tracer: tracer) { connection, channel in
+            let queryTask = Task {
+                let rows = try await connection.query("SELECT 1;", logger: self.logger)
+                var iterator = rows.decode(Int.self).makeAsyncIterator()
+                _ = try await iterator.next()  // consumes the first row
+                _ = try await iterator.next()  // throws when the server error arrives
+            }
+
+            _ = try await channel.waitForUnpreparedRequest()
+            try await channel.sendUnpreparedRequestResponseStart(columns: [Self.intColumn(name: "value")])
+
+            // Deliver one row so the consumer progresses into the async sequence state.
+            try await channel.writeInbound(PostgresBackendMessage.dataRow([Int(1)]))
+            try await channel.testingEventLoop.executeInContext { channel.read() }
+
+            // Server sends an error instead of the next row or CommandComplete.
+            try await channel.writeInbound(PostgresBackendMessage.error(.init(fields: [
+                .message: "disk full",
+                .sqlState: "53100",
+            ])))
+            try await channel.testingEventLoop.executeInContext { channel.read() }
+            try await channel.writeInbound(PostgresBackendMessage.readyForQuery(.idle))
+
+            do {
+                try await queryTask.value
+                Issue.record("Expected iteration to fail")
+            } catch {}
+
+            // The span should end with the server error (SQL state 53100), not CancellationError.
+            let span = try #require(tracer.finishedSpans.first)
+            #expect(span.operationName == "database")
+            #expect(span.status?.code == .error)
+            #expect(span.attributes.stringValue(for: "db.response.status_code") == "53100")
+            #expect(span.attributes.stringValue(for: "error.type") == "53100")
+        }
+    }
+
+    @Test func testAsyncQueryRecordsEnrichedErrorOnSpan() async throws {
+        let tracer = InMemoryTracer()
+        let file = "TracingFile.swift"
+        let line = 4242
+        let query = PostgresQuery(unsafeSQL: "SELECT broken;", binds: PostgresBindings())
+
+        try await self.withTracingConnection(tracer: tracer) { connection, channel in
+            let queryTask = Task {
+                try await connection.query(query, logger: self.logger, file: file, line: line)
+            }
+
+            let request = try await channel.waitForUnpreparedRequest()
+            #expect(request.parse.query == query.sql)
+
+            try await channel.writeInbound(PostgresBackendMessage.error(.init(fields: [
+                .message: "syntax error",
+                .sqlState: "42601",
+            ])))
+            try await channel.testingEventLoop.executeInContext { channel.read() }
+            try await channel.writeInbound(PostgresBackendMessage.readyForQuery(.idle))
+
+            do {
+                _ = try await queryTask.value
+                Issue.record("Expected query to fail")
+            } catch {
+                let psqlError = try #require(error as? PSQLError)
+                #expect(psqlError.file == file)
+                #expect(psqlError.line == line)
+                #expect(psqlError.query == query)
+            }
+
+            let span = try #require(tracer.finishedSpans.first)
+            #expect(span.status?.code == .error)
+            #expect(span.errors.count == 1)
+
+            let recordedError = try #require(span.errors.first?.error as? PSQLError)
+            #expect(recordedError.file == file)
+            #expect(recordedError.line == line)
+            #expect(recordedError.query == query)
+            #expect(recordedError.serverInfo?[.sqlState] == "42601")
+        }
+    }
+
+    @Test func testAsyncQueryCanAttachDebugErrorDescriptionToRecordedException() async throws {
+        let tracer = InMemoryTracer()
+        let file = "TracingFile.swift"
+        let line = 4242
+        let query = PostgresQuery(unsafeSQL: "SELECT broken;", binds: PostgresBindings())
+
+        var tracing = PostgresTracingConfiguration(
+            isEnabled: true,
+            queryTextPolicy: .recordAll,
+            errorDetailsPolicy: .debugDescription
+        )
+        tracing.tracer = tracer
+
+        try await self.withTracingConnection(tracing: tracing) { connection, channel in
+            let queryTask = Task {
+                try await connection.query(query, logger: self.logger, file: file, line: line)
+            }
+
+            _ = try await channel.waitForUnpreparedRequest()
+
+            try await channel.writeInbound(PostgresBackendMessage.error(.init(fields: [
+                .message: "syntax error",
+                .sqlState: "42601",
+            ])))
+            try await channel.testingEventLoop.executeInContext { channel.read() }
+            try await channel.writeInbound(PostgresBackendMessage.readyForQuery(.idle))
+
+            do {
+                _ = try await queryTask.value
+                Issue.record("Expected query to fail")
+            } catch {}
+
+            let span = try #require(tracer.finishedSpans.first)
+            let recordedError = try #require(span.errors.first)
+            let exceptionMessage = try #require(recordedError.attributes.stringValue(for: "exception.message"))
+            #expect(exceptionMessage.contains("PSQLError(code: server"))
+            #expect(exceptionMessage.contains("triggeredFromRequestInFile: TracingFile.swift"))
+            #expect(exceptionMessage.contains("line: 4242"))
+            #expect(exceptionMessage.contains("query: PostgresQuery(sql: SELECT broken;"))
+        }
+    }
+
+    @Test func testCallbackQueryRunsWithSpanContext() async throws {
+        let tracer = InMemoryTracer()
+
+        try await self.withTracingConnection(tracer: tracer) { connection, channel in
+            let queryFuture = connection.query("SELECT 1;", logger: self.logger) { _ in
+                let childSpan = tracer.startSpan(
+                    "row-handler",
+                    context: ServiceContext.current ?? .topLevel,
+                    ofKind: .internal
+                )
+                childSpan.end()
+            }
+
+            _ = try await channel.waitForUnpreparedRequest()
+            try await channel.sendUnpreparedRequestResponseStart(columns: [Self.intColumn(name: "value")])
+            try await channel.writeInbound(PostgresBackendMessage.dataRow([Int(1)]))
+            try await channel.testingEventLoop.executeInContext { channel.read() }
+            try await channel.writeInbound(PostgresBackendMessage.commandComplete("SELECT 1"))
+            try await channel.testingEventLoop.executeInContext { channel.read() }
+            try await channel.writeInbound(PostgresBackendMessage.readyForQuery(.idle))
+
+            _ = try await queryFuture.get()
+
+            let querySpan = try #require(tracer.finishedSpans.first(where: {
+                $0.attributes.stringValue(for: "db.query.text") == "SELECT 1;"
+            }))
+            let childSpan = try #require(tracer.finishedSpans.first(where: { $0.operationName == "row-handler" }))
+
+            #expect(childSpan.parentSpanID == querySpan.spanID)
+        }
+    }
+
+    @Test func testTransactionWrapperSpanParentsDatabaseSpans() async throws {
+        let tracer = InMemoryTracer()
+
+        try await self.withTracingConnection(tracer: tracer) { connection, channel in
+            let transactionTask = Task {
+                try await connection.withTransaction(logger: self.logger) { transaction in
+                    let rows = try await transaction.query("SELECT 1;", logger: self.logger)
+                    var iterator = rows.decode(Int.self).makeAsyncIterator()
+                    _ = try await iterator.next()
+                    _ = try await iterator.next()
+                }
+            }
+
+            let begin = try await channel.waitForUnpreparedRequest()
+            #expect(begin.parse.query == "BEGIN;")
+            try await channel.sendUnpreparedRequestWithNoParametersBindResponse()
+            try await channel.writeInbound(PostgresBackendMessage.commandComplete("BEGIN"))
+            try await channel.testingEventLoop.executeInContext { channel.read() }
+            try await channel.writeInbound(PostgresBackendMessage.readyForQuery(.idle))
+
+            let select = try await channel.waitForUnpreparedRequest()
+            #expect(select.parse.query == "SELECT 1;")
+            try await channel.sendUnpreparedRequestResponseStart(columns: [Self.intColumn(name: "value")])
+            try await channel.writeInbound(PostgresBackendMessage.dataRow([Int(1)]))
+            try await channel.testingEventLoop.executeInContext { channel.read() }
+            try await channel.writeInbound(PostgresBackendMessage.commandComplete("SELECT 1"))
+            try await channel.testingEventLoop.executeInContext { channel.read() }
+            try await channel.writeInbound(PostgresBackendMessage.readyForQuery(.idle))
+
+            let commit = try await channel.waitForUnpreparedRequest()
+            #expect(commit.parse.query == "COMMIT;")
+            try await channel.sendUnpreparedRequestWithNoParametersBindResponse()
+            try await channel.writeInbound(PostgresBackendMessage.commandComplete("COMMIT"))
+            try await channel.testingEventLoop.executeInContext { channel.read() }
+            try await channel.writeInbound(PostgresBackendMessage.readyForQuery(.idle))
+
+            try await transactionTask.value
+
+            let transactionSpan = try #require(tracer.finishedSpans.first(where: { $0.operationName == "postgres.transaction" }))
+            let beginSpan = try #require(tracer.finishedSpans.first(where: {
+                $0.attributes.stringValue(for: "db.query.text") == "BEGIN;"
+            }))
+            let selectSpan = try #require(tracer.finishedSpans.first(where: {
+                $0.attributes.stringValue(for: "db.query.text") == "SELECT 1;"
+            }))
+            let commitSpan = try #require(tracer.finishedSpans.first(where: {
+                $0.attributes.stringValue(for: "db.query.text") == "COMMIT;"
+            }))
+
+            #expect(transactionSpan.kind == .internal)
+            #expect(beginSpan.parentSpanID == transactionSpan.spanID)
+            #expect(selectSpan.parentSpanID == transactionSpan.spanID)
+            #expect(commitSpan.parentSpanID == transactionSpan.spanID)
+        }
+    }
+
+    private func withTracingConnection(
+        tracer: InMemoryTracer? = nil,
+        tracing: PostgresTracingConfiguration? = nil,
+        _ body: (PostgresConnection, NIOAsyncTestingChannel) async throws -> Void
+    ) async throws {
+        let eventLoop = NIOAsyncTestingEventLoop()
+        let channel = try await NIOAsyncTestingChannel(loop: eventLoop) { channel in
+            try channel.pipeline.syncOperations.addHandlers(ReverseByteToMessageHandler(PSQLFrontendMessageDecoder()))
+            try channel.pipeline.syncOperations.addHandlers(ReverseMessageToByteHandler(PSQLBackendMessageEncoder()))
+        }
+        try await channel.connect(to: .makeAddressResolvingHost("localhost", port: 5432))
+
+        var configuration = PostgresConnection.Configuration(
+            establishedChannel: channel,
+            username: "username",
+            password: "postgres",
+            database: "database"
+        )
+        configuration.options.tracing = tracing ?? .init(isEnabled: true, queryTextPolicy: .recordAll)
+        if let tracer {
+            configuration.options.tracing.tracer = tracer
+        }
+
+        async let connectionTask = PostgresConnection.connect(
+            on: eventLoop,
+            configuration: configuration,
+            id: 1,
+            logger: self.logger
+        )
+
+        let startup = try await channel.waitForOutboundWrite(as: PostgresFrontendMessage.self)
+        #expect(startup == .startup(.versionThree(parameters: .init(
+            user: "username",
+            database: "database",
+            options: [],
+            replication: .false
+        ))))
+        try await channel.writeInbound(PostgresBackendMessage.authentication(.ok))
+        try await channel.writeInbound(PostgresBackendMessage.backendKeyData(.init(processID: 1234, secretKey: 5678)))
+        try await channel.writeInbound(PostgresBackendMessage.readyForQuery(.idle))
+
+        let connection = try await connectionTask
+        do {
+            try await body(connection, channel)
+        } catch {
+            try await connection.close()
+            throw error
+        }
+
+        try await connection.close()
+    }
+
+    private static func intColumn(name: String) -> RowDescription.Column {
+        .init(
+            name: name,
+            tableOID: 0,
+            columnAttributeNumber: 0,
+            dataType: .int8,
+            dataTypeSize: 8,
+            dataTypeModifier: 0,
+            format: .binary
+        )
+    }
+}
+
+private extension SpanAttributes {
+    func stringValue(for key: String) -> String? {
+        switch self[key]?.toSpanAttribute() {
+        case .string(let value):
+            return value
+        case .stringConvertible(let value):
+            return String(describing: value)
+        default:
+            return nil
+        }
+    }
+}
+
+private extension NIOAsyncTestingChannel {
+    func sendUnpreparedRequestResponseStart(columns: [RowDescription.Column]) async throws {
+        try await self.writeInbound(PostgresBackendMessage.parseComplete)
+        try await self.writeInbound(PostgresBackendMessage.parameterDescription(.init(dataTypes: [])))
+        try await self.writeInbound(PostgresBackendMessage.rowDescription(.init(columns: columns)))
+        try await self.testingEventLoop.executeInContext { self.read() }
+        try await self.writeInbound(PostgresBackendMessage.bindComplete)
+        try await self.testingEventLoop.executeInContext { self.read() }
+    }
+}

--- a/Tests/PostgresNIOTests/Tracing/PostgresTracingSupportTests.swift
+++ b/Tests/PostgresNIOTests/Tracing/PostgresTracingSupportTests.swift
@@ -1,0 +1,424 @@
+import InMemoryTracing
+import Testing
+import Tracing
+@testable import PostgresNIO
+
+@Suite struct PostgresTracingSupportTests {
+    @Test func testUserQuerySpanDefaultsToNamespaceTargetSpanName() {
+        var tracing = PostgresTracingConfiguration(isEnabled: true)
+        tracing.queryTextPolicy = .safe
+
+        let config = PostgresConnection.Configuration(
+            host: "db.example.com",
+            port: 5433,
+            username: "trace_user",
+            password: nil,
+            database: "trace_db",
+            tls: .disable
+        )
+
+        let metadata = PostgresTraceMetadata(
+            operation: .userQuery(Self.parameterizedQuery("SELECT * FROM public.users WHERE id = $1")),
+            configuration: tracing,
+            connectionInfo: .init(configuration: .init(config))
+        )
+
+        #expect(metadata.spanName == "trace_db")
+        #expect(metadata.spanKind == SpanKind.client)
+        #expect(metadata.attributes.stringValue(for: "db.system.name") == "postgresql")
+        #expect(metadata.attributes.stringValue(for: "db.system") == "postgresql")
+        #expect(metadata.attributes.stringValue(for: "db.namespace") == "trace_db")
+        #expect(metadata.attributes.stringValue(for: "server.address") == "db.example.com")
+        #expect(metadata.attributes.intValue(for: "server.port") == 5433)
+        #expect(metadata.attributes["db.operation.name"] == nil)
+        #expect(metadata.attributes["db.collection.name"] == nil)
+        #expect(metadata.attributes["db.query.summary"] == nil)
+        #expect(metadata.attributes.stringValue(for: "db.query.text") == "SELECT * FROM public.users WHERE id = $1")
+    }
+
+    @Test func testUserQuerySpanFallsBackToNamespaceTargetWhenNoStatementMetadataExists() {
+        var tracing = PostgresTracingConfiguration(isEnabled: true)
+        tracing.queryTextPolicy = .recordAll
+
+        let info = PostgresTracingConnectionInfo(configuration: .init(
+            PostgresConnection.Configuration(
+                host: "localhost",
+                port: 5432,
+                username: "postgres",
+                password: nil,
+                database: "postgres",
+                tls: .disable
+            )
+        ))
+
+        let metadata = PostgresTraceMetadata(
+            operation: .userQuery(PostgresQuery(unsafeSQL: "", binds: PostgresBindings())),
+            configuration: tracing,
+            connectionInfo: info
+        )
+
+        #expect(metadata.spanName == "postgres")
+        #expect(metadata.attributes["db.operation.name"] == nil)
+        #expect(metadata.attributes["db.query.summary"] == nil)
+    }
+
+    @Test func testInferredStatementMetadataPolicyUsesSQLKeywordAndTarget() {
+        let tracing = PostgresTracingConfiguration(
+            isEnabled: true,
+            statementMetadataPolicy: .inferred
+        )
+        let info = PostgresTracingConnectionInfo(configuration: .init(
+            PostgresConnection.Configuration(
+                host: "localhost",
+                port: 5432,
+                username: "postgres",
+                password: nil,
+                database: "postgres",
+                tls: .disable
+            )
+        ))
+
+        func spanName(for sql: String) -> String? {
+            PostgresTraceMetadata(
+                operation: .userQuery(Self.parameterizedQuery(sql)),
+                configuration: tracing,
+                connectionInfo: info
+            ).spanName
+        }
+
+        #expect(spanName(for: #"INSERT INTO "perf_uploads" ("id") VALUES ($1)"#) == "INSERT postgres")
+        #expect(spanName(for: "SELECT * FROM users WHERE id = $1") == "SELECT postgres")
+        #expect(spanName(for: "UPDATE users SET name = $1") == "UPDATE postgres")
+        #expect(spanName(for: "DELETE FROM orders WHERE id = $1") == "DELETE postgres")
+        #expect(spanName(for: "BEGIN") == "BEGIN postgres")
+        #expect(spanName(for: "") == "postgres")
+
+        let metadata = PostgresTraceMetadata(
+            operation: .userQuery(Self.parameterizedQuery("INSERT INTO t VALUES ($1)")),
+            configuration: tracing,
+            connectionInfo: info
+        )
+        #expect(metadata.attributes.stringValue(for: "db.operation.name") == "INSERT")
+        #expect(metadata.attributes["db.query.summary"] == nil)
+    }
+
+    @Test func testPreparedExecutionSpanUsesInferredOperationNameAndTarget() {
+        let tracing = PostgresTracingConfiguration(
+            isEnabled: true,
+            statementMetadataPolicy: .inferred
+        )
+        let info = PostgresTracingConnectionInfo(configuration: .init(
+            PostgresConnection.Configuration(
+                host: "localhost",
+                port: 5432,
+                username: "postgres",
+                password: nil,
+                database: "postgres",
+                tls: .disable
+            )
+        ))
+
+        let metadata = PostgresTraceMetadata(
+            operation: .preparedExecution(
+                sql: #"INSERT INTO "perf_uploads" ("id", "user_id") VALUES ($1, $2)"#,
+                bindCount: 2
+            ),
+            configuration: tracing,
+            connectionInfo: info
+        )
+
+        #expect(metadata.spanName == "INSERT postgres")
+        #expect(metadata.attributes.stringValue(for: "db.operation.name") == "INSERT")
+        #expect(metadata.attributes["db.query.summary"] == nil)
+    }
+
+    @Test func testCopyFromUsesExactMetadataWithoutSQLInference() {
+        let tracing = PostgresTracingConfiguration(isEnabled: true)
+        let info = PostgresTracingConnectionInfo(configuration: .init(
+            PostgresConnection.Configuration(
+                host: "localhost",
+                port: 5432,
+                username: "postgres",
+                password: nil,
+                database: "postgres",
+                tls: .disable
+            )
+        ))
+
+        let metadata = PostgresTraceMetadata(
+            operation: .libraryQuery(
+                PostgresQuery(
+                    unsafeSQL: #"COPY "perf_uploads" FROM STDIN WITH (FORMAT text)"#,
+                    binds: PostgresBindings()
+                ),
+                safeQueryText: #"COPY "perf_uploads" FROM STDIN WITH (FORMAT text)"#,
+                exactSummary: .init(
+                    operationName: "COPY",
+                    querySummary: nil,
+                    collectionName: "perf_uploads",
+                    storedProcedureName: nil
+                )
+            ),
+            configuration: tracing,
+            connectionInfo: info
+        )
+
+        #expect(metadata.spanName == "COPY perf_uploads")
+        #expect(metadata.attributes.stringValue(for: "db.operation.name") == "COPY")
+        #expect(metadata.attributes.stringValue(for: "db.collection.name") == "perf_uploads")
+    }
+
+    @Test func testSafeQueryTextPolicyOnlyCapturesSafeSQL() {
+        let safe = PostgresTracingConfiguration(isEnabled: true, queryTextPolicy: .safe)
+        let info = PostgresTracingConnectionInfo(configuration: .init(
+            PostgresConnection.Configuration(
+                host: "localhost",
+                port: 5432,
+                username: "postgres",
+                password: nil,
+                database: "postgres",
+                tls: .disable
+            )
+        ))
+
+        let rawLiteral = PostgresTraceMetadata(
+            operation: .userQuery(PostgresQuery(unsafeSQL: "SELECT 1", binds: PostgresBindings())),
+            configuration: safe,
+            connectionInfo: info
+        )
+        let libraryGenerated = PostgresTraceMetadata(
+            operation: .libraryQuery(
+                PostgresQuery(
+                    unsafeSQL: #"COPY "users" FROM STDIN WITH (FORMAT text,DELIMITER U&'\0009')"#,
+                    binds: PostgresBindings()
+                ),
+                safeQueryText: #"COPY "users" FROM STDIN WITH (FORMAT text,DELIMITER ?)"#
+            ),
+            configuration: safe,
+            connectionInfo: info
+        )
+        let parameterized = PostgresTraceMetadata(
+            operation: .userQuery(Self.parameterizedQuery("SELECT * FROM users WHERE id = $1")),
+            configuration: safe,
+            connectionInfo: info
+        )
+        let placeholderInLiteral = PostgresTraceMetadata(
+            operation: .userQuery(PostgresQuery(unsafeSQL: #"SELECT '$1'"#, binds: PostgresBindings())),
+            configuration: safe,
+            connectionInfo: info
+        )
+        let recordAll = PostgresTraceMetadata(
+            operation: .userQuery(PostgresQuery(unsafeSQL: "SELECT 1", binds: PostgresBindings())),
+            configuration: .init(isEnabled: true, queryTextPolicy: .recordAll),
+            connectionInfo: info
+        )
+
+        #expect(rawLiteral.attributes["db.query.text"] == nil)
+        #expect(
+            libraryGenerated.attributes.stringValue(for: "db.query.text")
+                == #"COPY "users" FROM STDIN WITH (FORMAT text,DELIMITER ?)"#
+        )
+        #expect(parameterized.attributes.stringValue(for: "db.query.text") == "SELECT * FROM users WHERE id = $1")
+        #expect(placeholderInLiteral.attributes["db.query.text"] == nil)
+        #expect(recordAll.attributes.stringValue(for: "db.query.text") == "SELECT 1")
+    }
+
+    @Test func testDisabledStatementMetadataPolicySkipsDerivedSQLMetadata() {
+        let tracing = PostgresTracingConfiguration(
+            isEnabled: true,
+            queryTextPolicy: .safe,
+            statementMetadataPolicy: .disabled
+        )
+        let info = PostgresTracingConnectionInfo(configuration: .init(
+            PostgresConnection.Configuration(
+                host: "localhost",
+                port: 5432,
+                username: "postgres",
+                password: nil,
+                database: "postgres",
+                tls: .disable
+            )
+        ))
+
+        let metadata = PostgresTraceMetadata(
+            operation: .userQuery(Self.parameterizedQuery("SELECT * FROM public.users WHERE id = $1")),
+            configuration: tracing,
+            connectionInfo: info
+        )
+
+        #expect(metadata.spanName == "postgres")
+        #expect(metadata.attributes["db.operation.name"] == nil)
+        #expect(metadata.attributes["db.query.summary"] == nil)
+        #expect(metadata.attributes["db.collection.name"] == nil)
+        #expect(metadata.attributes.stringValue(for: "db.query.text") == "SELECT * FROM public.users WHERE id = $1")
+    }
+
+    @Test func testPrepareMetadataUsesExactOperationOnlyWhenEnabled() {
+        let info = PostgresTracingConnectionInfo(configuration: .init(
+            PostgresConnection.Configuration(
+                host: "localhost",
+                port: 5432,
+                username: "postgres",
+                password: nil,
+                database: "postgres",
+                tls: .disable
+            )
+        ))
+
+        let exact = PostgresTraceMetadata(
+            operation: .prepare(sql: "SELECT 1"),
+            configuration: .init(isEnabled: true, queryTextPolicy: .safe, statementMetadataPolicy: .exact),
+            connectionInfo: info
+        )
+        let disabled = PostgresTraceMetadata(
+            operation: .prepare(sql: "SELECT 1"),
+            configuration: .init(isEnabled: true, queryTextPolicy: .safe, statementMetadataPolicy: .disabled),
+            connectionInfo: info
+        )
+
+        #expect(exact.spanName == "PREPARE")
+        #expect(exact.attributes.stringValue(for: "db.operation.name") == "PREPARE")
+        #expect(exact.attributes.stringValue(for: "db.query.summary") == "PREPARE")
+        #expect(disabled.spanName == "postgres")
+        #expect(disabled.attributes["db.operation.name"] == nil)
+        #expect(disabled.attributes["db.query.summary"] == nil)
+    }
+
+    @Test func testFailureRecordsSQLStateOnSpan() throws {
+        let tracer = InMemoryTracer()
+        var tracing = PostgresTracingConfiguration(isEnabled: true)
+        tracing.tracer = tracer
+
+        let info = PostgresTracingConnectionInfo(configuration: .init(
+            PostgresConnection.Configuration(
+                host: "localhost",
+                port: 5432,
+                username: "postgres",
+                password: nil,
+                database: "postgres",
+                tls: .disable
+            )
+        ))
+
+        let span = try #require(
+            PostgresTraceOperation
+                .userQuery(Self.parameterizedQuery("SELECT * FROM users WHERE id = $1"))
+                .makeSpan(configuration: tracing, connectionInfo: info, parentContext: .topLevel)
+        )
+
+        span.fail(PSQLError.server(.init(fields: [.sqlState: "08P01", .message: "protocol violation"])))
+
+        let finished = try #require(tracer.finishedSpans.first)
+        #expect(finished.operationName == "postgres")
+        #expect(finished.status?.code == .error)
+        #expect(finished.attributes.stringValue(for: "db.response.status_code") == "08P01")
+        #expect(finished.attributes.stringValue(for: "error.type") == "08P01")
+        #expect(finished.errors.count == 1)
+        #expect((finished.errors.first?.error as? PSQLError)?.serverInfo?[.sqlState] == "08P01")
+    }
+
+    @Test func testFailureErrorDetailsPolicyCanAttachPrimaryServerMessage() throws {
+        let tracer = InMemoryTracer()
+        var tracing = PostgresTracingConfiguration(isEnabled: true)
+        tracing.tracer = tracer
+        tracing.errorDetailsPolicy = .message
+
+        let info = PostgresTracingConnectionInfo(configuration: .init(
+            PostgresConnection.Configuration(
+                host: "localhost",
+                port: 5432,
+                username: "postgres",
+                password: nil,
+                database: "postgres",
+                tls: .disable
+            )
+        ))
+
+        let span = try #require(
+            PostgresTraceOperation
+                .userQuery(Self.parameterizedQuery("SELECT * FROM users WHERE id = $1"))
+                .makeSpan(configuration: tracing, connectionInfo: info, parentContext: .topLevel)
+        )
+
+        span.fail(PSQLError.server(.init(fields: [
+            .sqlState: "40P01",
+            .message: "deadlock detected",
+            .detail: "query details",
+        ])))
+
+        let finished = try #require(tracer.finishedSpans.first)
+        let recordedError = try #require(finished.errors.first)
+        #expect(recordedError.attributes.stringValue(for: "exception.message") == "deadlock detected")
+    }
+
+    @Test func testFailureErrorDetailsPolicyCanAttachDebugDescription() throws {
+        let tracer = InMemoryTracer()
+        var tracing = PostgresTracingConfiguration(isEnabled: true)
+        tracing.tracer = tracer
+        tracing.errorDetailsPolicy = .debugDescription
+
+        let info = PostgresTracingConnectionInfo(configuration: .init(
+            PostgresConnection.Configuration(
+                host: "localhost",
+                port: 5432,
+                username: "postgres",
+                password: nil,
+                database: "postgres",
+                tls: .disable
+            )
+        ))
+
+        let span = try #require(
+            PostgresTraceOperation
+                .userQuery(Self.parameterizedQuery("SELECT * FROM users WHERE id = $1"))
+                .makeSpan(configuration: tracing, connectionInfo: info, parentContext: .topLevel)
+        )
+
+        var error = PSQLError.server(.init(fields: [
+            .sqlState: "40P01",
+            .message: "deadlock detected",
+        ]))
+        error.file = "TracingFile.swift"
+        error.line = 4242
+        error.query = Self.parameterizedQuery("SELECT broken WHERE id = $1")
+
+        span.fail(error)
+
+        let finished = try #require(tracer.finishedSpans.first)
+        let recordedError = try #require(finished.errors.first)
+        let exceptionMessage = try #require(recordedError.attributes.stringValue(for: "exception.message"))
+        #expect(exceptionMessage.contains("PSQLError(code: server"))
+        #expect(exceptionMessage.contains("triggeredFromRequestInFile: TracingFile.swift"))
+        #expect(exceptionMessage.contains("query: PostgresQuery(sql: SELECT broken WHERE id = $1"))
+    }
+
+    private static func parameterizedQuery(_ sql: String) -> PostgresQuery {
+        var bindings = PostgresBindings()
+        bindings.appendNull()
+        return PostgresQuery(unsafeSQL: sql, binds: bindings)
+    }
+}
+
+private extension SpanAttributes {
+    func stringValue(for key: String) -> String? {
+        switch self[key]?.toSpanAttribute() {
+        case .string(let value):
+            return value
+        case .stringConvertible(let value):
+            return String(describing: value)
+        default:
+            return nil
+        }
+    }
+
+    func intValue(for key: String) -> Int? {
+        switch self[key]?.toSpanAttribute() {
+        case .int32(let value):
+            return Int(value)
+        case .int64(let value):
+            return Int(value)
+        default:
+            return nil
+        }
+    }
+}


### PR DESCRIPTION
This PR adds initial distributed tracing support to PostgresNIO.

The main goal here is to make it easier for applications to see database work inside end-to-end traces without forcing a specific observability backend or adding much complexity to the default path.

## What's included

- Adds tracing configuration for Postgres connections and clients
- Creates spans around query execution, prepared queries, `COPY FROM`, and row streaming where the operation crosses async boundaries
- Records database attributes such as system name, namespace, server address, and port
- Optionally records query text according to the configured query text policy
- Adds documentation and targeted tests for the new tracing behavior

## A couple of behavior notes

- Statement metadata is `exact` by default, so `db.operation.name` is only emitted when the library knows the operation exactly
- Heuristic SQL keyword inference is still available as `.inferred` for applications that want compatibility with observability backends that group queries by verb
- For generic queries, span names fall back to the database target instead of parsing arbitrary SQL by default

------

I tried to keep the implementation conservative by default and avoid introducing SQL parsing complexity into the main path, while still leaving room for compatibility with existing tracing setups.

We've been testing these changes for about a week now with a DataDog OTel collector in a service that has ~2K queries per minute and it's been super useful to improve performance.

I realize this may make more sense once the package has moved further toward full Swift concurrency adoption. If you'd prefer to hold off on merging tracing until then, I completely understand. I'd be happy to revisit and update this PR once that work is in place.