### PR TITLE
Feat 1.32.3

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:6.1
+// swift-tools-version:6.3
 import PackageDescription
 
 let swiftSettings: [SwiftSetting] = [
@@ -20,15 +20,15 @@ let package = Package(
         .library(name: "_ConnectionPoolTestUtils", targets: ["_ConnectionPoolTestUtils"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-atomics.git", from: "1.2.0"),
-        .package(url: "https://github.com/apple/swift-collections.git", from: "1.0.4"),
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.81.0"),
-        .package(url: "https://github.com/apple/swift-nio-transport-services.git", from: "1.19.0"),
-        .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.25.0"),
-        .package(url: "https://github.com/apple/swift-crypto.git", "3.9.0" ..< "5.0.0"),
-        .package(url: "https://github.com/apple/swift-metrics.git", from: "2.4.1"),
-        .package(url: "https://github.com/apple/swift-log.git", from: "1.5.3"),
-        .package(url: "https://github.com/swift-server/swift-service-lifecycle.git", from: "2.5.0"),
+        .package(url: "https://github.com/apple/swift-atomics.git", from: "1.3.0"),
+        .package(url: "https://github.com/apple/swift-collections.git", from: "1.4.1"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.99.0"),
+        .package(url: "https://github.com/apple/swift-nio-transport-services.git", from: "1.28.0"),
+        .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.37.0"),
+        .package(url: "https://github.com/apple/swift-crypto.git", "4.5.0" ..< "5.0.0"),
+        .package(url: "https://github.com/apple/swift-metrics.git", from: "2.10.1"),
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.12.0"),
+        .package(url: "https://github.com/swift-server/swift-service-lifecycle.git", from: "2.11.0"),
     ],
     targets: [
         .target(

--- a/Sources/PostgresNIO/Connection/PostgresConnection.swift
+++ b/Sources/PostgresNIO/Connection/PostgresConnection.swift
@@ -338,12 +338,14 @@ extension PostgresConnection {
         username: String,
         database: String? = nil,
         password: String? = nil,
+        additionalParameters: [(String, String)] = [],
         logger: Logger = .init(label: "codes.vapor.postgres")
     ) -> EventLoopFuture<Void> {
         let authContext = AuthContext(
             username: username,
             password: password,
-            database: database)
+            database: database,
+            additionalParameters: additionalParameters)
         let outgoing = PSQLOutgoingEvent.authenticate(authContext)
         self.channel.triggerUserOutboundEvent(outgoing, promise: nil)
 

--- a/Sources/PostgresNIO/New/Data/JSONB+PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/Data/JSONB+PostgresCodable.swift
@@ -1,0 +1,115 @@
+// MARK: - PostgresJSONB wrapper
+
+/// A wrapper that encodes any `Encodable` value as a Postgres JSONB bind parameter.
+///
+/// Use this to bind values that don't conform to any of the Postgres encoding protocols
+/// (``PostgresEncodable``, ``PostgresDynamicTypeEncodable``, etc.) directly as JSONB.
+///
+/// ```swift
+/// struct MyModel: Codable { var name: String; var tags: [String] }
+/// let model = MyModel(name: "example", tags: ["a", "b"])
+///
+/// // Via the wrapper type directly:
+/// try bindings.append(PostgresJSONB(model))
+///
+/// // Via string interpolation convenience:
+/// let query: PostgresQuery = "INSERT INTO t (data) VALUES (\(jsonb: model))"
+/// ```
+public struct PostgresJSONB<Value: Encodable>: PostgresEncodable, PostgresThrowingDynamicTypeEncodable, Sendable
+    where Value: Sendable
+{
+    public static var psqlType: PostgresDataType { .jsonb }
+    public static var psqlFormat: PostgresFormat { .binary }
+
+    @usableFromInline
+    let value: Value
+
+    /// Wrap an `Encodable & Sendable` value for binding as JSONB.
+    @inlinable
+    public init(_ value: Value) {
+        self.value = value
+    }
+
+    @inlinable
+    public func encode<JSONEncoder: PostgresJSONEncoder>(
+        into byteBuffer: inout ByteBuffer,
+        context: PostgresEncodingContext<JSONEncoder>
+    ) throws {
+        byteBuffer.writeInteger(JSONBVersionByte)
+        try context.jsonEncoder.encode(self.value, into: &byteBuffer)
+    }
+}
+
+// MARK: - PostgresJSONBArray wrapper
+
+/// A wrapper that encodes an array of `Encodable` values as a native Postgres `JSONB[]` array,
+/// where each element is individually JSONB-encoded.
+///
+/// This is distinct from ``PostgresJSONB`` wrapping an array, which would produce a single JSONB
+/// value containing a JSON array. `PostgresJSONBArray` produces a Postgres array whose element type
+/// is `jsonb` — i.e. each element is a separate JSONB datum within the array wire format.
+///
+/// ```swift
+/// struct Tag: Codable { var label: String }
+/// let tags: [Tag] = [Tag(label: "swift"), Tag(label: "postgres")]
+///
+/// // Produces a JSONB[] bind:
+/// try bindings.append(PostgresJSONBArray(tags))
+///
+/// // Via string interpolation convenience:
+/// let query: PostgresQuery = "INSERT INTO t (tags) VALUES (\(jsonb: tags))"
+/// ```
+public struct PostgresJSONBArray<Element: Encodable>: PostgresEncodable, PostgresThrowingDynamicTypeEncodable, Sendable
+    where Element: Sendable
+{
+    public static var psqlType: PostgresDataType { .jsonbArray }
+    public static var psqlFormat: PostgresFormat { .binary }
+
+    @usableFromInline
+    let elements: [Element]
+
+    /// Wrap an array of `Encodable & Sendable` values for binding as a Postgres `JSONB[]` array.
+    @inlinable
+    public init(_ elements: [Element]) {
+        self.elements = elements
+    }
+
+    @inlinable
+    public func encode<JSONEncoder: PostgresJSONEncoder>(
+        into byteBuffer: inout ByteBuffer,
+        context: PostgresEncodingContext<JSONEncoder>
+    ) throws {
+        // Postgres array binary format header
+        // dimensions: 0 if empty, 1 if not
+        byteBuffer.writeInteger(self.elements.isEmpty ? 0 : 1, as: UInt32.self)
+        // has-null flag (we never write NULLs; nullable elements would need Optional handling)
+        byteBuffer.writeInteger(0, as: Int32.self)
+        // element OID
+        byteBuffer.writeInteger(PostgresDataType.jsonb.rawValue)
+
+        guard !self.elements.isEmpty else {
+            return
+        }
+
+        // length of the single dimension
+        byteBuffer.writeInteger(numericCast(self.elements.count), as: Int32.self)
+        // lower bound (1-based, standard Postgres convention)
+        byteBuffer.writeInteger(1, as: Int32.self)
+
+        for element in self.elements {
+            // Reserve space for the element byte-length prefix
+            let lengthIndex = byteBuffer.writerIndex
+            byteBuffer.writeInteger(0, as: Int32.self)
+            let startIndex = byteBuffer.writerIndex
+
+            // Write the JSONB payload (version byte + JSON data)
+            byteBuffer.writeInteger(JSONBVersionByte)
+            try context.jsonEncoder.encode(element, into: &byteBuffer)
+
+            // Patch the length
+            byteBuffer.setInteger(
+                Int32(byteBuffer.writerIndex - startIndex),
+                at: lengthIndex
+            )
+        }
+    }

--- a/Sources/PostgresNIO/New/PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/PostgresCodable.swift
@@ -233,3 +233,4 @@ extension Optional: PostgresDecodable where Wrapped: PostgresDecodable, Wrapped.
         }
     }
 }
+

--- a/Sources/PostgresNIO/New/PostgresQuery.swift
+++ b/Sources/PostgresNIO/New/PostgresQuery.swift
@@ -92,6 +92,65 @@ extension PostgresQuery {
         public mutating func appendInterpolation(unescaped interpolated: String) {
             self.sql.append(contentsOf: interpolated)
         }
+
+        // MARK: JSONB convenience interpolation
+
+        /// Bind an arbitrary `Encodable & Sendable` value as a JSONB parameter.
+        ///
+        /// ```swift
+        /// let query: PostgresQuery = "INSERT INTO t (data) VALUES (\(jsonb: myModel))"
+        /// ```
+        @inlinable
+        public mutating func appendInterpolation<Value: Encodable & Sendable>(jsonb value: Value) throws {
+            try self.binds.append(PostgresJSONB(value), context: .default)
+            self.sql.append(contentsOf: "$\(self.binds.count)")
+        }
+
+        /// Bind an optional `Encodable & Sendable` value as a JSONB parameter, or NULL if `nil`.
+        @inlinable
+        public mutating func appendInterpolation<Value: Encodable & Sendable>(jsonb value: Optional<Value>) throws {
+            switch value {
+            case .none:
+                self.binds.appendNull()
+            case .some(let value):
+                try self.binds.append(PostgresJSONB(value), context: .default)
+            }
+            self.sql.append(contentsOf: "$\(self.binds.count)")
+        }
+
+        /// Bind an array of `Encodable & Sendable` values as a native Postgres `JSONB[]` array parameter.
+        ///
+        /// Each element is individually JSONB-encoded within the Postgres array wire format.
+        ///
+        /// ```swift
+        /// let query: PostgresQuery = "INSERT INTO t (tags) VALUES (\(jsonb: arrayOfModels))"
+        /// ```
+        @inlinable
+        public mutating func appendInterpolation<Element: Encodable & Sendable>(jsonb value: [Element]) throws {
+            try self.binds.append(PostgresJSONBArray(value), context: .default)
+            self.sql.append(contentsOf: "$\(self.binds.count)")
+        }
+
+        /// Bind an arbitrary `Encodable & Sendable` value as a JSONB parameter with a custom encoding context.
+        @inlinable
+        public mutating func appendInterpolation<Value: Encodable & Sendable, JSONEncoder: PostgresJSONEncoder>(
+            jsonb value: Value,
+            context: PostgresEncodingContext<JSONEncoder>
+        ) throws {
+            try self.binds.append(PostgresJSONB(value), context: context)
+            self.sql.append(contentsOf: "$\(self.binds.count)")
+        }
+
+        /// Bind an array of `Encodable & Sendable` values as a native Postgres `JSONB[]` array parameter
+        /// with a custom encoding context.
+        @inlinable
+        public mutating func appendInterpolation<Element: Encodable & Sendable, JSONEncoder: PostgresJSONEncoder>(
+            jsonb value: [Element],
+            context: PostgresEncodingContext<JSONEncoder>
+        ) throws {
+            try self.binds.append(PostgresJSONBArray(value), context: context)
+            self.sql.append(contentsOf: "$\(self.binds.count)")
+        }
     }
 }
 

--- a/Tests/IntegrationTests/AsyncTests.swift
+++ b/Tests/IntegrationTests/AsyncTests.swift
@@ -72,8 +72,8 @@ final class AsyncPostgresConnectionTests: XCTestCase {
             var counter = 0
 
             for try await element in rows.decode((Int, String, String, String, String?, Int, Date, Date, String, String).self) {
-                XCTAssertEqual(element.1, env("POSTGRES_DB") ?? "test_database")
-                XCTAssertEqual(element.2, env("POSTGRES_USER") ?? "test_username")
+                XCTAssertEqual(element.1, TestConfiguration.database)
+                XCTAssertEqual(element.2, TestConfiguration.username)
 
                 XCTAssertEqual(element.8, query.sql)
                 XCTAssertEqual(element.9, "active")
@@ -534,7 +534,7 @@ final class AsyncPostgresConnectionTests: XCTestCase {
             var counter = 0
 
             for try await element in results {
-                XCTAssertEqual(element.1, env("POSTGRES_DB") ?? "test_database")
+                XCTAssertEqual(element.1, TestConfiguration.database)
                 counter += 1
             }
 
@@ -543,7 +543,7 @@ final class AsyncPostgresConnectionTests: XCTestCase {
             // Second execution, which reuses the existing prepared statement
             results = try await connection.execute(preparedStatement, logger: .psqlTest)
             for try await element in results {
-                XCTAssertEqual(element.1, env("POSTGRES_DB") ?? "test_database")
+                XCTAssertEqual(element.1, TestConfiguration.database)
                 counter += 1
             }
         }

--- a/Tests/IntegrationTests/PSQLIntegrationTests.swift
+++ b/Tests/IntegrationTests/PSQLIntegrationTests.swift
@@ -21,14 +21,14 @@ final class IntegrationTests: XCTestCase {
     func testAuthenticationFailure() throws {
         // If the postgres server trusts every connection, it is really hard to create an
         // authentication failure.
-        try XCTSkipIf(env("POSTGRES_HOST_AUTH_METHOD") == "trust")
+        try XCTSkipIf(TestConfiguration.hostAuthMethod == "trust")
 
         let config = PostgresConnection.Configuration(
-            host: env("POSTGRES_HOSTNAME") ?? "localhost",
-            port: env("POSTGRES_PORT").flatMap(Int.init(_:)) ?? 5432,
-            username: env("POSTGRES_USER") ?? "test_username",
+            host: TestConfiguration.hostname,
+            port: TestConfiguration.port,
+            username: TestConfiguration.username,
             password: "wrong_password",
-            database: env("POSTGRES_DB") ?? "test_database",
+            database: TestConfiguration.database,
             tls: .disable
         )
 

--- a/Tests/IntegrationTests/PostgresClientTests.swift
+++ b/Tests/IntegrationTests/PostgresClientTests.swift
@@ -354,11 +354,11 @@ extension PostgresClient.Configuration {
         var tlsConfiguration = TLSConfiguration.makeClientConfiguration()
         tlsConfiguration.certificateVerification = .none
         var clientConfig = PostgresClient.Configuration(
-            host: env("POSTGRES_HOSTNAME") ?? "localhost",
-            port: env("POSTGRES_PORT").flatMap({ Int($0) }) ?? 5432,
-            username: env("POSTGRES_USER") ?? "test_username",
-            password: env("POSTGRES_PASSWORD") ?? "test_password",
-            database: env("POSTGRES_DB") ?? "test_database",
+            host: TestConfiguration.hostname,
+            port: TestConfiguration.port,
+            username: TestConfiguration.username,
+            password: TestConfiguration.password,
+            database: TestConfiguration.database,
             tls: .prefer(tlsConfiguration)
         )
         clientConfig.options.minimumConnections = 0

--- a/Tests/IntegrationTests/PostgresNIOTests.swift
+++ b/Tests/IntegrationTests/PostgresNIOTests.swift
@@ -36,7 +36,7 @@ final class PostgresNIOTests: XCTestCase {
     }
     
     func testConnectUDSAndClose() throws {
-        try XCTSkipUnless(env("POSTGRES_SOCKET") != nil)
+        try XCTSkipUnless(TestConfiguration.socket != nil)
         let conn = try PostgresConnection.testUDS(on: eventLoop).wait()
         try conn.close().wait()
     }
@@ -58,7 +58,7 @@ final class PostgresNIOTests: XCTestCase {
     }
 
     func testSimpleQueryVersionUsingUDS() throws {
-        try XCTSkipUnless(env("POSTGRES_SOCKET") != nil)
+        try XCTSkipUnless(TestConfiguration.socket != nil)
         var conn: PostgresConnection?
         XCTAssertNoThrow(conn = try PostgresConnection.testUDS(on: eventLoop).wait())
         defer { XCTAssertNoThrow( try conn?.close().wait() ) }
@@ -1504,7 +1504,7 @@ final class PostgresNIOTests: XCTestCase {
 let isLoggingConfigured: Bool = {
     LoggingSystem.bootstrap { label in
         var handler = StreamLogHandler.standardOutput(label: label)
-        handler.logLevel = env("LOG_LEVEL").flatMap { .init(rawValue: $0) } ?? .info
+        handler.logLevel = TestConfiguration.env("LOG_LEVEL").flatMap { .init(rawValue: $0) } ?? .info
         return handler
     }
     return true

--- a/Tests/IntegrationTests/TestConfiguration.swift
+++ b/Tests/IntegrationTests/TestConfiguration.swift
@@ -1,0 +1,71 @@
+#if canImport(Darwin)
+import Darwin.C
+#else
+import Glibc
+#endif
+
+/// Centralized test configuration for all Postgres integration tests.
+///
+/// All connection parameters are resolved once from environment variables,
+/// falling back to sensible defaults. Every test helper and factory should
+/// read from this struct instead of duplicating `env(…) ?? "…"` calls.
+enum TestConfiguration {
+    // MARK: - Environment helper
+
+    static func env(_ name: String) -> String? {
+        getenv(name).flatMap { String(cString: $0) }
+    }
+
+    // MARK: - Connection parameters
+
+    static var hostname: String {
+        env("POSTGRES_HOSTNAME") ?? "127.0.0.1"
+    }
+
+    static var port: Int {
+        env("POSTGRES_PORT").flatMap(Int.init(_:)) ?? 55432
+    }
+
+    static var username: String {
+        env("POSTGRES_USER") ?? "test_username"
+    }
+
+    static var password: String {
+        env("POSTGRES_PASSWORD") ?? "test_password"
+    }
+
+    static var database: String {
+        env("POSTGRES_DB") ?? "test_database"
+    }
+
+    static var socket: String? {
+        env("POSTGRES_SOCKET")
+    }
+
+    static var defaultUnixSocketPath: String {
+        socket ?? "/tmp/.s.PGSQL.\(port)"
+    }
+
+    // MARK: - Auth method
+
+    static var hostAuthMethod: String? {
+        env("POSTGRES_HOST_AUTH_METHOD")
+    }
+
+    // MARK: - Test gates
+
+    static var shouldRunLongRunningTests: Bool {
+        guard let rawValue = env("POSTGRES_LONG_RUNNING_TESTS") else { return false }
+        if let boolValue = Bool(rawValue) { return boolValue }
+        if let intValue = Int(rawValue) { return intValue == 1 }
+        return rawValue.lowercased() == "yes"
+    }
+
+    static var shouldRunPerformanceTests: Bool {
+        let defaultValue = !_isDebugAssertConfiguration()
+        guard let rawValue = env("POSTGRES_PERFORMANCE_TESTS") else { return defaultValue }
+        if let boolValue = Bool(rawValue) { return boolValue }
+        if let intValue = Int(rawValue) { return intValue == 1 }
+        return rawValue.lowercased() == "yes"
+    }
+}

--- a/Tests/IntegrationTests/Utilities.swift
+++ b/Tests/IntegrationTests/Utilities.swift
@@ -2,15 +2,10 @@ import XCTest
 import PostgresNIO
 import NIOCore
 import Logging
-#if canImport(Darwin)
-import Darwin.C
-#else
-import Glibc
-#endif
 
 extension PostgresConnection {
     static func address() throws -> SocketAddress {
-        try .makeAddressResolvingHost(env("POSTGRES_HOSTNAME") ?? "localhost", port: env("POSTGRES_PORT").flatMap(Int.init(_:)) ?? 5432)
+        try .makeAddressResolvingHost(TestConfiguration.hostname, port: TestConfiguration.port)
     }
     
     @available(*, deprecated, message: "Test deprecated functionality")
@@ -27,11 +22,11 @@ extension PostgresConnection {
     static func test(on eventLoop: any EventLoop, options: Configuration.Options? = nil) -> EventLoopFuture<PostgresConnection> {
         let logger = Logger(label: "postgres.connection.test")
         var config = PostgresConnection.Configuration(
-            host: env("POSTGRES_HOSTNAME") ?? "localhost",
-            port: env("POSTGRES_PORT").flatMap(Int.init(_:)) ?? 5432,
-            username: env("POSTGRES_USER") ?? "test_username",
-            password: env("POSTGRES_PASSWORD") ?? "test_password",
-            database: env("POSTGRES_DB") ?? "test_database",
+            host: TestConfiguration.hostname,
+            port: TestConfiguration.port,
+            username: TestConfiguration.username,
+            password: TestConfiguration.password,
+            database: TestConfiguration.database,
             tls: .disable
         )
         if let options {
@@ -44,10 +39,10 @@ extension PostgresConnection {
     static func testUDS(on eventLoop: any EventLoop) -> EventLoopFuture<PostgresConnection> {
         let logger = Logger(label: "postgres.connection.test")
         let config = PostgresConnection.Configuration(
-            unixSocketPath: env("POSTGRES_SOCKET") ?? "/tmp/.s.PGSQL.\(env("POSTGRES_PORT").flatMap(Int.init(_:)) ?? 5432)",
-            username: env("POSTGRES_USER") ?? "test_username",
-            password: env("POSTGRES_PASSWORD") ?? "test_password",
-            database: env("POSTGRES_DB") ?? "test_database"
+            unixSocketPath: TestConfiguration.defaultUnixSocketPath,
+            username: TestConfiguration.username,
+            password: TestConfiguration.password,
+            database: TestConfiguration.database
         )
         
         return PostgresConnection.connect(on: eventLoop, configuration: config, id: 0, logger: logger)
@@ -57,9 +52,9 @@ extension PostgresConnection {
         let logger = Logger(label: "postgres.connection.test")
         let config = PostgresConnection.Configuration(
             establishedChannel: channel,
-            username: env("POSTGRES_USER") ?? "test_username",
-            password: env("POSTGRES_PASSWORD") ?? "test_password",
-            database: env("POSTGRES_DB") ?? "test_database"
+            username: TestConfiguration.username,
+            password: TestConfiguration.password,
+            database: TestConfiguration.database
         )
         
         return PostgresConnection.connect(on: eventLoop, configuration: config, id: 0, logger: logger)
@@ -72,29 +67,13 @@ extension Logger {
     }
 }
 
-func env(_ name: String) -> String? {
-    getenv(name).flatMap { String(cString: $0) }
-}
-
 extension XCTestCase {
     
     public static var shouldRunLongRunningTests: Bool {
-        // The env var must be set and have the value `"true"`, `"1"`, or `"yes"` (case-insensitive).
-        // For the sake of sheer annoying pedantry, values like `"2"` are treated as false.
-        guard let rawValue = env("POSTGRES_LONG_RUNNING_TESTS") else { return false }
-        if let boolValue = Bool(rawValue) { return boolValue }
-        if let intValue = Int(rawValue) { return intValue == 1 }
-        return rawValue.lowercased() == "yes"
+        TestConfiguration.shouldRunLongRunningTests
     }
     
     public static var shouldRunPerformanceTests: Bool {
-        // Same semantics as above. Any present non-truthy value will explicitly disable performance
-        // tests even if they would've overwise run in the current configuration.
-        let defaultValue = !_isDebugAssertConfiguration() // default to not running in debug builds
-
-        guard let rawValue = env("POSTGRES_PERFORMANCE_TESTS") else { return defaultValue }
-        if let boolValue = Bool(rawValue) { return boolValue }
-        if let intValue = Int(rawValue) { return intValue == 1 }
-        return rawValue.lowercased() == "yes"
+        TestConfiguration.shouldRunPerformanceTests
     }
 }

--- a/Tests/PostgresNIOTests/New/Data/JSONB+PSQLCodableTests.swift
+++ b/Tests/PostgresNIOTests/New/Data/JSONB+PSQLCodableTests.swift
@@ -1,0 +1,487 @@
+import Atomics
+import Foundation
+import NIOCore
+import Testing
+@testable import PostgresNIO
+
+@Suite struct PostgresJSONB_PSQLCodableTests {
+
+    // MARK: - Fixtures
+
+    /// A simple model that is Codable but NOT PostgresCodable.
+    /// This is the exact use case the wrappers exist to serve.
+    struct SampleModel: Codable, Equatable, Sendable {
+        var name: String
+        var count: Int
+    }
+
+    struct Nested: Codable, Equatable, Sendable {
+        struct Inner: Codable, Equatable, Sendable {
+            var value: Double
+        }
+        var label: String
+        var inner: Inner
+    }
+
+    struct Empty: Codable, Equatable, Sendable {}
+
+    // MARK: - PostgresJSONB: type metadata
+
+    @Test func jsonbStaticType() {
+        #expect(PostgresJSONB<SampleModel>.psqlType == .jsonb)
+        #expect(PostgresJSONB<SampleModel>.psqlFormat == .binary)
+    }
+
+    @Test func jsonbInstanceTypeMatchesStatic() {
+        let wrapper = PostgresJSONB(SampleModel(name: "test", count: 1))
+        #expect(wrapper.psqlType == PostgresJSONB<SampleModel>.psqlType)
+        #expect(wrapper.psqlFormat == PostgresJSONB<SampleModel>.psqlFormat)
+    }
+
+    // MARK: - PostgresJSONB: encode
+
+    @Test func jsonbEncodesVersionByteAndValidJSON() throws {
+        let model = SampleModel(name: "hello", count: 42)
+        let wrapper = PostgresJSONB(model)
+
+        var buffer = ByteBuffer()
+        try wrapper.encode(into: &buffer, context: .default)
+
+        // first byte: JSONB version byte 0x01
+        #expect(buffer.getInteger(at: buffer.readerIndex, as: UInt8.self) == 0x01)
+        buffer.moveReaderIndex(forwardBy: 1)
+
+        // remaining bytes: valid JSON that round-trips
+        let decoded = try JSONDecoder().decode(SampleModel.self, from: Data(buffer.readableBytesView))
+        #expect(decoded == model)
+    }
+
+    @Test func jsonbEncodesNestedStruct() throws {
+        let model = Nested(label: "outer", inner: .init(value: 3.14))
+        var buffer = ByteBuffer()
+        try PostgresJSONB(model).encode(into: &buffer, context: .default)
+
+        #expect(buffer.readInteger(as: UInt8.self) == 0x01)
+        let decoded = try JSONDecoder().decode(Nested.self, from: Data(buffer.readableBytesView))
+        #expect(decoded == model)
+    }
+
+    @Test func jsonbEncodesEmptyStruct() throws {
+        var buffer = ByteBuffer()
+        try PostgresJSONB(Empty()).encode(into: &buffer, context: .default)
+
+        #expect(buffer.readInteger(as: UInt8.self) == 0x01)
+        #expect(throws: Never.self) {
+            try JSONDecoder().decode(Empty.self, from: Data(buffer.readableBytesView))
+        }
+    }
+
+    @Test func jsonbEncodesPrimitiveString() throws {
+        var buffer = ByteBuffer()
+        try PostgresJSONB("just a string").encode(into: &buffer, context: .default)
+
+        #expect(buffer.readInteger(as: UInt8.self) == 0x01)
+        let decoded = try JSONDecoder().decode(String.self, from: Data(buffer.readableBytesView))
+        #expect(decoded == "just a string")
+    }
+
+    @Test func jsonbEncodesDictionary() throws {
+        let dict: [String: Int] = ["a": 1, "b": 2]
+        var buffer = ByteBuffer()
+        try PostgresJSONB(dict).encode(into: &buffer, context: .default)
+
+        #expect(buffer.readInteger(as: UInt8.self) == 0x01)
+        let decoded = try JSONDecoder().decode([String: Int].self, from: Data(buffer.readableBytesView))
+        #expect(decoded == dict)
+    }
+
+    /// Wrapping an array in PostgresJSONB should produce a single JSONB value
+    /// containing a JSON array — NOT a Postgres JSONB[] array type.
+    @Test func jsonbWrappingArrayProducesSingleJSONBNotArray() throws {
+        let arr = [1, 2, 3]
+        let wrapper = PostgresJSONB(arr)
+        #expect(wrapper.psqlType == .jsonb)
+
+        var buffer = ByteBuffer()
+        try wrapper.encode(into: &buffer, context: .default)
+        #expect(buffer.readInteger(as: UInt8.self) == 0x01)
+        let decoded = try JSONDecoder().decode([Int].self, from: Data(buffer.readableBytesView))
+        #expect(decoded == arr)
+    }
+
+    // MARK: - PostgresJSONB: through PostgresBindings
+
+    @Test func jsonbAppendToBindings() throws {
+        let model = SampleModel(name: "bound", count: 7)
+        var bindings = PostgresBindings()
+        try bindings.append(PostgresJSONB(model), context: .default)
+
+        #expect(bindings.count == 1)
+        #expect(bindings.metadata[0].dataType == .jsonb)
+        #expect(bindings.metadata[0].format == .binary)
+
+        // encodeRaw writes: [Int32 length][payload]
+        var bytes = bindings.bytes
+        let length = bytes.readInteger(as: Int32.self)!
+        #expect(length > 0)
+        #expect(bytes.readInteger(as: UInt8.self) == 0x01)
+        let jsonSlice = bytes.readSlice(length: Int(length) - 1)!
+        let decoded = try JSONDecoder().decode(SampleModel.self, from: Data(jsonSlice.readableBytesView))
+        #expect(decoded == model)
+    }
+
+    /// Verify PostgresBindings byte layout matches what PostgresQueryTests expects:
+    /// the exact bytes produced by encodeRaw for a known model.
+    @Test func jsonbBindingsExactBytes() throws {
+        let model = SampleModel(name: "x", count: 0)
+        var bindings = PostgresBindings()
+        try bindings.append(PostgresJSONB(model), context: .default)
+
+        // Build the expected buffer manually
+        let jsonPayload = try JSONEncoder().encode(model)
+        var expected = ByteBuffer()
+        expected.writeInteger(Int32(1 + jsonPayload.count)) // version byte + json
+        expected.writeInteger(UInt8(0x01))
+        expected.writeData(jsonPayload)
+
+        #expect(bindings.bytes == expected)
+    }
+
+    // MARK: - PostgresJSONBArray: type metadata
+
+    @Test func jsonbArrayStaticType() {
+        #expect(PostgresJSONBArray<SampleModel>.psqlType == .jsonbArray)
+        #expect(PostgresJSONBArray<SampleModel>.psqlFormat == .binary)
+    }
+
+    @Test func jsonbArrayInstanceTypeMatchesStatic() {
+        let wrapper = PostgresJSONBArray([SampleModel(name: "a", count: 1)])
+        #expect(wrapper.psqlType == PostgresJSONBArray<SampleModel>.psqlType)
+        #expect(wrapper.psqlFormat == PostgresJSONBArray<SampleModel>.psqlFormat)
+    }
+
+    // MARK: - PostgresJSONBArray: empty
+
+    @Test func jsonbArrayEncodesEmpty() throws {
+        let wrapper = PostgresJSONBArray<SampleModel>([])
+        var buffer = ByteBuffer()
+        try wrapper.encode(into: &buffer, context: .default)
+
+        // Header: dimensions=0, has-null=0, element-oid=jsonb
+        #expect(buffer.readInteger(as: UInt32.self) == 0) // dimensions
+        #expect(buffer.readInteger(as: Int32.self) == 0)   // has-null
+        #expect(buffer.readInteger(as: UInt32.self) == PostgresDataType.jsonb.rawValue)
+        #expect(buffer.readableBytes == 0) // nothing after header
+    }
+
+    // MARK: - PostgresJSONBArray: wire format
+
+    /// Parse the full Postgres binary array wire format byte-by-byte, matching
+    /// the structure tested in Array+PSQLCodableTests for native arrays.
+    @Test func jsonbArrayWireFormatTwoElements() throws {
+        let models = [
+            SampleModel(name: "first", count: 1),
+            SampleModel(name: "second", count: 2),
+        ]
+        let wrapper = PostgresJSONBArray(models)
+
+        var buffer = ByteBuffer()
+        try wrapper.encode(into: &buffer, context: .default)
+
+        // --- Array header ---
+        #expect(buffer.readInteger(as: UInt32.self) == 1) // dimensions
+        #expect(buffer.readInteger(as: Int32.self) == 0)   // has-null flag
+        #expect(buffer.readInteger(as: UInt32.self) == PostgresDataType.jsonb.rawValue) // element OID
+
+        // --- Dimension descriptor ---
+        #expect(buffer.readInteger(as: Int32.self) == 2)   // array length
+        #expect(buffer.readInteger(as: Int32.self) == 1)   // lower bound (1-based)
+
+        // --- Elements ---
+        for (index, expected) in models.enumerated() {
+            let elementLength = try #require(buffer.readInteger(as: Int32.self))
+            #expect(elementLength > 1, "Element \(index) must be at least version byte + JSON")
+
+            var elementSlice = try #require(buffer.readSlice(length: Int(elementLength)))
+            #expect(elementSlice.readInteger(as: UInt8.self) == 0x01, "JSONB version byte at index \(index)")
+
+            let decoded = try JSONDecoder().decode(SampleModel.self, from: Data(elementSlice.readableBytesView))
+            #expect(decoded == expected, "Decoded element at index \(index) must match")
+        }
+
+        #expect(buffer.readableBytes == 0, "Buffer must be fully consumed")
+    }
+
+    @Test func jsonbArraySingleElement() throws {
+        let wrapper = PostgresJSONBArray([SampleModel(name: "solo", count: 99)])
+        var buffer = ByteBuffer()
+        try wrapper.encode(into: &buffer, context: .default)
+
+        // Skip header: dims(4) + hasNull(4) + oid(4) + length(4) + lowerBound(4) = 20
+        buffer.moveReaderIndex(forwardBy: 20)
+
+        let elementLength = try #require(buffer.readInteger(as: Int32.self))
+        #expect(buffer.readInteger(as: UInt8.self) == 0x01)
+
+        let jsonSlice = try #require(buffer.readSlice(length: Int(elementLength) - 1))
+        let decoded = try JSONDecoder().decode(SampleModel.self, from: Data(jsonSlice.readableBytesView))
+        #expect(decoded.name == "solo")
+        #expect(decoded.count == 99)
+    }
+
+    @Test func jsonbArrayManyElements() throws {
+        let models = (0..<100).map { SampleModel(name: "item-\($0)", count: $0) }
+        let wrapper = PostgresJSONBArray(models)
+
+        var buffer = ByteBuffer()
+        try wrapper.encode(into: &buffer, context: .default)
+
+        // Verify header
+        #expect(buffer.readInteger(as: UInt32.self) == 1)
+        buffer.moveReaderIndex(forwardBy: 4) // has-null
+        buffer.moveReaderIndex(forwardBy: 4) // element OID
+        #expect(buffer.readInteger(as: Int32.self) == 100)
+        buffer.moveReaderIndex(forwardBy: 4) // lower bound
+
+        // Decode all 100 elements
+        for i in 0..<100 {
+            let len = try #require(buffer.readInteger(as: Int32.self))
+            var slice = try #require(buffer.readSlice(length: Int(len)))
+            #expect(slice.readInteger(as: UInt8.self) == 0x01)
+            let decoded = try JSONDecoder().decode(SampleModel.self, from: Data(slice.readableBytesView))
+            #expect(decoded == SampleModel(name: "item-\(i)", count: i))
+        }
+
+        #expect(buffer.readableBytes == 0)
+    }
+
+    // MARK: - PostgresJSONBArray: through PostgresBindings
+
+    @Test func jsonbArrayAppendToBindings() throws {
+        let models = [SampleModel(name: "a", count: 1), SampleModel(name: "b", count: 2)]
+        var bindings = PostgresBindings()
+        try bindings.append(PostgresJSONBArray(models), context: .default)
+
+        #expect(bindings.count == 1)
+        #expect(bindings.metadata[0].dataType == .jsonbArray)
+        #expect(bindings.metadata[0].format == .binary)
+
+        var bytes = bindings.bytes
+        let totalLength = try #require(bytes.readInteger(as: Int32.self))
+        #expect(totalLength > 0)
+        #expect(Int(totalLength) == bytes.readableBytes)
+    }
+
+    // MARK: - OID consistency
+
+    @Test func jsonbArrayElementOIDInWireFormatMatchesJsonbType() throws {
+        let wrapper = PostgresJSONBArray([SampleModel(name: "oid", count: 0)])
+        var buffer = ByteBuffer()
+        try wrapper.encode(into: &buffer, context: .default)
+
+        // Skip dimensions (4) and has-null (4)
+        buffer.moveReaderIndex(forwardBy: 8)
+        let writtenOID = try #require(buffer.readInteger(as: UInt32.self))
+        #expect(writtenOID == PostgresDataType.jsonb.rawValue)
+    }
+
+    @Test func jsonbArrayTypeOIDIsArrayOfJsonb() {
+        #expect(PostgresDataType.jsonb.arrayType == .jsonbArray)
+        #expect(PostgresJSONBArray<SampleModel>.psqlType == PostgresDataType.jsonb.arrayType)
+    }
+
+    @Test func jsonbArrayElementTypeRoundTrips() {
+        #expect(PostgresDataType.jsonbArray.elementType == .jsonb)
+    }
+
+    // MARK: - String interpolation: \(jsonb:)
+
+    @Test func interpolationJSONBSingleValue() throws {
+        let model = SampleModel(name: "interp", count: 5)
+        let query: PostgresQuery = try "INSERT INTO t (data) VALUES (\(jsonb: model))"
+
+        #expect(query.sql == "INSERT INTO t (data) VALUES ($1)")
+        #expect(query.binds.count == 1)
+        #expect(query.binds.metadata[0].dataType == .jsonb)
+        #expect(query.binds.metadata[0].format == .binary)
+    }
+
+    @Test func interpolationJSONBArray() throws {
+        let models = [SampleModel(name: "x", count: 1)]
+        let query: PostgresQuery = try "INSERT INTO t (tags) VALUES (\(jsonb: models))"
+
+        #expect(query.sql == "INSERT INTO t (tags) VALUES ($1)")
+        #expect(query.binds.count == 1)
+        #expect(query.binds.metadata[0].dataType == .jsonbArray)
+    }
+
+    @Test func interpolationJSONBNil() throws {
+        let value: SampleModel? = nil
+        let query: PostgresQuery = try "SELECT * FROM t WHERE data = \(jsonb: value)"
+
+        #expect(query.sql == "SELECT * FROM t WHERE data = $1")
+        #expect(query.binds.count == 1)
+        #expect(query.binds.metadata[0].dataType == .null)
+    }
+
+    @Test func interpolationJSONBSome() throws {
+        let value: SampleModel? = SampleModel(name: "opt", count: 3)
+        let query: PostgresQuery = try "SELECT * FROM t WHERE data = \(jsonb: value)"
+
+        #expect(query.sql == "SELECT * FROM t WHERE data = $1")
+        #expect(query.binds.count == 1)
+        #expect(query.binds.metadata[0].dataType == .jsonb)
+    }
+
+    @Test func interpolationMixedNativeAndJSONBBinds() throws {
+        let model = SampleModel(name: "mixed", count: 10)
+        let id: Int64 = 42
+        let query: PostgresQuery = try "UPDATE t SET data = \(jsonb: model) WHERE id = \(id)"
+
+        #expect(query.sql == "UPDATE t SET data = $1 WHERE id = $2")
+        #expect(query.binds.count == 2)
+        #expect(query.binds.metadata[0].dataType == .jsonb)
+        #expect(query.binds.metadata[1].dataType == .int8)
+    }
+
+    @Test func interpolationMultipleJSONBBinds() throws {
+        let a = SampleModel(name: "a", count: 1)
+        let b = SampleModel(name: "b", count: 2)
+        let query: PostgresQuery = try "INSERT INTO t (a, b) VALUES (\(jsonb: a), \(jsonb: b))"
+
+        #expect(query.sql == "INSERT INTO t (a, b) VALUES ($1, $2)")
+        #expect(query.binds.count == 2)
+        #expect(query.binds.metadata[0].dataType == .jsonb)
+        #expect(query.binds.metadata[1].dataType == .jsonb)
+    }
+
+    /// Verifies exact byte layout produced by interpolation, following the same
+    /// pattern used in PostgresQueryTests.testStringInterpolationWithCustomJSONEncoder.
+    @Test func interpolationJSONBExactBindingsBytes() throws {
+        let model = SampleModel(name: "x", count: 0)
+        let query: PostgresQuery = try "SELECT \(jsonb: model)"
+
+        let jsonPayload = try JSONEncoder().encode(model)
+
+        var expected = ByteBuffer()
+        // encodeRaw: [Int32 length][UInt8 version][json bytes]
+        expected.writeInteger(Int32(1 + jsonPayload.count))
+        expected.writeInteger(UInt8(0x01))
+        expected.writeData(jsonPayload)
+
+        #expect(query.binds.bytes == expected)
+    }
+
+    // MARK: - Custom encoding context
+
+    @Test func jsonbRespectsCustomEncoder() throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let context = PostgresEncodingContext(jsonEncoder: encoder)
+
+        let model = SampleModel(name: "ctx", count: 0)
+        var buffer = ByteBuffer()
+        try PostgresJSONB(model).encode(into: &buffer, context: context)
+
+        buffer.moveReaderIndex(forwardBy: 1) // skip version byte
+        let jsonString = buffer.readString(length: buffer.readableBytes)!
+        // With sortedKeys, "count" comes before "name"
+        #expect(jsonString.hasPrefix("{\"count\""))
+    }
+
+    @Test func jsonbArrayRespectsCustomEncoder() throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let context = PostgresEncodingContext(jsonEncoder: encoder)
+
+        let wrapper = PostgresJSONBArray([SampleModel(name: "ctx", count: 0)])
+        var buffer = ByteBuffer()
+        try wrapper.encode(into: &buffer, context: context)
+
+        // Skip array header (20 bytes) + element length (4 bytes) + version byte (1 byte)
+        buffer.moveReaderIndex(forwardBy: 25)
+        let jsonString = buffer.readString(length: buffer.readableBytes)!
+        #expect(jsonString.hasPrefix("{\"count\""))
+    }
+
+    @Test func customEncoderIsCalled() throws {
+        final class TestEncoder: PostgresJSONEncoder {
+            let encodeHits = ManagedAtomic(0)
+
+            func encode<T>(_ value: T, into buffer: inout ByteBuffer) throws where T: Encodable {
+                self.encodeHits.wrappingIncrement(ordering: .relaxed)
+            }
+
+            func encode<T>(_ value: T) throws -> Data where T: Encodable {
+                preconditionFailure()
+            }
+        }
+
+        let encoder = TestEncoder()
+        var buffer = ByteBuffer()
+        try PostgresJSONB(SampleModel(name: "test", count: 0)).encode(
+            into: &buffer, context: .init(jsonEncoder: encoder)
+        )
+        #expect(encoder.encodeHits.load(ordering: .relaxed) == 1)
+    }
+
+    @Test func customEncoderIsCalledPerArrayElement() throws {
+        final class TestEncoder: PostgresJSONEncoder {
+            let encodeHits = ManagedAtomic(0)
+
+            func encode<T>(_ value: T, into buffer: inout ByteBuffer) throws where T: Encodable {
+                self.encodeHits.wrappingIncrement(ordering: .relaxed)
+            }
+
+            func encode<T>(_ value: T) throws -> Data where T: Encodable {
+                preconditionFailure()
+            }
+        }
+
+        let encoder = TestEncoder()
+        let models = [
+            SampleModel(name: "a", count: 1),
+            SampleModel(name: "b", count: 2),
+            SampleModel(name: "c", count: 3),
+        ]
+        var buffer = ByteBuffer()
+        try PostgresJSONBArray(models).encode(
+            into: &buffer, context: .init(jsonEncoder: encoder)
+        )
+        #expect(encoder.encodeHits.load(ordering: .relaxed) == 3)
+    }
+
+    // MARK: - String interpolation with custom context
+
+    @Test func interpolationJSONBWithCustomContext() throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let context = PostgresEncodingContext(jsonEncoder: encoder)
+
+        let model = SampleModel(name: "ctx", count: 0)
+        let query: PostgresQuery = try "SELECT \(jsonb: model, context: context)"
+
+        #expect(query.binds.count == 1)
+        #expect(query.binds.metadata[0].dataType == .jsonb)
+
+        // Verify sortedKeys is applied by checking the raw bytes
+        var bytes = query.binds.bytes
+        let length = try #require(bytes.readInteger(as: Int32.self))
+        #expect(bytes.readInteger(as: UInt8.self) == 0x01)
+        let jsonSlice = try #require(bytes.readSlice(length: Int(length) - 1))
+        let jsonString = String(buffer: jsonSlice)
+        #expect(jsonString.hasPrefix("{\"count\""))
+    }
+
+    @Test func interpolationJSONBArrayWithCustomContext() throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let context = PostgresEncodingContext(jsonEncoder: encoder)
+
+        let models = [SampleModel(name: "ctx", count: 0)]
+        let query: PostgresQuery = try "SELECT \(jsonb: models, context: context)"
+
+        #expect(query.binds.count == 1)
+        #expect(query.binds.metadata[0].dataType == .jsonbArray)
+    }
+}


### PR DESCRIPTION
bump: update dependencies to swift 6_3
feat: first class support for arrays as jsonb
fix: centralize testing suite configuration

update to support static linux builds
fluent bridges the append api to translate arrays into valid jsonb.
this change extends first class postgres types with jsonb<value> and jsonbarray<elem> types.
configuration is all over the place if it diverges from the original it becomes a mess fast.
    
- bump swift toolchain to 6.3
- bump dependencies to available atm
- add types and append api on jsonb interpolation
- add tests to assert functionality.
- created a file Testing configuration in Tests/IntegrationTests/TestConfiguration.swift
- replaced any dynamic variable related to configuration with its centralized counterpart
