### PR TITLE
Make `PostgresDataType` PostgresCodable

### DIFF
--- a/Sources/PostgresNIO/Data/PostgresDataType.swift
+++ b/Sources/PostgresNIO/Data/PostgresDataType.swift
@@ -173,7 +173,7 @@ public struct PostgresDataType: RawRepresentable, Sendable, Hashable, CustomStri
     /// `1027`
     public static let polygonArray = PostgresDataType(1027)
     /// `1028`
-    public static let oidArray = PostgresDataType(1018)
+    public static let oidArray = PostgresDataType(1028)
     /// `1033`
     public static let aclitem = PostgresDataType(1033)
     /// `1034` _aclitem

--- a/Sources/PostgresNIO/New/Data/Array+PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/Data/Array+PostgresCodable.swift
@@ -104,6 +104,13 @@ extension ClosedRange: PostgresArrayEncodable where Bound: PostgresRangeArrayEnc
     public static var psqlArrayType: PostgresDataType { Bound.psqlRangeArrayType }
 }
 
+extension PostgresDataType: PostgresArrayEncodable {
+    public static var psqlArrayType: PostgresDataType { .oidArray }
+}
+
+extension PostgresDataType: PostgresArrayDecodable {}
+
+
 // MARK: Array conformances
 
 extension Array: PostgresEncodable where Element: PostgresArrayEncodable {

--- a/Sources/PostgresNIO/New/Data/Array+PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/Data/Array+PostgresCodable.swift
@@ -110,7 +110,6 @@ extension PostgresDataType: PostgresArrayEncodable {
 
 extension PostgresDataType: PostgresArrayDecodable {}
 
-
 // MARK: Array conformances
 
 extension Array: PostgresEncodable where Element: PostgresArrayEncodable {

--- a/Sources/PostgresNIO/New/Data/PostgresDataType+PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/Data/PostgresDataType+PostgresCodable.swift
@@ -9,28 +9,28 @@ extension PostgresDataType: PostgresDecodable {
         context: PostgresDecodingContext<JSONDecoder>
     ) throws where JSONDecoder: PostgresJSONDecoder {
         switch (format, type) {
-        case (.binary, .oid), (.binary, .regproc):
-            guard 
+        case (.binary, .oid), (.binary, .regproc), (.binary, .regclass), (.binary, .regtype):
+            guard
                 byteBuffer.readableBytes == 4,
                 let value = byteBuffer.readInteger(as: UInt32.self)
-            else { 
-                throw PostgresDecodingError.Code.failure 
+            else {
+                throw PostgresDecodingError.Code.failure
             }
             self.rawValue = value
         case (.binary, .int4):
-            guard 
+            guard
                 byteBuffer.readableBytes == 4,
                 let value = byteBuffer.readInteger(as: Int32.self).flatMap(UInt32.init(exactly:))
-            else { 
-                throw PostgresDecodingError.Code.failure 
+            else {
+                throw PostgresDecodingError.Code.failure
             }
             self.rawValue = value
         case (.text, .oid), (.text, .int4):
-            guard 
+            guard
                 let string = byteBuffer.readString(length: byteBuffer.readableBytes),
                 let value = UInt32(string)
             else {
-                throw PostgresDecodingError.Code.failure 
+                throw PostgresDecodingError.Code.failure
             }
             self.rawValue = value
         default:
@@ -40,12 +40,12 @@ extension PostgresDataType: PostgresDecodable {
 }
 
 extension PostgresDataType: PostgresNonThrowingEncodable {
-    public static var psqlType: PostgresDataType { 
-        .oid 
+    public static var psqlType: PostgresDataType {
+        .oid
     }
 
-    public static var psqlFormat: PostgresFormat { 
-        .binary 
+    public static var psqlFormat: PostgresFormat {
+        .binary
     }
 
     @inlinable
@@ -53,6 +53,6 @@ extension PostgresDataType: PostgresNonThrowingEncodable {
         into byteBuffer: inout ByteBuffer,
         context: PostgresEncodingContext<JSONEncoder>
     ) {
-        byteBuffer.writeInteger(self.rawValue)
+        byteBuffer.writeInteger(self.rawValue, as: UInt32.self)
     }
 }

--- a/Sources/PostgresNIO/New/Data/PostgresDataType+PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/Data/PostgresDataType+PostgresCodable.swift
@@ -25,6 +25,8 @@ extension PostgresDataType: PostgresDecodable {
                 throw PostgresDecodingError.Code.failure
             }
             self.rawValue = value
+        // The `oid` aliases (`regproc`, `regclass` etc) only carry an id in binary form.
+        // In text form they're a string containing a name and so cannot be decoded into a PostgresDataType.
         case (.text, .oid), (.text, .int4):
             guard
                 let string = byteBuffer.readString(length: byteBuffer.readableBytes),

--- a/Sources/PostgresNIO/New/Data/PostgresDataType+PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/Data/PostgresDataType+PostgresCodable.swift
@@ -1,0 +1,58 @@
+import NIOCore
+
+extension PostgresDataType: PostgresDecodable {
+    @inlinable
+    public init<JSONDecoder>(
+        from byteBuffer: inout ByteBuffer,
+        type: PostgresDataType,
+        format: PostgresFormat,
+        context: PostgresDecodingContext<JSONDecoder>
+    ) throws where JSONDecoder: PostgresJSONDecoder {
+        switch (format, type) {
+        case (.binary, .oid), (.binary, .regproc):
+            guard 
+                byteBuffer.readableBytes == 4,
+                let value = byteBuffer.readInteger(as: UInt32.self)
+            else { 
+                throw PostgresDecodingError.Code.failure 
+            }
+            self.rawValue = value
+        case (.binary, .int4):
+            guard 
+                byteBuffer.readableBytes == 4,
+                let value = byteBuffer.readInteger(as: Int32.self).flatMap(UInt32.init(exactly:))
+            else { 
+                throw PostgresDecodingError.Code.failure 
+            }
+            self.rawValue = value
+        case (.text, .oid), (.text, .int4):
+            guard 
+                let string = byteBuffer.readString(length: byteBuffer.readableBytes),
+                let value = UInt32(string)
+            else {
+                throw PostgresDecodingError.Code.failure 
+            }
+            self.rawValue = value
+        default:
+            throw PostgresDecodingError.Code.typeMismatch
+        }
+    }
+}
+
+extension PostgresDataType: PostgresNonThrowingEncodable {
+    public static var psqlType: PostgresDataType { 
+        .oid 
+    }
+
+    public static var psqlFormat: PostgresFormat { 
+        .binary 
+    }
+
+    @inlinable
+    public func encode<JSONEncoder>(
+        into byteBuffer: inout ByteBuffer,
+        context: PostgresEncodingContext<JSONEncoder>
+    ) {
+        byteBuffer.writeInteger(self.rawValue)
+    }
+}

--- a/Tests/IntegrationTests/PostgresDataTypeTests.swift
+++ b/Tests/IntegrationTests/PostgresDataTypeTests.swift
@@ -41,7 +41,26 @@ final class PostgresDataTypeIntegrationTests: XCTestCase {
         }
     }
 
-    func testOIDArray() async throws {
+    func testOIDAboveInt32MaxRoundTrips() async throws {
+        let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully()) }
+
+        let large = PostgresDataType(3_000_000_000)
+
+        try await withTestConnection(on: eventLoopGroup.next()) { connection in
+            let serverSide = try await connection.query("SELECT 3000000000::oid", logger: .psqlTest)
+            var serverSideIterator = serverSide.makeAsyncIterator()
+            let serverSideRow = try await serverSideIterator.next()
+            XCTAssertEqual(try serverSideRow?.decode(PostgresDataType.self), large)
+
+            let roundTrip = try await connection.query("SELECT \(large)::oid", logger: .psqlTest)
+            var roundTripIterator = roundTrip.makeAsyncIterator()
+            let roundTripRow = try await roundTripIterator.next()
+            XCTAssertEqual(try roundTripRow?.decode(PostgresDataType.self), large)
+        }
+    }
+
+    func testOIDArrayRoundTrips() async throws {
         let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully()) }
 

--- a/Tests/IntegrationTests/PostgresDataTypeTests.swift
+++ b/Tests/IntegrationTests/PostgresDataTypeTests.swift
@@ -1,0 +1,85 @@
+import Logging
+import NIOCore
+import NIOPosix
+import PostgresNIO
+import XCTest
+
+final class PostgresDataTypeIntegrationTests: XCTestCase {
+    func testDecodeOIDFromCatalog() async throws {
+        let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully()) }
+
+        try await withTestConnection(on: eventLoopGroup.next()) { connection in
+            let rows = try await connection.query(
+                "SELECT 'text'::regtype::oid",
+                logger: .psqlTest
+            )
+
+            var iterator = rows.makeAsyncIterator()
+            let firstRow = try await iterator.next()
+            XCTAssertEqual(try firstRow?.decode(PostgresDataType.self), .text)
+            let done = try await iterator.next()
+            XCTAssertNil(done)
+        }
+    }
+
+    func testEncodeOIDAsQueryParameter() async throws {
+        let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully()) }
+
+        try await withTestConnection(on: eventLoopGroup.next()) { connection in
+            let rows = try await connection.query(
+                "SELECT typname FROM pg_type WHERE oid = \(PostgresDataType.text)",
+                logger: .psqlTest
+            )
+
+            var iterator = rows.makeAsyncIterator()
+            let firstRow = try await iterator.next()
+            XCTAssertEqual(try firstRow?.decode(String.self), "text")
+            let done = try await iterator.next()
+            XCTAssertNil(done)
+        }
+    }
+
+    func testOIDArray() async throws {
+        let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully()) }
+
+        try await withTestConnection(on: eventLoopGroup.next()) { connection in
+            let wanted: [PostgresDataType] = [.bool, .text]
+            let rows = try await connection.query(
+                "SELECT typname FROM pg_type WHERE oid = ANY(\(wanted)) ORDER BY oid",
+                logger: .psqlTest
+            )
+
+            var typeNames = [String]()
+            for try await row in rows {
+                typeNames.append(try row.decode(String.self))
+            }
+            XCTAssertEqual(typeNames, ["bool", "text"])
+
+            let arrayRows = try await connection.query("SELECT ARRAY[16, 25]::oid[]", logger: .psqlTest)
+            var arrayIterator = arrayRows.makeAsyncIterator()
+            let arrayRow = try await arrayIterator.next()
+            XCTAssertEqual(try arrayRow?.decode([PostgresDataType].self), [.bool, .text])
+        }
+    }
+
+    func testDecodeRegprocFromCatalog() async throws {
+        let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully()) }
+
+        try await withTestConnection(on: eventLoopGroup.next()) { connection in
+            let rows = try await connection.query(
+                "SELECT typinput, typinput::oid FROM pg_type WHERE typname = 'bool'",
+                logger: .psqlTest
+            )
+
+            var iterator = rows.makeAsyncIterator()
+            let firstRow = try await iterator.next()
+            let (asRegproc, asOID) = try XCTUnwrap(firstRow).decode((PostgresDataType, PostgresDataType).self)
+            XCTAssertEqual(asRegproc, asOID)
+            XCTAssertNotEqual(asRegproc.rawValue, 0)
+        }
+    }
+}

--- a/Tests/IntegrationTests/PostgresDataTypeTests.swift
+++ b/Tests/IntegrationTests/PostgresDataTypeTests.swift
@@ -11,7 +11,7 @@ final class PostgresDataTypeIntegrationTests: XCTestCase {
 
         try await withTestConnection(on: eventLoopGroup.next()) { connection in
             let rows = try await connection.query(
-                "SELECT 'text'::regtype::oid",
+                "SELECT 'text'::regtype",
                 logger: .psqlTest
             )
 

--- a/Tests/PostgresNIOTests/New/Data/PostgresDataType+PSQLCodableTests.swift
+++ b/Tests/PostgresNIOTests/New/Data/PostgresDataType+PSQLCodableTests.swift
@@ -103,12 +103,19 @@ import Testing
         var buffer = ByteBuffer()
         buffer.writeInteger(UInt32(26))
 
-        for type in [PostgresDataType.bool, .int2, .int8, .uuid, .text] {
+        for type in [PostgresDataType.bool, .int2, .int8, .uuid, .text, .oidArray] {
             for format in [PostgresFormat.binary, .text] {
                 var copy = buffer
                 #expect(throws: PostgresDecodingError.Code.typeMismatch) {
                     try PostgresDataType(from: &copy, type: type, format: format, context: .default)
                 }
+            }
+        }
+
+        for type in [PostgresDataType.regproc, .regtype, .regclass] {
+            var copy = buffer
+            #expect(throws: PostgresDecodingError.Code.typeMismatch) {
+                try PostgresDataType(from: &copy, type: type, format: .text, context: .default)
             }
         }
     }

--- a/Tests/PostgresNIOTests/New/Data/PostgresDataType+PSQLCodableTests.swift
+++ b/Tests/PostgresNIOTests/New/Data/PostgresDataType+PSQLCodableTests.swift
@@ -1,0 +1,115 @@
+import NIOCore
+import Testing
+
+@testable import PostgresNIO
+
+@Suite struct PostgresDataType_PSQLCodableTests {
+    @Test func testRoundTrip() {
+        let values: [UInt32] = [0, 1, 26, 42, 12345, UInt32(UInt16.max), UInt32.max]
+        for value in values {
+            let oid = PostgresDataType(rawValue: value)
+            var buffer = ByteBuffer()
+            oid?.encode(into: &buffer, context: .default)
+
+            #expect(PostgresDataType.psqlType == .oid)
+            #expect(PostgresDataType.psqlFormat == .binary)
+            #expect(buffer.readableBytes == 4)
+            #expect(buffer.getInteger(at: buffer.readerIndex, as: UInt32.self) == value)
+
+            var decoded: PostgresDataType?
+            #expect(throws: Never.self) {
+                decoded = try PostgresDataType(from: &buffer, type: .oid, format: .binary, context: .default)
+            }
+            #expect(decoded == oid)
+        }
+    }
+
+    @Test func testDecodeFromBinaryOID() {
+        let values: [UInt32] = [0, 1, 26, UInt32(UInt16.max), UInt32(Int32.max), UInt32.max]
+        for value in values {
+            for type in [PostgresDataType.oid, .regproc] {
+                var buffer = ByteBuffer()
+                buffer.writeInteger(value)
+
+                var decoded: PostgresDataType?
+                #expect(throws: Never.self) {
+                    decoded = try PostgresDataType(from: &buffer, type: type, format: .binary, context: .default)
+                }
+                #expect(decoded?.rawValue == value)
+            }
+        }
+    }
+
+    @Test func testDecodeFromBinaryInt4() {
+        for value in [Int32(0), 1, 26, Int32(UInt16.max), Int32.max] {
+            var buffer = ByteBuffer()
+            buffer.writeInteger(value)
+
+            var decoded: PostgresDataType?
+            #expect(throws: Never.self) {
+                decoded = try PostgresDataType(from: &buffer, type: .int4, format: .binary, context: .default)
+            }
+            #expect(decoded?.rawValue == UInt32(value))
+        }
+
+        for value in [Int32(-1), -26, Int32.min] {
+            var buffer = ByteBuffer()
+            buffer.writeInteger(value)
+
+            #expect(throws: PostgresDecodingError.Code.failure) {
+                try PostgresDataType(from: &buffer, type: .int4, format: .binary, context: .default)
+            }
+        }
+    }
+
+    @Test func testDecodeFromText() {
+        for value in [0, 1, 26, UInt32(UInt16.max), UInt32.max] {
+            for type in [PostgresDataType.oid, .int4] {
+                var buffer = ByteBuffer()
+                buffer.writeString(String(value))
+
+                var decoded: PostgresDataType?
+                #expect(throws: Never.self) {
+                    decoded = try PostgresDataType(from: &buffer, type: type, format: .text, context: .default)
+                }
+                #expect(decoded?.rawValue == value)
+            }
+        }
+    }
+
+    @Test func testDecodeFailureFromInvalidByteCount() {
+        var buffer = ByteBuffer()
+        buffer.writeInteger(UInt32(26))
+        // Make only three bytes readable
+        buffer.moveReaderIndex(forwardBy: 1)
+
+        #expect(throws: PostgresDecodingError.Code.failure) {
+            try PostgresDataType(from: &buffer, type: .oid, format: .binary, context: .default)
+        }
+    }
+
+    @Test func testDecodeFailureFromInvalidText() {
+        for string in ["", "notanumber", "-1", "4294967296"] {
+            var buffer = ByteBuffer()
+            buffer.writeString(string)
+
+            #expect(throws: PostgresDecodingError.Code.failure) {
+                try PostgresDataType(from: &buffer, type: .oid, format: .text, context: .default)
+            }
+        }
+    }
+
+    @Test func testDecodeFailureFromInvalidPostgresType() {
+        var buffer = ByteBuffer()
+        buffer.writeInteger(UInt32(26))
+
+        for type in [PostgresDataType.bool, .int2, .int8, .uuid, .text] {
+            for format in [PostgresFormat.binary, .text] {
+                var copy = buffer
+                #expect(throws: PostgresDecodingError.Code.typeMismatch) {
+                    try PostgresDataType(from: &copy, type: type, format: format, context: .default)
+                }
+            }
+        }
+    }
+}

--- a/Tests/PostgresNIOTests/New/Data/PostgresDataType+PSQLCodableTests.swift
+++ b/Tests/PostgresNIOTests/New/Data/PostgresDataType+PSQLCodableTests.swift
@@ -28,8 +28,7 @@ import Testing
         let values: [UInt32] = [0, 1, 26, UInt32(UInt16.max), UInt32(Int32.max), UInt32.max]
         for value in values {
             for type in [PostgresDataType.oid, .regproc] {
-                var buffer = ByteBuffer()
-                buffer.writeInteger(value)
+                var buffer = ByteBuffer(integer: value)
 
                 var decoded: PostgresDataType?
                 #expect(throws: Never.self) {
@@ -42,8 +41,7 @@ import Testing
 
     @Test func testDecodeFromBinaryInt4() {
         for value in [Int32(0), 1, 26, Int32(UInt16.max), Int32.max] {
-            var buffer = ByteBuffer()
-            buffer.writeInteger(value)
+            var buffer = ByteBuffer(integer: value)
 
             var decoded: PostgresDataType?
             #expect(throws: Never.self) {
@@ -53,8 +51,7 @@ import Testing
         }
 
         for value in [Int32(-1), -26, Int32.min] {
-            var buffer = ByteBuffer()
-            buffer.writeInteger(value)
+            var buffer = ByteBuffer(integer: value)
 
             #expect(throws: PostgresDecodingError.Code.failure) {
                 try PostgresDataType(from: &buffer, type: .int4, format: .binary, context: .default)
@@ -65,8 +62,7 @@ import Testing
     @Test func testDecodeFromText() {
         for value in [0, 1, 26, UInt32(UInt16.max), UInt32.max] {
             for type in [PostgresDataType.oid, .int4] {
-                var buffer = ByteBuffer()
-                buffer.writeString(String(value))
+                var buffer = ByteBuffer(string: String(value))
 
                 var decoded: PostgresDataType?
                 #expect(throws: Never.self) {
@@ -78,8 +74,7 @@ import Testing
     }
 
     @Test func testDecodeFailureFromInvalidByteCount() {
-        var buffer = ByteBuffer()
-        buffer.writeInteger(UInt32(26))
+        var buffer = ByteBuffer(integer: UInt32(26))
         // Make only three bytes readable
         buffer.moveReaderIndex(forwardBy: 1)
 
@@ -90,8 +85,7 @@ import Testing
 
     @Test func testDecodeFailureFromInvalidText() {
         for string in ["", "notanumber", "-1", "4294967296"] {
-            var buffer = ByteBuffer()
-            buffer.writeString(string)
+            var buffer = ByteBuffer(string: string)
 
             #expect(throws: PostgresDecodingError.Code.failure) {
                 try PostgresDataType(from: &buffer, type: .oid, format: .text, context: .default)
@@ -100,8 +94,7 @@ import Testing
     }
 
     @Test func testDecodeFailureFromInvalidPostgresType() {
-        var buffer = ByteBuffer()
-        buffer.writeInteger(UInt32(26))
+        let buffer = ByteBuffer(integer: UInt32(26))
 
         for type in [PostgresDataType.bool, .int2, .int8, .uuid, .text, .oidArray] {
             for format in [PostgresFormat.binary, .text] {


### PR DESCRIPTION
This allows usage of `PostgresDataType` inside queries so dynamic OIDs can be queried at runtime and decoded into this