### PR TITLE
Add missing @available() attributes

### DIFF
--- a/Sources/ConnectionPoolModule/ConnectionPool.swift
+++ b/Sources/ConnectionPoolModule/ConnectionPool.swift
@@ -616,6 +616,7 @@ extension DiscardingTaskGroup: TaskGroupProtocol {
     }
 }
 
+@available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
 extension TaskGroup<Void>: TaskGroupProtocol {
     @inlinable
     mutating func addTask_(operation: @isolated(any) @escaping @Sendable () async -> Void) {

--- a/Sources/ConnectionPoolModule/ConnectionRequest.swift
+++ b/Sources/ConnectionPoolModule/ConnectionRequest.swift
@@ -1,4 +1,5 @@
 
+@available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
 public struct ConnectionRequest<Connection: PooledConnection>: ConnectionRequestProtocol {
     public typealias ID = Int
 


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->

Add additional `@available` attributes where needed. This doesn't affect Postgres-nio directly as it has platform requirements already, but when the connection pool code is copied to other projects (eg valkey-swift) these have to be added back in, and sometimes this gets forgotten. 

<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
