### PR TITLE
Add graceful shutdown

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -75,6 +75,7 @@ let package = Package(
                 .target(name: "PostgresNIO"),
                 .product(name: "NIOEmbedded", package: "swift-nio"),
                 .product(name: "NIOTestUtils", package: "swift-nio"),
+                .product(name: "ServiceLifecycleTestKit", package: "swift-service-lifecycle"),
             ],
             swiftSettings: swiftSettings
         ),

--- a/Sources/ConnectionPoolModule/ConnectionPool.swift
+++ b/Sources/ConnectionPoolModule/ConnectionPool.swift
@@ -299,6 +299,13 @@ public final class ConnectionPool<
         }
     }
 
+    public func triggerGracefulShutdown() {
+        let actions = self.stateBox.withLockedValue { state in
+            state.stateMachine.triggerGracefulShutdown()
+        }
+        self.runStateMachineActions(actions)
+    }
+
     public func triggerForceShutdown() {
         let actions = self.stateBox.withLockedValue { state in
             state.stateMachine.triggerForceShutdown()

--- a/Sources/ConnectionPoolModule/PoolStateMachine+ConnectionGroup.swift
+++ b/Sources/ConnectionPoolModule/PoolStateMachine+ConnectionGroup.swift
@@ -829,11 +829,22 @@ extension PoolStateMachine {
 
         mutating func triggerGracefulShutdown(_ cleanup: inout ConnectionAction.Shutdown) {
             for index in self.connections.indices {
-                if self.connections[index].isIdle, let closeAction = closeConnectionIfIdle(at: index) {
-                    cleanup.connections.append(closeAction.connection)
-                    cleanup.timersToCancel.append(contentsOf: closeAction.timersToCancel)
+                switch self.connections[index].state {
+                case .idle, .backingOff:
+                    switch closeConnection(at: index, deleteConnection: false) {
+                    case .close(let closeAction):
+                        cleanup.connections.append(closeAction.connection)
+                        cleanup.timersToCancel.append(contentsOf: closeAction.timersToCancel)
+                    case .cancelTimers(let timers):
+                        cleanup.timersToCancel.append(contentsOf: timers)
+                    case .doNothing:
+                        break
+                    }
+                default:
+                    break
                 }
             }
+            self.connections = self.connections.filter { !$0.isClosed }
         }
 
         mutating func triggerForceShutdown(_ cleanup: inout ConnectionAction.Shutdown) {

--- a/Sources/ConnectionPoolModule/PoolStateMachine+ConnectionGroup.swift
+++ b/Sources/ConnectionPoolModule/PoolStateMachine+ConnectionGroup.swift
@@ -827,6 +827,15 @@ extension PoolStateMachine {
 
         // MARK: Shutdown
 
+        mutating func triggerGracefulShutdown(_ cleanup: inout ConnectionAction.Shutdown) {
+            for index in self.connections.indices {
+                if self.connections[index].isIdle, let closeAction = closeConnectionIfIdle(at: index) {
+                    cleanup.connections.append(closeAction.connection)
+                    cleanup.timersToCancel.append(contentsOf: closeAction.timersToCancel)
+                }
+            }
+        }
+
         mutating func triggerForceShutdown(_ cleanup: inout ConnectionAction.Shutdown) {
             for index in self.connections.indices {
                 switch closeConnection(at: index, deleteConnection: false) {

--- a/Sources/ConnectionPoolModule/PoolStateMachine.swift
+++ b/Sources/ConnectionPoolModule/PoolStateMachine.swift
@@ -748,30 +748,36 @@ struct PoolStateMachine<
     @usableFromInline
     mutating func triggerForceShutdown() -> Action {
         switch self.poolState {
-        case .running, .connectionCreationFailing, .circuitBreakOpen:
-            self.poolState = .shuttingDown
-            var shutdown = ConnectionAction.Shutdown()
-            self.connections.triggerForceShutdown(&shutdown)
-
-            if self.connections.isEmpty, shutdown.connections.isEmpty {
-                self.poolState = .shutDown
-                return .init(
-                    request: .failRequests(self.requestQueue.removeAll(), ConnectionPoolError.poolShutdown),
-                    connection: .cancelEventStreamAndFinalCleanup(shutdown.timersToCancel)
-                )
-            }
-
-            return .init(
-                request: .failRequests(self.requestQueue.removeAll(), ConnectionPoolError.poolShutdown),
-                connection: .initiateShutdown(shutdown)
-            )
+        case .shutDown:
+            return .init(request: .none, connection: .none)
+        
+        case .shuttingDown where self.gracefulShutdownTriggered:
+            // Graceful shutdown is in progress, escalate to force shutdown.
+            self.gracefulShutdownTriggered = false
 
         case .shuttingDown:
             return .none()
 
-        case .shutDown:
-            return .init(request: .none, connection: .none)
+        case .running, .connectionCreationFailing, .circuitBreakOpen:
+            break
         }
+
+        self.poolState = .shuttingDown
+        var shutdown = ConnectionAction.Shutdown()
+        self.connections.triggerForceShutdown(&shutdown)
+
+        if self.connections.isEmpty, shutdown.connections.isEmpty {
+            self.poolState = .shutDown
+            return .init(
+                request: .failRequests(self.requestQueue.removeAll(), ConnectionPoolError.poolShutdown),
+                connection: .cancelEventStreamAndFinalCleanup(shutdown.timersToCancel)
+            )
+        }
+
+        return .init(
+            request: .failRequests(self.requestQueue.removeAll(), ConnectionPoolError.poolShutdown),
+            connection: .initiateShutdown(shutdown)
+        )
     }
 
     @inlinable

--- a/Sources/ConnectionPoolModule/PoolStateMachine.swift
+++ b/Sources/ConnectionPoolModule/PoolStateMachine.swift
@@ -698,8 +698,30 @@ struct PoolStateMachine<
         var requests: [Request]
     }
 
+    @usableFromInline
     mutating func triggerGracefulShutdown() -> Action {
-        fatalError("Unimplemented")
+        switch self.poolState {
+        case .running, .connectionCreationFailing, .circuitBreakOpen:
+            self.poolState = .shuttingDown
+            var shutdown = ConnectionAction.Shutdown()
+            self.connections.triggerGracefulShutdown(&shutdown)
+
+            if self.connections.isEmpty, shutdown.connections.isEmpty {
+                self.poolState = .shutDown
+                return .init(
+                    request: .failRequests(self.requestQueue.removeAll(), ConnectionPoolError.poolShutdown),
+                    connection: .cancelEventStreamAndFinalCleanup(shutdown.timersToCancel)
+                )
+            }
+
+            return .init(
+                request: .failRequests(self.requestQueue.removeAll(), ConnectionPoolError.poolShutdown),
+                connection: .initiateShutdown(shutdown)
+            )
+
+        case .shuttingDown, .shutDown:
+            return .none()
+        }
     }
 
     @usableFromInline

--- a/Sources/ConnectionPoolModule/PoolStateMachine.swift
+++ b/Sources/ConnectionPoolModule/PoolStateMachine.swift
@@ -495,6 +495,15 @@ struct PoolStateMachine<
             if self.connections.isEmpty {
                 self.poolState = .shutDown
                 connectionAction = .cancelEventStreamAndFinalCleanup(timerToCancel.map {[$0]} ?? [])
+
+                if !requestQueue.isEmpty {
+                    // If there's no connections left but there are requests left in the queue, fail them.
+                    // We don't want to open other connections while draining
+                    return .init(
+                        request: .failRequests(self.requestQueue.removeAll(), .poolShutdown),
+                        connection: connectionAction
+                    )
+                }
             } else {
                 connectionAction = .cancelTimers(timerToCancel.map {[$0]} ?? [])
             }
@@ -677,6 +686,14 @@ struct PoolStateMachine<
             if self.connections.isEmpty {
                 self.poolState = .shutDown
                 connectionAction = .cancelEventStreamAndFinalCleanup(.init(closedConnectionAction.timersToCancel))
+
+                if !requestQueue.isEmpty {
+                    // If all connections were closed (errored) but there are requests left in the queue, fail them
+                    return .init(
+                        request: .failRequests(requestQueue.removeAll(), .poolShutdown),
+                        connection: connectionAction
+                    )
+                }
             } else {
                 connectionAction = .cancelTimers(closedConnectionAction.timersToCancel)
             }
@@ -703,6 +720,8 @@ struct PoolStateMachine<
         switch self.poolState {
         case .running, .connectionCreationFailing, .circuitBreakOpen:
             self.poolState = .shuttingDown
+            self.gracefulShutdownTriggered = true
+
             var shutdown = ConnectionAction.Shutdown()
             self.connections.triggerGracefulShutdown(&shutdown)
 
@@ -714,10 +733,12 @@ struct PoolStateMachine<
                 )
             }
 
-            return .init(
-                request: .failRequests(self.requestQueue.removeAll(), ConnectionPoolError.poolShutdown),
-                connection: .initiateShutdown(shutdown)
-            )
+            // Don't shut down connections if queue still has requests. We have to drain it
+            if shutdown.connections.isEmpty && shutdown.timersToCancel.isEmpty {
+                return .none()
+            }
+
+            return .init(request: .none, connection: .initiateShutdown(shutdown))
 
         case .shuttingDown, .shutDown:
             return .none()
@@ -763,6 +784,13 @@ struct PoolStateMachine<
         if !requests.isEmpty {
             let leaseResult = self.connections.leaseConnection(at: index, streams: UInt16(requests.count))
             let connectionsRequired: Int
+
+            if gracefulShutdownTriggered {
+                return .init(
+                    request: .leaseConnection(requests, leaseResult.connection),
+                    connection: .cancelTimers(.init(leaseResult.timersToCancel))
+                )
+            }
             // if request count is less than available streams and leased streams plus incoming connections then only 
             // ensure we have minimum connections otherwise grow the number of connections
             if (self.requestQueue.count + 1) <= self.connections.stats.availableStreams + self.connections.stats.leasedStreams + self.connections.stats.connecting {

--- a/Sources/ConnectionPoolModule/PoolStateMachine.swift
+++ b/Sources/ConnectionPoolModule/PoolStateMachine.swift
@@ -725,25 +725,28 @@ struct PoolStateMachine<
             var shutdown = ConnectionAction.Shutdown()
             self.connections.triggerGracefulShutdown(&shutdown)
 
-            // `triggerGracefulShutdown` moves closed connections out of `self.connections` into
-            // `shutdown.connections`, so both being empty means there's no more connections,
-            // so queued requests can never be served and we should fail them immediately.
+            let requestAction: RequestAction
+            let connectionAction: ConnectionAction
             if self.connections.isEmpty, shutdown.connections.isEmpty {
+                // `triggerGracefulShutdown` moves closed connections out of `self.connections` into
+                // `shutdown.connections`, so both being empty means there's no more connections,
+                // so queued requests can never be served and we should fail them immediately.
                 self.poolState = .shutDown
-                return .init(
-                    request: .failRequests(self.requestQueue.removeAll(), ConnectionPoolError.poolShutdown),
-                    connection: .cancelEventStreamAndFinalCleanup(shutdown.timersToCancel)
-                )
+                requestAction = .failRequests(self.requestQueue.removeAll(), ConnectionPoolError.poolShutdown)
+                connectionAction = .cancelEventStreamAndFinalCleanup(shutdown.timersToCancel)
+            } else if shutdown.connections.isEmpty, shutdown.timersToCancel.isEmpty {
+                // Nothing to close or cancel right now: all remaining connections are leased or
+                // still starting. Shutdown proceeds as they are released, established, or fail,
+                // which also drains the request queue.
+                requestAction = .none
+                connectionAction = .none
+            } else {
+                // Close the idle connections and cancel their timers.
+                requestAction = .none
+                connectionAction = .initiateShutdown(shutdown)
             }
 
-            // Nothing to close or cancel right now: all remaining connections are leased or
-            // still starting. Shutdown proceeds as they are released, established, or fail,
-            // which also drains the request queue.
-            if shutdown.connections.isEmpty, shutdown.timersToCancel.isEmpty {
-                return .none()
-            }
-
-            return .init(request: .none, connection: .initiateShutdown(shutdown))
+            return .init(request: requestAction, connection: connectionAction)
 
         case .shuttingDown, .shutDown:
             return .none()

--- a/Sources/ConnectionPoolModule/PoolStateMachine.swift
+++ b/Sources/ConnectionPoolModule/PoolStateMachine.swift
@@ -725,6 +725,9 @@ struct PoolStateMachine<
             var shutdown = ConnectionAction.Shutdown()
             self.connections.triggerGracefulShutdown(&shutdown)
 
+            // `triggerGracefulShutdown` moves closed connections out of `self.connections` into
+            // `shutdown.connections`, so both being empty means there's no more connections,
+            // so queued requests can never be served and we should fail them immediately.
             if self.connections.isEmpty, shutdown.connections.isEmpty {
                 self.poolState = .shutDown
                 return .init(
@@ -733,8 +736,10 @@ struct PoolStateMachine<
                 )
             }
 
-            // Don't shut down connections if the queue still has requests. We have to drain it.
-            if shutdown.connections.isEmpty && shutdown.timersToCancel.isEmpty {
+            // Nothing to close or cancel right now: all remaining connections are leased or
+            // still starting. Shutdown proceeds as they are released, established, or fail,
+            // which also drains the request queue.
+            if shutdown.connections.isEmpty, shutdown.timersToCancel.isEmpty {
                 return .none()
             }
 

--- a/Sources/ConnectionPoolModule/PoolStateMachine.swift
+++ b/Sources/ConnectionPoolModule/PoolStateMachine.swift
@@ -497,8 +497,8 @@ struct PoolStateMachine<
                 connectionAction = .cancelEventStreamAndFinalCleanup(timerToCancel.map {[$0]} ?? [])
 
                 if !requestQueue.isEmpty {
-                    // If there's no connections left but there are requests left in the queue, fail them.
-                    // We don't want to open other connections while draining
+                    // If there are no connections left but requests remain in the queue, fail them.
+                    // We don't want to open new connections while draining.
                     return .init(
                         request: .failRequests(self.requestQueue.removeAll(), .poolShutdown),
                         connection: connectionAction
@@ -688,7 +688,7 @@ struct PoolStateMachine<
                 connectionAction = .cancelEventStreamAndFinalCleanup(.init(closedConnectionAction.timersToCancel))
 
                 if !requestQueue.isEmpty {
-                    // If all connections were closed (errored) but there are requests left in the queue, fail them
+                    // If all connections were closed (errored) but there are requests left in the queue, fail them.
                     return .init(
                         request: .failRequests(requestQueue.removeAll(), .poolShutdown),
                         connection: connectionAction
@@ -733,7 +733,7 @@ struct PoolStateMachine<
                 )
             }
 
-            // Don't shut down connections if queue still has requests. We have to drain it
+            // Don't shut down connections if the queue still has requests. We have to drain it.
             if shutdown.connections.isEmpty && shutdown.timersToCancel.isEmpty {
                 return .none()
             }

--- a/Sources/ConnectionPoolTestUtils/MockConnection.swift
+++ b/Sources/ConnectionPoolTestUtils/MockConnection.swift
@@ -19,6 +19,20 @@ public final class MockConnection: PooledConnection, Sendable {
         self.id = id
     }
 
+    public var isRunning: Bool {
+        self.lock.withLockedValue { state in
+            if case .running = state { return true }
+            return false
+        }
+    }
+
+    public var isClosing: Bool {
+        self.lock.withLockedValue { state in
+            if case .closing = state { return true }
+            return false
+        }
+    }
+
     public var signalToClose: Void {
         get async throws {
             try await withCheckedThrowingContinuation { continuation in

--- a/Sources/PostgresNIO/Pool/PostgresClient.swift
+++ b/Sources/PostgresNIO/Pool/PostgresClient.swift
@@ -469,8 +469,8 @@ public final class PostgresClient: Sendable, ServiceLifecycle.Service {
     /// has been cancelled the client is not able to process any new queries or prepared statements.
     ///
     /// Graceful shutdown is different to cancellation. If the client is gracefully shut down, in-flight requests
-    /// are completed and the requests queue is drained, but no new connection is opened. If the last connection
-    /// fails while there's still queued requests, those requests fail.
+    /// are completed and the requests queue is drained, but no new connections are opened. If the last connection
+    /// fails while there are still queued requests, those requests fail.
     ///
     /// @Snippet(path: "postgres-nio/Snippets/PostgresClient", slice: "run")
     ///

--- a/Sources/PostgresNIO/Pool/PostgresClient.swift
+++ b/Sources/PostgresNIO/Pool/PostgresClient.swift
@@ -468,6 +468,10 @@ public final class PostgresClient: Sendable, ServiceLifecycle.Service {
     /// Cancelling the task that executes the ``run()`` method is equivalent to closing the client. Once the task
     /// has been cancelled the client is not able to process any new queries or prepared statements.
     ///
+    /// Graceful shutdown is different to cancellation. If the client is gracefully shut down, in-flight requests
+    /// are completed and the requests queue is drained, but no new connection is opened. If the last connection
+    /// fails while there's still queued requests, those requests fail.
+    ///
     /// @Snippet(path: "postgres-nio/Snippets/PostgresClient", slice: "run")
     ///
     /// > Note:
@@ -477,8 +481,10 @@ public final class PostgresClient: Sendable, ServiceLifecycle.Service {
         let atomicOp = self.runningAtomic.compareExchange(expected: false, desired: true, ordering: .relaxed)
         precondition(!atomicOp.original, "PostgresClient.run() should just be called once!")
 
-        await cancelWhenGracefulShutdown {
+        await withGracefulShutdownHandler {
             await self.pool.run()
+        } onGracefulShutdown: {
+            self.pool.triggerGracefulShutdown()
         }
     }
 

--- a/Tests/ConnectionPoolModuleTests/ConnectionPoolTests.swift
+++ b/Tests/ConnectionPoolModuleTests/ConnectionPoolTests.swift
@@ -1031,6 +1031,54 @@ import Testing
     }
 
     @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
+    @Test func testGracefulShutdownWithLeasedConnection() async throws {
+        let clock = MockClock()
+        let factory = MockConnectionFactory<MockClock>()
+        let keepAliveDuration = Duration.seconds(30)
+        let keepAlive = MockPingPongBehavior(keepAliveFrequency: keepAliveDuration, connectionType: MockConnection.self)
+
+        var mutableConfig = ConnectionPoolConfiguration()
+        mutableConfig.minimumConnectionCount = 1
+        mutableConfig.maximumConnectionSoftLimit = 4
+        mutableConfig.maximumConnectionHardLimit = 4
+        mutableConfig.idleTimeout = .seconds(10)
+        let config = mutableConfig
+
+        let pool = ConnectionPool(
+            configuration: config,
+            idGenerator: ConnectionIDGenerator(),
+            requestType: ConnectionRequest<MockConnection>.self,
+            keepAliveBehavior: keepAlive,
+            observabilityDelegate: NoOpConnectionPoolMetrics(connectionIDType: MockConnection.ID.self),
+            clock: clock
+        ) {
+            try await factory.makeConnection(id: $0, for: $1)
+        }
+
+        try await withThrowingTaskGroup(of: Void.self) { taskGroup in
+            taskGroup.addTask {
+                await pool.run()
+            }
+            await factory.nextConnectAttempt { connectionID in
+                return 1
+            }
+            let lease = try await pool.leaseConnection()
+            let leasedConnection = lease.connection
+
+            pool.triggerGracefulShutdown()
+            #expect(leasedConnection.isRunning)
+
+            pool.releaseConnection(leasedConnection)
+            #expect(leasedConnection.isClosing)
+
+            for connection in factory.runningConnections {
+                try await connection.signalToClose
+                connection.closeIfClosing()
+            }
+        }
+    }
+
+    @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
     @Test func testCircuitBreaker() async throws {
         struct ConnectionFailedError: Error {}
         let clock = MockClock()

--- a/Tests/ConnectionPoolModuleTests/ConnectionPoolTests.swift
+++ b/Tests/ConnectionPoolModuleTests/ConnectionPoolTests.swift
@@ -1079,6 +1079,56 @@ import Testing
     }
 
     @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
+    @Test func testForceShutdownOverridesRunningGracefulShutdown() async throws {
+        let clock = MockClock()
+        let factory = MockConnectionFactory<MockClock>()
+        let keepAliveDuration = Duration.seconds(30)
+        let keepAlive = MockPingPongBehavior(keepAliveFrequency: keepAliveDuration, connectionType: MockConnection.self)
+
+        var mutableConfig = ConnectionPoolConfiguration()
+        mutableConfig.minimumConnectionCount = 1
+        mutableConfig.maximumConnectionSoftLimit = 4
+        mutableConfig.maximumConnectionHardLimit = 4
+        mutableConfig.idleTimeout = .seconds(10)
+        let config = mutableConfig
+
+        let pool = ConnectionPool(
+            configuration: config,
+            idGenerator: ConnectionIDGenerator(),
+            requestType: ConnectionRequest<MockConnection>.self,
+            keepAliveBehavior: keepAlive,
+            observabilityDelegate: NoOpConnectionPoolMetrics(connectionIDType: MockConnection.ID.self),
+            clock: clock
+        ) {
+            try await factory.makeConnection(id: $0, for: $1)
+        }
+
+        try await withThrowingTaskGroup(of: Void.self) { taskGroup in
+            taskGroup.addTask {
+                await pool.run()
+            }
+            await factory.nextConnectAttempt { connectionID in
+                return 1
+            }
+            let lease = try await pool.leaseConnection()
+            let leasedConnection = lease.connection
+
+            pool.triggerGracefulShutdown()
+            #expect(leasedConnection.isRunning)
+
+            pool.triggerForceShutdown()
+            #expect(leasedConnection.isClosing)
+
+            pool.releaseConnection(leasedConnection)
+
+            for connection in factory.runningConnections {
+                try await connection.signalToClose
+                connection.closeIfClosing()
+            }
+        }
+    }
+
+    @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
     @Test func testCircuitBreaker() async throws {
         struct ConnectionFailedError: Error {}
         let clock = MockClock()

--- a/Tests/ConnectionPoolModuleTests/PoolStateMachineTests.swift
+++ b/Tests/ConnectionPoolModuleTests/PoolStateMachineTests.swift
@@ -904,15 +904,120 @@ typealias TestPoolStateMachine = PoolStateMachine<
             clock: MockClock()
         )
 
-        // Refill creates one connection request; fail it so the connection enters `.backingOff`.
         let requests = stateMachine.refillConnections()
         #expect(requests.count == 1)
         _ = stateMachine.connectionEstablishFailed(ConnectionFailed(), for: requests[0])
 
-        // Graceful shutdown must reap the backing-off connection. With no other connections and an
-        // empty queue, the pool is now empty and must shut down immediately - otherwise the backing-off
-        // connection lingers forever and `run()` never returns.
         _ = stateMachine.triggerGracefulShutdown()
+        #expect(stateMachine.isShutdown)
+    }
+
+    @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
+    @Test func testTriggerGracefulShutdownFailsQueuedRequestsWhenReapingLastBackingOffConnection() {
+        struct ConnectionFailed: Error {}
+        var configuration = PoolConfiguration()
+        configuration.minimumConnectionCount = 0
+        configuration.maximumConnectionSoftLimit = 1
+        configuration.maximumConnectionHardLimit = 1
+        configuration.keepAliveDuration = nil
+        configuration.idleTimeoutDuration = .seconds(3)
+
+        var stateMachine = TestPoolStateMachine(
+            configuration: configuration,
+            generator: .init(),
+            timerCancellationTokenType: MockTimerCancellationToken.self,
+            clock: MockClock()
+        )
+
+        #expect(stateMachine.refillConnections().isEmpty)
+
+        let mockRequest1 = MockRequest(connectionType: MockConnection.self)
+        guard case .makeConnection(let connectionRequest, _) = stateMachine.leaseConnection(mockRequest1).connection else {
+            Issue.record()
+            return
+        }
+
+        let failedAction = stateMachine.connectionEstablishFailed(ConnectionFailed(), for: connectionRequest)
+        guard case .scheduleTimers(let timers) = failedAction.connection, let backoffTimer = Array(timers).first else {
+            Issue.record()
+            return
+        }
+        let backoffTimerToken = MockTimerCancellationToken(backoffTimer)
+        #expect(stateMachine.timerScheduled(backoffTimer, cancelContinuation: backoffTimerToken) == .none)
+
+        let shutdownAction = stateMachine.triggerGracefulShutdown()
+        #expect(shutdownAction.request == .failRequests(.init(element: mockRequest1), .poolShutdown))
+        #expect(shutdownAction.connection == .cancelEventStreamAndFinalCleanup([backoffTimerToken]))
+        #expect(stateMachine.isShutdown)
+    }
+
+    @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
+    @Test func testTriggerGracefulShutdownWithStartingConnectionDrainsQueueOnceEstablished() {
+        var configuration = PoolConfiguration()
+        configuration.minimumConnectionCount = 0
+        configuration.maximumConnectionSoftLimit = 1
+        configuration.maximumConnectionHardLimit = 1
+        configuration.keepAliveDuration = nil
+        configuration.idleTimeoutDuration = .seconds(3)
+
+        var stateMachine = TestPoolStateMachine(
+            configuration: configuration,
+            generator: .init(),
+            timerCancellationTokenType: MockTimerCancellationToken.self,
+            clock: MockClock()
+        )
+
+        #expect(stateMachine.refillConnections().isEmpty)
+
+        let mockRequest1 = MockRequest(connectionType: MockConnection.self)
+        guard case .makeConnection = stateMachine.leaseConnection(mockRequest1).connection else { Issue.record(); return }
+
+        #expect(stateMachine.triggerGracefulShutdown() == .none())
+        #expect(!stateMachine.isShutdown)
+
+        let establishedAction = stateMachine.connectionEstablished(MockConnection(id: 0), maxStreams: 1)
+        guard case .leaseConnection(let requests, let connection) = establishedAction.request else {
+            Issue.record("Expected the queued request to be leased, got \(establishedAction.request)")
+            return
+        }
+        #expect(Array(requests) == [mockRequest1])
+
+        #expect(stateMachine.releaseConnection(connection, streams: 1).connection == .closeConnection(connection, []))
+        #expect(stateMachine.connectionClosed(connection).connection == .cancelEventStreamAndFinalCleanup([]))
+        #expect(stateMachine.isShutdown)
+    }
+
+    @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
+    @Test func testTriggerForceShutdownWithStartingConnection() {
+        var configuration = PoolConfiguration()
+        configuration.minimumConnectionCount = 0
+        configuration.maximumConnectionSoftLimit = 1
+        configuration.maximumConnectionHardLimit = 1
+        configuration.keepAliveDuration = nil
+        configuration.idleTimeoutDuration = .seconds(3)
+
+        var stateMachine = TestPoolStateMachine(
+            configuration: configuration,
+            generator: .init(),
+            timerCancellationTokenType: MockTimerCancellationToken.self,
+            clock: MockClock()
+        )
+
+        #expect(stateMachine.refillConnections().isEmpty)
+
+        let mockRequest1 = MockRequest(connectionType: MockConnection.self)
+        guard case .makeConnection = stateMachine.leaseConnection(mockRequest1).connection else { Issue.record(); return }
+
+        let shutdownAction = stateMachine.triggerForceShutdown()
+        #expect(shutdownAction.request == .failRequests(.init(element: mockRequest1), .poolShutdown))
+        #expect(!stateMachine.isShutdown)
+
+        let connection = MockConnection(id: 0)
+        let establishedAction = stateMachine.connectionEstablished(connection, maxStreams: 1)
+        #expect(establishedAction.request == .none)
+        #expect(establishedAction.connection == .closeConnection(connection, []))
+
+        #expect(stateMachine.connectionClosed(connection).connection == .cancelEventStreamAndFinalCleanup([]))
         #expect(stateMachine.isShutdown)
     }
 

--- a/Tests/ConnectionPoolModuleTests/PoolStateMachineTests.swift
+++ b/Tests/ConnectionPoolModuleTests/PoolStateMachineTests.swift
@@ -616,9 +616,7 @@ typealias TestPoolStateMachine = PoolStateMachine<
         #expect(leaseAction.connection == .cancelTimers([MockTimerCancellationToken(connection1KeepAliveTimer)]))
 
         let shutdownAction = stateMachine.triggerGracefulShutdown()
-        let shutdown = TestPoolStateMachine.ConnectionAction.Shutdown()
-        #expect(shutdown.connections.isEmpty)
-        #expect(shutdownAction.connection == .initiateShutdown(shutdown))
+        #expect(shutdownAction.connection == .none)
         #expect(!stateMachine.isShutdown)
         
         let closeConnection = stateMachine.releaseConnection(connection, streams: 1)
@@ -652,7 +650,7 @@ typealias TestPoolStateMachine = PoolStateMachine<
         #expect(requests.count == 1)
 
         let shutdownAction = stateMachine.triggerGracefulShutdown()
-        #expect(shutdownAction.connection ==  .initiateShutdown(.init()))
+        #expect(shutdownAction.connection == .none)
 
         // make connection 1
         let connection = MockConnection(id: 0)
@@ -707,7 +705,7 @@ typealias TestPoolStateMachine = PoolStateMachine<
         #expect(release1.connection == .none)
 
         let shutdownAction = stateMachine.triggerGracefulShutdown()
-        #expect(shutdownAction.connection == .initiateShutdown(.init()))
+        #expect(shutdownAction.connection == .none)
         #expect(!stateMachine.isShutdown)
 
         let release2 = stateMachine.releaseConnection(connection, streams: 1)
@@ -715,6 +713,166 @@ typealias TestPoolStateMachine = PoolStateMachine<
 
         let closedAction = stateMachine.connectionClosed(connection)
         #expect(closedAction.connection == .cancelEventStreamAndFinalCleanup([]))
+        #expect(stateMachine.isShutdown)
+    }
+
+    @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
+    @Test func testTriggerGracefulShutdownDrainsQueueWithoutCreatingConnections() {
+        var configuration = PoolConfiguration()
+        configuration.minimumConnectionCount = 0
+        configuration.maximumConnectionSoftLimit = 1
+        configuration.maximumConnectionHardLimit = 1
+        configuration.keepAliveDuration = nil
+        configuration.idleTimeoutDuration = .seconds(3)
+
+        var stateMachine = TestPoolStateMachine(
+            configuration: configuration,
+            generator: .init(),
+            timerCancellationTokenType: MockTimerCancellationToken.self,
+            clock: MockClock()
+        )
+
+        #expect(stateMachine.refillConnections().isEmpty)
+
+        let mockRequest1 = MockRequest(connectionType: MockConnection.self)
+        guard case .makeConnection = stateMachine.leaseConnection(mockRequest1).connection else { Issue.record(); return }
+        let connection = MockConnection(id: 0)
+        #expect(stateMachine.connectionEstablished(connection, maxStreams: 1).request == .leaseConnection(.init(element: mockRequest1), connection))
+
+        let mockRequest2 = MockRequest(connectionType: MockConnection.self)
+        #expect(stateMachine.leaseConnection(mockRequest2) == .none())
+        let mockRequest3 = MockRequest(connectionType: MockConnection.self)
+        #expect(stateMachine.leaseConnection(mockRequest3) == .none())
+
+        #expect(stateMachine.triggerGracefulShutdown() == .none())
+        #expect(!stateMachine.isShutdown)
+
+        let drain1 = stateMachine.releaseConnection(connection, streams: 1)
+        #expect(drain1.request == .leaseConnection(.init(element: mockRequest2), connection))
+        if case .makeConnection = drain1.connection { Issue.record("graceful shutdown must not create connections") }
+
+        let drain2 = stateMachine.releaseConnection(connection, streams: 1)
+        #expect(drain2.request == .leaseConnection(.init(element: mockRequest3), connection))
+        if case .makeConnection = drain2.connection { Issue.record("graceful shutdown must not create connections") }
+
+        #expect(stateMachine.releaseConnection(connection, streams: 1).connection == .closeConnection(connection, []))
+        #expect(stateMachine.connectionClosed(connection).connection == .cancelEventStreamAndFinalCleanup([]))
+        #expect(stateMachine.isShutdown)
+    }
+
+    @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
+    @Test func testTriggerGracefulShutdownKeepsDrainingQueueAfterOneConnectionCloses() {
+        var configuration = PoolConfiguration()
+        configuration.minimumConnectionCount = 0
+        configuration.maximumConnectionSoftLimit = 2
+        configuration.maximumConnectionHardLimit = 2
+        configuration.keepAliveDuration = nil
+        configuration.idleTimeoutDuration = .seconds(3)
+
+        var stateMachine = TestPoolStateMachine(
+            configuration: configuration,
+            generator: .init(),
+            timerCancellationTokenType: MockTimerCancellationToken.self,
+            clock: MockClock()
+        )
+
+        #expect(stateMachine.refillConnections().isEmpty)
+
+        let mockRequest1 = MockRequest(connectionType: MockConnection.self)
+        guard case .makeConnection = stateMachine.leaseConnection(mockRequest1).connection else { Issue.record(); return }
+        let connection1 = MockConnection(id: 0)
+        #expect(stateMachine.connectionEstablished(connection1, maxStreams: 1).request == .leaseConnection(.init(element: mockRequest1), connection1))
+
+        let mockRequest2 = MockRequest(connectionType: MockConnection.self)
+        guard case .makeConnection = stateMachine.leaseConnection(mockRequest2).connection else { Issue.record(); return }
+        let connection2 = MockConnection(id: 1)
+        #expect(stateMachine.connectionEstablished(connection2, maxStreams: 1).request == .leaseConnection(.init(element: mockRequest2), connection2))
+
+        let mockRequest3 = MockRequest(connectionType: MockConnection.self)
+        #expect(stateMachine.leaseConnection(mockRequest3) == .none())
+        let mockRequest4 = MockRequest(connectionType: MockConnection.self)
+        #expect(stateMachine.leaseConnection(mockRequest4) == .none())
+
+        #expect(stateMachine.triggerGracefulShutdown() == .none())
+        #expect(!stateMachine.isShutdown)
+
+        let closedAction = stateMachine.connectionClosed(connection1)
+        #expect(closedAction.request == .none)
+        #expect(!stateMachine.isShutdown)
+
+        #expect(stateMachine.releaseConnection(connection2, streams: 1).request == .leaseConnection(.init(element: mockRequest3), connection2))
+        #expect(stateMachine.releaseConnection(connection2, streams: 1).request == .leaseConnection(.init(element: mockRequest4), connection2))
+
+        #expect(stateMachine.releaseConnection(connection2, streams: 1).connection == .closeConnection(connection2, []))
+        #expect(stateMachine.connectionClosed(connection2).connection == .cancelEventStreamAndFinalCleanup([]))
+        #expect(stateMachine.isShutdown)
+    }
+
+    @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
+    @Test func testTriggerGracefulShutdownFailsQueueWhenLastConnectionCreationFails() {
+        struct ConnectionFailed: Error {}
+        var configuration = PoolConfiguration()
+        configuration.minimumConnectionCount = 0
+        configuration.maximumConnectionSoftLimit = 2
+        configuration.maximumConnectionHardLimit = 2
+        configuration.keepAliveDuration = nil
+        configuration.idleTimeoutDuration = .seconds(3)
+
+        var stateMachine = TestPoolStateMachine(
+            configuration: configuration,
+            generator: .init(),
+            timerCancellationTokenType: MockTimerCancellationToken.self,
+            clock: MockClock()
+        )
+
+        #expect(stateMachine.refillConnections().isEmpty)
+
+        let mockRequest1 = MockRequest(connectionType: MockConnection.self)
+        guard case .makeConnection(let connectionRequest, _) = stateMachine.leaseConnection(mockRequest1).connection else {
+            Issue.record()
+            return
+        }
+
+        #expect(stateMachine.triggerGracefulShutdown() == .none())
+        #expect(!stateMachine.isShutdown)
+
+        let failedAction = stateMachine.connectionEstablishFailed(ConnectionFailed(), for: connectionRequest)
+        switch failedAction.request {
+        case .failRequests(let requests, let error):
+            #expect(Array(requests) == [mockRequest1])
+            #expect(error == .poolShutdown)
+        default:
+            Issue.record("Expected the queued request to be failed, got \(failedAction.request)")
+        }
+        #expect(stateMachine.isShutdown)
+    }
+
+    @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
+    @Test func testTriggerGracefulShutdownReapsBackingOffConnection() {
+        struct ConnectionFailed: Error {}
+        var configuration = PoolConfiguration()
+        configuration.minimumConnectionCount = 1
+        configuration.maximumConnectionSoftLimit = 2
+        configuration.maximumConnectionHardLimit = 2
+        configuration.keepAliveDuration = nil
+        configuration.idleTimeoutDuration = .seconds(3)
+
+        var stateMachine = TestPoolStateMachine(
+            configuration: configuration,
+            generator: .init(),
+            timerCancellationTokenType: MockTimerCancellationToken.self,
+            clock: MockClock()
+        )
+
+        // Refill creates one connection request; fail it so the connection enters `.backingOff`.
+        let requests = stateMachine.refillConnections()
+        #expect(requests.count == 1)
+        _ = stateMachine.connectionEstablishFailed(ConnectionFailed(), for: requests[0])
+
+        // Graceful shutdown must reap the backing-off connection. With no other connections and an
+        // empty queue, the pool is now empty and must shut down immediately - otherwise the backing-off
+        // connection lingers forever and `run()` never returns.
+        _ = stateMachine.triggerGracefulShutdown()
         #expect(stateMachine.isShutdown)
     }
 

--- a/Tests/ConnectionPoolModuleTests/PoolStateMachineTests.swift
+++ b/Tests/ConnectionPoolModuleTests/PoolStateMachineTests.swift
@@ -630,6 +630,46 @@ typealias TestPoolStateMachine = PoolStateMachine<
     }
 
     @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
+    @Test func testTriggerForceShutdownOverridesRunningGracefulShutdown() {
+        var configuration = PoolConfiguration()
+        configuration.minimumConnectionCount = 1
+        configuration.maximumConnectionSoftLimit = 2
+        configuration.maximumConnectionHardLimit = 2
+        configuration.keepAliveDuration = .seconds(2)
+        configuration.idleTimeoutDuration = .seconds(4)
+
+        var stateMachine = TestPoolStateMachine(
+            configuration: configuration,
+            generator: .init(),
+            timerCancellationTokenType: MockTimerCancellationToken.self,
+            clock: MockClock()
+        )
+
+        #expect(stateMachine.refillConnections().count == 1)
+
+        let connection = MockConnection(id: 0)
+        let createdAction = stateMachine.connectionEstablished(connection, maxStreams: 1)
+        let keepAliveTimer = TestPoolStateMachine.Timer(.init(timerID: 0, connectionID: 0, usecase: .keepAlive), duration: .seconds(2))
+        #expect(createdAction.connection == .scheduleTimers([keepAliveTimer]))
+        #expect(stateMachine.timerScheduled(keepAliveTimer, cancelContinuation: MockTimerCancellationToken(keepAliveTimer)) == .none)
+
+        let request = MockRequest(connectionType: MockConnection.self)
+        #expect(stateMachine.leaseConnection(request).request == .leaseConnection(.init(element: request), connection))
+
+        #expect(stateMachine.triggerGracefulShutdown().connection == .none)
+        #expect(!stateMachine.isShutdown)
+
+        var shutdown = TestPoolStateMachine.ConnectionAction.Shutdown()
+        shutdown.connections = [connection]
+        #expect(stateMachine.triggerForceShutdown().connection == .initiateShutdown(shutdown))
+
+        let closedAction = stateMachine.connectionClosed(connection)
+        #expect(closedAction.connection == .cancelEventStreamAndFinalCleanup([]))
+        #expect(stateMachine.isShutdown)
+        #expect(stateMachine.connections.stats.active == 0)
+    }
+
+    @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
     @Test func testTriggerGracefulShutdownWithInProgessRequest() {
         var configuration = PoolConfiguration()
         configuration.minimumConnectionCount = 1

--- a/Tests/ConnectionPoolModuleTests/PoolStateMachineTests.swift
+++ b/Tests/ConnectionPoolModuleTests/PoolStateMachineTests.swift
@@ -542,6 +542,183 @@ typealias TestPoolStateMachine = PoolStateMachine<
     }
 
     @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
+    @Test func testTriggerGracefulShutdownWithIdleConnections() {
+        var configuration = PoolConfiguration()
+        configuration.minimumConnectionCount = 1
+        configuration.maximumConnectionSoftLimit = 2
+        configuration.maximumConnectionHardLimit = 2
+        configuration.keepAliveDuration = .seconds(2)
+        configuration.idleTimeoutDuration = .seconds(4)
+
+        var stateMachine = TestPoolStateMachine(
+            configuration: configuration,
+            generator: .init(),
+            timerCancellationTokenType: MockTimerCancellationToken.self,
+            clock: MockClock()
+        )
+
+        // refill pool
+        let requests = stateMachine.refillConnections()
+        #expect(requests.count == 1)
+
+        // make connection 1
+        let connection = MockConnection(id: 0)
+        let createdAction = stateMachine.connectionEstablished(connection, maxStreams: 1)
+        #expect(createdAction.request == .none)
+        let connection1KeepAliveTimer = TestPoolStateMachine.Timer(.init(timerID: 0, connectionID: 0, usecase: .keepAlive), duration: .seconds(2))
+        #expect(createdAction.connection == .scheduleTimers([connection1KeepAliveTimer]))
+        #expect(stateMachine.timerScheduled(connection1KeepAliveTimer, cancelContinuation: MockTimerCancellationToken(connection1KeepAliveTimer)) == .none)
+
+        let shutdownAction = stateMachine.triggerGracefulShutdown()
+        var shutdown = TestPoolStateMachine.ConnectionAction.Shutdown()
+        shutdown.connections = [connection]
+        shutdown.timersToCancel = [MockTimerCancellationToken(connection1KeepAliveTimer)]
+        #expect(shutdownAction.connection == .initiateShutdown(shutdown))
+
+        let closedAction = stateMachine.connectionClosed(connection)
+        #expect(closedAction.connection == .cancelEventStreamAndFinalCleanup([]))
+
+        #expect(stateMachine.isShutdown)
+        #expect(stateMachine.connections.stats.active == 0)
+    }
+
+    @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
+    @Test func testTriggerGracefulShutdownWithLeasedConnections() {
+        var configuration = PoolConfiguration()
+        configuration.minimumConnectionCount = 1
+        configuration.maximumConnectionSoftLimit = 2
+        configuration.maximumConnectionHardLimit = 2
+        configuration.keepAliveDuration = .seconds(2)
+        configuration.idleTimeoutDuration = .seconds(4)
+
+        var stateMachine = TestPoolStateMachine(
+            configuration: configuration,
+            generator: .init(),
+            timerCancellationTokenType: MockTimerCancellationToken.self,
+            clock: MockClock()
+        )
+
+        // refill pool
+        let requests = stateMachine.refillConnections()
+        #expect(requests.count == 1)
+
+        // make connection 1
+        let connection = MockConnection(id: 0)
+        let createdAction = stateMachine.connectionEstablished(connection, maxStreams: 1)
+        #expect(createdAction.request == .none)
+        let connection1KeepAliveTimer = TestPoolStateMachine.Timer(.init(timerID: 0, connectionID: 0, usecase: .keepAlive), duration: .seconds(2))
+        #expect(createdAction.connection == .scheduleTimers([connection1KeepAliveTimer]))
+        #expect(stateMachine.timerScheduled(connection1KeepAliveTimer, cancelContinuation: MockTimerCancellationToken(connection1KeepAliveTimer)) == .none)
+
+        let request = MockRequest(connectionType: MockConnection.self)
+        let leaseAction = stateMachine.leaseConnection(request)
+        #expect(leaseAction.request == .leaseConnection(.init(element: request), connection))
+        #expect(leaseAction.connection == .cancelTimers([MockTimerCancellationToken(connection1KeepAliveTimer)]))
+
+        let shutdownAction = stateMachine.triggerGracefulShutdown()
+        let shutdown = TestPoolStateMachine.ConnectionAction.Shutdown()
+        #expect(shutdown.connections.isEmpty)
+        #expect(shutdownAction.connection == .initiateShutdown(shutdown))
+        #expect(!stateMachine.isShutdown)
+        
+        let closeConnection = stateMachine.releaseConnection(connection, streams: 1)
+        #expect(closeConnection.connection == .closeConnection(connection, []))
+
+        let closedAction = stateMachine.connectionClosed(connection)
+        #expect(closedAction.connection == .cancelEventStreamAndFinalCleanup([]))
+
+        #expect(stateMachine.isShutdown)
+        #expect(stateMachine.connections.stats.active == 0)
+    }
+
+    @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
+    @Test func testTriggerGracefulShutdownWithInProgessRequest() {
+        var configuration = PoolConfiguration()
+        configuration.minimumConnectionCount = 1
+        configuration.maximumConnectionSoftLimit = 2
+        configuration.maximumConnectionHardLimit = 2
+        configuration.keepAliveDuration = .seconds(2)
+        configuration.idleTimeoutDuration = .seconds(4)
+
+        var stateMachine = TestPoolStateMachine(
+            configuration: configuration,
+            generator: .init(),
+            timerCancellationTokenType: MockTimerCancellationToken.self,
+            clock: MockClock()
+        )
+
+        // refill pool
+        let requests = stateMachine.refillConnections()
+        #expect(requests.count == 1)
+
+        let shutdownAction = stateMachine.triggerGracefulShutdown()
+        #expect(shutdownAction.connection ==  .initiateShutdown(.init()))
+
+        // make connection 1
+        let connection = MockConnection(id: 0)
+        let createdAction = stateMachine.connectionEstablished(connection, maxStreams: 1)
+        #expect(createdAction.request == .none)
+        #expect(createdAction.connection == .closeConnection(connection, []))
+
+        let closedAction = stateMachine.connectionClosed(connection)
+        #expect(closedAction.connection == .cancelEventStreamAndFinalCleanup([]))
+
+        #expect(stateMachine.isShutdown)
+        #expect(stateMachine.connections.stats.active == 0)
+    }
+
+    @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
+    @Test func testTriggerGracefulShutdownDoesNotInterruptOtherStreams() {
+        var configuration = PoolConfiguration()
+        configuration.minimumConnectionCount = 1
+        configuration.maximumConnectionSoftLimit = 2
+        configuration.maximumConnectionHardLimit = 2
+        configuration.keepAliveDuration = .seconds(2)
+        configuration.idleTimeoutDuration = .seconds(4)
+
+        var stateMachine = TestPoolStateMachine(
+            configuration: configuration,
+            generator: .init(),
+            timerCancellationTokenType: MockTimerCancellationToken.self,
+            clock: MockClock()
+        )
+
+        let requests = stateMachine.refillConnections()
+        #expect(requests.count == 1)
+
+        // make connection 1
+        let connection = MockConnection(id: 0)
+        let createdAction = stateMachine.connectionEstablished(connection, maxStreams: 2)
+        #expect(createdAction.request == .none)
+        let connection1KeepAliveTimer = TestPoolStateMachine.Timer(.init(timerID: 0, connectionID: 0, usecase: .keepAlive), duration: .seconds(2))
+        #expect(createdAction.connection == .scheduleTimers([connection1KeepAliveTimer]))
+        #expect(stateMachine.timerScheduled(connection1KeepAliveTimer, cancelContinuation: MockTimerCancellationToken(connection1KeepAliveTimer)) == .none)
+
+        let mockRequest1 = MockRequest(connectionType: MockConnection.self)
+        let leaseAction1 = stateMachine.leaseConnection(mockRequest1)
+        #expect(leaseAction1.request == .leaseConnection(.init(element: mockRequest1), connection))
+        #expect(leaseAction1.connection == .cancelTimers([MockTimerCancellationToken(connection1KeepAliveTimer)]))
+        let mockRequest2 = MockRequest(connectionType: MockConnection.self)
+        let leaseAction2 = stateMachine.leaseConnection(mockRequest2)
+        #expect(leaseAction2.request == .leaseConnection(.init(element: mockRequest2), connection))
+        #expect(leaseAction2.connection == .cancelTimers([]))
+
+        let release1 = stateMachine.releaseConnection(connection, streams: 1)
+        #expect(release1.connection == .none)
+
+        let shutdownAction = stateMachine.triggerGracefulShutdown()
+        #expect(shutdownAction.connection == .initiateShutdown(.init()))
+        #expect(!stateMachine.isShutdown)
+
+        let release2 = stateMachine.releaseConnection(connection, streams: 1)
+        #expect(release2.connection == .closeConnection(connection, []))
+
+        let closedAction = stateMachine.connectionClosed(connection)
+        #expect(closedAction.connection == .cancelEventStreamAndFinalCleanup([]))
+        #expect(stateMachine.isShutdown)
+    }
+
+    @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
     @Test func testBackingOffRequests() {
         struct ConnectionFailed: Error, Equatable {}
         let clock = MockClock()

--- a/Tests/PostgresNIOTests/New/PostgresClientTests.swift
+++ b/Tests/PostgresNIOTests/New/PostgresClientTests.swift
@@ -1,6 +1,7 @@
 import Logging
 import NIOCore
 import PostgresNIO
+import ServiceLifecycleTestKit
 import Testing
 
 @Suite struct PostgresClientTests {
@@ -36,6 +37,46 @@ import Testing
                 group.cancelAll()
             }
             // If we reach here the test passed (the .timeLimit above enforces the deadline).
+        }
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    func gracefulShutdownWaitsForInFlightRequest() async throws {
+        try await withSilentServer { port in
+            var config = PostgresClient.Configuration(
+                host: "127.0.0.1",
+                port: port,
+                username: "postgres",
+                password: "irrelevant",
+                database: "test",
+                tls: .disable
+            )
+            config.options.connectTimeout = .seconds(2)
+            config.options.minimumConnections = 1
+
+            let client = PostgresClient(
+                configuration: config,
+                eventLoopGroup: NIOSingletons.posixEventLoopGroup,
+                backgroundLogger: Logger(label: "test")
+            )
+
+            let elapsed = await ServiceLifecycleTestKit.testGracefulShutdown { gracefulShutdownTrigger in
+                let start = ContinuousClock.now
+                await withTaskGroup(of: Void.self) { group in
+                    // We don't have a server to connect to, so  we'll reach `connectTimeout` (2s).
+                    group.addTask { await client.run() }
+
+                    try? await Task.sleep(for: .milliseconds(200))
+
+                    gracefulShutdownTrigger.triggerGracefulShutdown()
+                }
+                return ContinuousClock.now - start
+            }
+
+            // If this took ~200ms (our sleep time) it would mean the connect timeout wasn't reached,
+            // and the client was canceled instead of gracefully shut down.
+            // If the test reached the time limit (1m, and would fail), it would mean there's no graceful shutdown hook.
+            #expect(elapsed > .seconds(1))
         }
     }
 }


### PR DESCRIPTION
Closes #595 

This implements graceful shutdown behaviour in the connection state machine. When it's triggered, in flight requests are completed and open connections are kept open until all requests in the request queue are completed. The PostgresClient now makes use of this new behaviour