### PR TITLE
Add ltree type with dynamic OID fetching

### DIFF
--- a/Sources/PostgresNIO/Connection/PostgresConnection+Configuration.swift
+++ b/Sources/PostgresNIO/Connection/PostgresConnection+Configuration.swift
@@ -90,6 +90,10 @@ extension PostgresConnection {
             /// startup message that the client sends to the server.
             public var additionalStartupParameters: [(String, String)]
 
+            /// The names of additional Postgres data types whose object identifiers (OIDs) shall be resolved while
+            /// the connection is established.
+            public var additionalDataTypeNames: [String]
+
             /// Create an options structure with default values.
             ///
             /// Most users should not need to adjust the defaults.
@@ -98,6 +102,7 @@ extension PostgresConnection {
                 self.tlsServerName = nil
                 self.requireBackendKeyData = true
                 self.additionalStartupParameters = []
+                self.additionalDataTypeNames = []
             }
         }
         

--- a/Sources/PostgresNIO/New/Data/PostgresLTree+PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/Data/PostgresLTree+PostgresCodable.swift
@@ -1,0 +1,131 @@
+/// A Swift representation for the Postgres `ltree` type, provided by the `ltree` extension.
+///
+/// An `ltree` value is a sequence of zero or more labels separated by dots, for example
+/// `Top.Science.Astronomy`.
+///
+/// Enable the extension in your database before using the type:
+/// ```sql
+/// CREATE EXTENSION IF NOT EXISTS ltree;
+/// ```
+///
+/// ## Wire format
+///
+/// Because `ltree` is an extension type its Postgres OID is assigned when the extension is installed
+/// and is therefore not stable across databases. It is instead resolved per connection: add `"ltree"`
+/// to ``PostgresConnection/Configuration/Options/additionalDataTypeNames`` and the OID is looked up
+/// while the connection is being established. The dotted path is always written as text, never as binary.
+///
+/// ```swift
+/// config.options.additionalDataTypeNames = ["ltree"]
+/// ```
+///
+/// Without that option, or if the extension is not installed, values are bound with an unspecified
+/// parameter type (OID `0`) and Postgres has to infer the type from context. Binding an `ltree` where
+/// Postgres can't infer it (for example `SELECT $1` with no surrounding type information)
+/// will then fail.
+///
+/// When decoding, both wire formats the server may send are supported:
+/// - `.text`: the raw dotted path.
+/// - `.binary`: a one-byte version prefix (currently `1`) followed by the path text. Binary
+///   send/receive for `ltree` was only added in PostgreSQL 13.
+///
+/// For more information on the type, see https://www.postgresql.org/docs/current/ltree.html.
+public struct PostgresLTree: Equatable, Hashable, Sendable {
+    @usableFromInline var values: [String]
+
+    /// Create an `ltree` from its individual labels, in order from the root to the leaf.
+    ///
+    /// - Parameter values: The labels making up the path, e.g. `["Top", "Science", "Astronomy"]`.
+    public init(labels: [String]) {
+        self.values = labels
+    }
+
+    /// Append a label to the end (leaf) of the path.
+    public mutating func append(_ label: String) {
+        values.append(label)
+    }
+
+    /// Remove and return the last (leaf) label of the path, or `nil` if the path is empty.
+    public mutating func popLast() -> String? {
+        values.popLast()
+    }
+
+    /// The individual labels of the path, ordered from the root to the leaf.
+    public var labels: [String] {
+        self.values
+    }
+}
+
+extension PostgresLTree: ExpressibleByArrayLiteral {
+    /// Create an `ltree` from its individual labels, in order from the root to the leaf.
+    ///
+    /// - Parameter arrayLiteral: The labels making up the path, e.g. `["Top", "Science", "Astronomy"]`.
+    public init(arrayLiteral elements: String...) {
+        self.values = elements
+    }
+}
+
+extension PostgresLTree: CustomStringConvertible, LosslessStringConvertible {
+    /// Create an `ltree` by splitting a dotted path string into its labels.
+    /// 
+    /// Input that Postgres would reject (such as `a..b`) is parsed leniently
+    /// rather than failing. The server is the authority here.
+    ///
+    /// - Parameter description: A dotted path such as `Top.Science.Astronomy`.
+    public init(_ description: String) {
+        self.values = description.split(separator: ".").map(String.init)
+    }
+
+    /// The path as a dotted string, e.g. `Top.Science.Astronomy`.
+    public var description: String {
+        self.values.joined(separator: ".")
+    }
+}
+
+extension PostgresLTree: PostgresDecodable {
+    /// Decode an `ltree` value from either wire format.
+    @inlinable
+    public init<JSONDecoder>(
+        from byteBuffer: inout ByteBuffer,
+        type: PostgresDataType,
+        format: PostgresFormat,
+        context: PostgresDecodingContext<JSONDecoder>
+    ) throws where JSONDecoder: PostgresJSONDecoder {
+        if format == .binary {
+            let version = byteBuffer.readInteger(as: Int8.self)
+            guard version == 1 else { throw PostgresDecodingError.Code.failure }
+        }
+
+        let string = byteBuffer.readString(length: byteBuffer.readableBytes)
+        guard let string else { throw PostgresDecodingError.Code.failure }
+        self = PostgresLTree(string)
+    }
+}
+
+extension PostgresLTree: PostgresDynamicTypeEncodable {
+    public var psqlType: PostgresDataType {
+        .null  // unspecified, since ltree's OID is not stable across databases
+    }
+
+    public var psqlFormat: PostgresFormat {
+        .text
+    }
+
+    public var psqlTypeName: String? {
+        "ltree"
+    }
+
+    @inlinable
+    public func encode<JSONEncoder>(
+        into byteBuffer: inout ByteBuffer,
+        context: PostgresEncodingContext<JSONEncoder>
+    ) {
+        // Write directly into the buffer avoiding extra allocations of `.joined`
+        for (index, label) in self.values.enumerated() {
+            if index != 0 {
+                byteBuffer.writeInteger(UInt8(ascii: "."))
+            }
+            byteBuffer.writeString(label)
+        }
+    }
+}

--- a/Sources/PostgresNIO/New/Extensions/Logging+PSQL.swift
+++ b/Sources/PostgresNIO/New/Extensions/Logging+PSQL.swift
@@ -13,6 +13,7 @@ extension PSQLConnection {
         case notice = "psql_notice"
         case binds = "psql_binds"
         case commandTag = "psql_command_tag"
+        case dataTypeNames = "psql_data_type_names"
         
         case connectionState = "psql_connection_state"
         case connectionAction = "psql_connection_action"

--- a/Sources/PostgresNIO/New/PostgresChannelHandler.swift
+++ b/Sources/PostgresNIO/New/PostgresChannelHandler.swift
@@ -24,6 +24,7 @@ final class PostgresChannelHandler: ChannelDuplexHandler {
 
     private var listenState = ListenStateMachine()
     private var preparedStatementState = PreparedStatementStateMachine()
+    private var resolvedDataTypes: [String: PostgresDataType] = [:]
 
     init(
         configuration: PostgresConnection.InternalConfiguration,
@@ -44,12 +45,73 @@ final class PostgresChannelHandler: ChannelDuplexHandler {
     func handlerAdded(context: ChannelHandlerContext) {
         self.handlerContext = context
         self.encoder = PostgresFrontendMessageEncoder(buffer: context.channel.allocator.buffer(capacity: 256))
-        
+
+        self.populateDataTypes(context: context)
+
         if context.channel.isActive {
             self.connected(context: context)
         }
     }
-    
+
+    /// Enqueue a query resolving the OIDs of ``PostgresConnection/Configuration/Options/additionalDataTypeNames``.
+    private func populateDataTypes(context: ChannelHandlerContext) {
+        let dataTypeNames = self.configuration.options.additionalDataTypeNames
+        guard !dataTypeNames.isEmpty else { return }
+
+        let promise = context.eventLoop.makePromise(of: PSQLRowStream.self)
+        let queryContext = ExtendedQueryContext(
+            query: """
+                SELECT typname, oid FROM pg_type
+                    WHERE typname = ANY (\(dataTypeNames))
+                    AND pg_type_is_visible(oid);
+                """,
+            logger: self.logger,
+            promise: promise
+        )
+
+        let loopBound = NIOLoopBound(self, eventLoop: self.eventLoop)
+        promise.futureResult.flatMap { $0.all() }.whenComplete { result in
+            loopBound.value.populateDataTypesCompleted(result, for: dataTypeNames)
+        }
+
+        self.run(self.state.enqueue(task: .extendedQuery(queryContext)), with: context)
+    }
+
+    private func populateDataTypesCompleted(
+        _ result: Result<[PostgresRow], any Error>,
+        for dataTypeNames: [String]
+    ) {
+        switch result {
+        case .success(let rows):
+            do {
+                let decoded = try rows.map { try $0.decode((String, PostgresDataType).self) }
+                self.resolvedDataTypes = Dictionary(decoded, uniquingKeysWith: { last, _ in last })
+            } catch {
+                self.logger.warning("Failed to decode additional data types", metadata: [
+                    .error: "\(error)", .dataTypeNames: "\(dataTypeNames)"
+                ])
+            }
+
+            let unresolved = dataTypeNames.filter { self.resolvedDataTypes[$0] == nil }
+            if !unresolved.isEmpty {
+                self.logger.warning("Some additional data types could not be resolved", metadata: [
+                    .dataTypeNames: "\(unresolved)"
+                ])
+            }
+
+        case .failure(let error):
+            if let error = error as? PSQLError,
+                [.clientClosedConnection, .serverClosedConnection, .connectionError, .uncleanShutdown].contains(error.code)
+            {
+                // The connection attempt failed so there will be another log somewhere
+            } else {
+                self.logger.warning("Failed to resolve additional data types", metadata: [
+                    .error: "\(error)", .dataTypeNames: "\(dataTypeNames)"
+                ])
+            }
+        }
+    }
+
     func handlerRemoved(context: ChannelHandlerContext) {
         self.handlerContext = nil
     }
@@ -605,16 +667,21 @@ final class PostgresChannelHandler: ChannelDuplexHandler {
     ) {
         precondition(self.rowStream == nil, "Expected to not have an open stream at this point")
         let unnamedStatementName = ""
+
         self.encoder.parse(
             preparedStatementName: unnamedStatementName,
             query: query.sql,
-            parameters: query.binds.metadata.lazy.map(\.dataType)
+            parameters: query.binds.metadata.lazy.map { self.resolveDataType($0) }
         )
         self.encoder.describePreparedStatement(unnamedStatementName)
         self.encoder.bind(portalName: "", preparedStatementName: unnamedStatementName, bind: query.binds)
         self.encoder.execute(portalName: "")
         self.encoder.sync()
         context.writeAndFlush(self.wrapOutboundOut(self.encoder.flushBuffer()), promise: nil)
+    }
+
+    private func resolveDataType(_ metadata: PostgresBindings.Metadata) -> PostgresDataType {
+        metadata.dataTypeName.flatMap { self.resolvedDataTypes[$0] } ?? metadata.dataType
     }
     
     private func succeedQuery(
@@ -813,7 +880,9 @@ final class PostgresChannelHandler: ChannelDuplexHandler {
         return .extendedQuery(.init(
             name: preparedStatement.name,
             query: preparedStatement.sql,
-            bindingDataTypes: preparedStatement.bindingDataTypes,
+            bindingDataTypes: preparedStatement.bindingDataTypes.isEmpty
+                ? preparedStatement.bindings.metadata.map(self.resolveDataType)
+                : preparedStatement.bindingDataTypes,
             logger: preparedStatement.logger,
             promise: promise
         ))

--- a/Sources/PostgresNIO/New/PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/PostgresCodable.swift
@@ -21,6 +21,17 @@ public protocol PostgresThrowingDynamicTypeEncodable {
         into byteBuffer: inout ByteBuffer,
         context: PostgresEncodingContext<JSONEncoder>
     ) throws
+
+    /// The Postgres name for this type. This is used for types that don't have a static OID.
+    /// Setting this on a type, combined with adding it to ``PostgresConnection/Configuration/Options/additionalDataTypeNames``,
+    /// will allow usage of this type through its dynamically constructed OID, by querying the OID
+    /// at connection startup.
+    var psqlTypeName: String? { get }
+}
+
+extension PostgresThrowingDynamicTypeEncodable {
+    @inlinable
+    public var psqlTypeName: String? { nil }
 }
 
 /// A type that can encode itself to a Postgres wire binary representation.

--- a/Sources/PostgresNIO/New/PostgresQuery.swift
+++ b/Sources/PostgresNIO/New/PostgresQuery.swift
@@ -124,20 +124,23 @@ public struct PostgresBindings: Sendable, Hashable {
         @usableFromInline
         var dataType: PostgresDataType
         @usableFromInline
+        var dataTypeName: String?
+        @usableFromInline
         var format: PostgresFormat
         @usableFromInline
         var protected: Bool
 
         @inlinable
-        init(dataType: PostgresDataType, format: PostgresFormat, protected: Bool) {
+        init(dataType: PostgresDataType, format: PostgresFormat, protected: Bool, dataTypeName: String? = nil) {
             self.dataType = dataType
             self.format = format
             self.protected = protected
+            self.dataTypeName = dataTypeName
         }
 
         @inlinable
         init<Value: PostgresThrowingDynamicTypeEncodable>(value: Value, protected: Bool) {
-            self.init(dataType: value.psqlType, format: value.psqlFormat, protected: protected)
+            self.init(dataType: value.psqlType, format: value.psqlFormat, protected: protected, dataTypeName: value.psqlTypeName)
         }
     }
 

--- a/Sources/PostgresNIO/Pool/ConnectionFactory.swift
+++ b/Sources/PostgresNIO/Pool/ConnectionFactory.swift
@@ -90,6 +90,7 @@ final class ConnectionFactory: Sendable {
         connectionConfig.options.tlsServerName = config.options.tlsServerName
         connectionConfig.options.requireBackendKeyData = config.options.requireBackendKeyData
         connectionConfig.options.additionalStartupParameters = config.options.additionalStartupParameters
+        connectionConfig.options.additionalDataTypeNames = config.options.additionalDataTypeNames
 
         return connectionConfig
     }

--- a/Sources/PostgresNIO/Pool/PostgresClient.swift
+++ b/Sources/PostgresNIO/Pool/PostgresClient.swift
@@ -110,6 +110,10 @@ public final class PostgresClient: Sendable, ServiceLifecycle.Service {
             /// startup message that the client sends to the server.
             public var additionalStartupParameters: [(String, String)] = []
 
+            /// The names of additional Postgres data types whose object identifiers (OIDs) shall be resolved while
+            /// a connection is established.
+            public var additionalDataTypeNames: [String] = []
+
             /// The minimum number of connections that the client shall keep open at any time, even if there is no
             /// demand. Defaults to `0`.
             ///

--- a/Tests/IntegrationTests/PostgresClientTests.swift
+++ b/Tests/IntegrationTests/PostgresClientTests.swift
@@ -346,6 +346,148 @@ final class PostgresClientTests: XCTestCase {
         }
     }
 
+    /// Ensures the `ltree` extension exists, using a client that does *not* resolve additional data types.
+    ///
+    /// A client configured with `additionalDataTypeNames = ["ltree"]` cannot be used for this: the OID is
+    /// resolved while the connection is being established, so a connection opened before the extension
+    /// exists caches an empty lookup table and keeps using it for every later query on that connection.
+    private func ensureLTreeExtension(eventLoopGroup: any EventLoopGroup, logger: Logger) async throws {
+        let client = PostgresClient(
+            configuration: .makeTestConfiguration(),
+            eventLoopGroup: eventLoopGroup,
+            backgroundLogger: logger
+        )
+
+        try await withThrowingTaskGroup(of: Void.self) { taskGroup in
+            taskGroup.addTask {
+                await client.run()
+            }
+
+            try await client.query("CREATE EXTENSION IF NOT EXISTS ltree;")
+
+            taskGroup.cancelAll()
+        }
+    }
+
+    func testLTreeBindRoundTrip() async throws {
+        let tableName = "test_client_ltree_bind"
+
+        var mlogger = Logger(label: "test")
+        mlogger.logLevel = .debug
+        let logger = mlogger
+        let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 8)
+        self.addTeardownBlock {
+            try await eventLoopGroup.shutdownGracefully()
+        }
+
+        try await self.ensureLTreeExtension(eventLoopGroup: eventLoopGroup, logger: logger)
+
+        var clientConfig = PostgresClient.Configuration.makeTestConfiguration()
+        clientConfig.options.additionalDataTypeNames = ["ltree"]
+        let client = PostgresClient(configuration: clientConfig, eventLoopGroup: eventLoopGroup, backgroundLogger: logger)
+
+        try await withThrowingTaskGroup(of: Void.self) { taskGroup in
+            taskGroup.addTask {
+                await client.run()
+            }
+
+            try await client.query("DROP TABLE IF EXISTS \"\(unescaped: tableName)\";")
+
+            try await client.query(
+                """
+                CREATE TABLE IF NOT EXISTS "\(unescaped: tableName)" (
+                    id SERIAL PRIMARY KEY,
+                    label ltree NOT NULL
+                );
+                """
+            )
+
+            let inserted = PostgresLTree(labels: ["foo", "bar", "baz"])
+
+            try await client.query(
+                """
+                INSERT INTO "\(unescaped: tableName)" (label) VALUES (\(inserted))
+                """
+            )
+
+            let rows = try await client.query(
+                """
+                SELECT label FROM "\(unescaped: tableName)" WHERE label ~ 'foo.*'
+                """
+            )
+
+            var decoded = [PostgresLTree]()
+            for try await label in rows.decode(PostgresLTree.self) {
+                decoded.append(label)
+            }
+            XCTAssertEqual(decoded, [inserted])
+
+            taskGroup.cancelAll()
+        }
+    }
+
+    func testLTreeBindInTypeAmbiguousContext() async throws {
+        var mlogger = Logger(label: "test")
+        mlogger.logLevel = .debug
+        let logger = mlogger
+        let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 8)
+        self.addTeardownBlock {
+            try await eventLoopGroup.shutdownGracefully()
+        }
+
+        try await self.ensureLTreeExtension(eventLoopGroup: eventLoopGroup, logger: logger)
+
+        var clientConfig = PostgresClient.Configuration.makeTestConfiguration()
+        clientConfig.options.additionalDataTypeNames = ["ltree"]
+        let client = PostgresClient(configuration: clientConfig, eventLoopGroup: eventLoopGroup, backgroundLogger: logger)
+
+        try await withThrowingTaskGroup(of: Void.self) { taskGroup in
+            taskGroup.addTask {
+                await client.run()
+            }
+
+            let value = PostgresLTree(labels: ["foo", "bar", "baz"])
+
+            let rows = try await client.query("SELECT \(value)")
+
+            var decoded = [PostgresLTree]()
+            for try await label in rows.decode(PostgresLTree.self) {
+                decoded.append(label)
+            }
+            XCTAssertEqual(decoded, [value])
+
+            taskGroup.cancelAll()
+        }
+    }
+
+    func testUnknownAdditionalDataTypeName() async throws {
+        var mlogger = Logger(label: "test")
+        mlogger.logLevel = .debug
+        let logger = mlogger
+        let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 8)
+        self.addTeardownBlock {
+            try await eventLoopGroup.shutdownGracefully()
+        }
+
+        var clientConfig = PostgresClient.Configuration.makeTestConfiguration()
+        clientConfig.options.additionalDataTypeNames = ["this_type_does_not_exist"]
+        let client = PostgresClient(configuration: clientConfig, eventLoopGroup: eventLoopGroup, backgroundLogger: logger)
+
+        await withThrowingTaskGroup(of: Void.self) { taskGroup in
+            taskGroup.addTask {
+                await client.run()
+            }
+
+            do {
+                _ = try await client.query("SELECT 1")
+            } catch {
+                XCTFail("The connection should continue if the type can't be found")
+            }
+
+            taskGroup.cancelAll()
+        }
+    }
+
 }
 
 @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)

--- a/Tests/PostgresNIOTests/New/Data/PostgresLTree+PSQLCodableTests.swift
+++ b/Tests/PostgresNIOTests/New/Data/PostgresLTree+PSQLCodableTests.swift
@@ -1,0 +1,121 @@
+import NIOCore
+import Testing
+
+@testable import PostgresNIO
+
+@Suite struct PostgresLTree_PSQLCodableTests {
+    @Test func testInitFromValues() throws {
+        let ltree = PostgresLTree(labels: ["Top", "Science", "Astronomy"])
+        #expect(ltree.labels == ["Top", "Science", "Astronomy"])
+        #expect(ltree.description == "Top.Science.Astronomy")
+    }
+
+    @Test func testInitFromStringSplitsOnDots() {
+        let ltree = PostgresLTree("Top.Science.Astronomy")
+        #expect(ltree.labels == ["Top", "Science", "Astronomy"])
+    }
+
+    @Test func testSingleLabel() {
+        let ltree = PostgresLTree("Top")
+        #expect(ltree.labels == ["Top"])
+        #expect(ltree.description == "Top")
+    }
+
+    @Test func testStringRoundTrip() {
+        let paths = ["Top", "Top.Science", "Top.Science.Astronomy.Astrophysics", "a-b.c_d.e0"]
+        for path in paths {
+            let ltree = PostgresLTree(path)
+            #expect(ltree.description == path)
+        }
+    }
+
+    @Test func testParsing() {
+        #expect(PostgresLTree("Top.Science.Astronomy").labels == ["Top", "Science", "Astronomy"])
+        #expect(PostgresLTree("Top").labels == ["Top"])
+        #expect(PostgresLTree("").labels == [])
+
+        #expect(PostgresLTree("a..b").labels == ["a", "b"])
+        #expect(PostgresLTree("a.b.").labels == ["a", "b"])
+        #expect(PostgresLTree(".a.b").labels == ["a", "b"])
+    }
+
+    @Test func testEmptyPath() throws {
+        let empty = PostgresLTree(labels: [])
+        #expect(empty.description == "")
+
+        var buffer = ByteBuffer()
+        empty.encode(into: &buffer, context: .default)
+        #expect(buffer.readableBytes == 0)
+
+        let decoded = try PostgresLTree(from: &buffer, type: .text, format: .text, context: .default)
+        #expect(decoded == empty)
+        #expect(decoded.labels == [])
+    }
+
+    @Test func testAppend() throws {
+        var ltree = PostgresLTree(labels: ["Top", "Science"])
+        ltree.append("Astronomy")
+        #expect(ltree.labels == ["Top", "Science", "Astronomy"])
+        #expect(ltree.description == "Top.Science.Astronomy")
+    }
+
+    @Test func testPop() throws {
+        var ltree = PostgresLTree(labels: ["Top", "Science", "Astronomy"])
+        #expect(ltree.popLast() == "Astronomy")
+        #expect(ltree.labels == ["Top", "Science"])
+        #expect(ltree.popLast() == "Science")
+        #expect(ltree.popLast() == "Top")
+        #expect(ltree.popLast() == nil)
+        #expect(ltree.labels == [])
+    }
+
+    @Test func testEncodeAsText() throws {
+        let ltree = PostgresLTree(labels: ["Top", "Science", "Astronomy"])
+
+        #expect(ltree.psqlType == .null)
+        #expect(ltree.psqlFormat == .text)
+        #expect(ltree.psqlTypeName == "ltree")
+
+        var buffer = ByteBuffer()
+        ltree.encode(into: &buffer, context: .default)
+        #expect(buffer.getString(at: buffer.readerIndex, length: buffer.readableBytes) == "Top.Science.Astronomy")
+    }
+
+    @Test func testEncodeDecodeRoundTripAsText() throws {
+        let ltree = PostgresLTree(labels: ["Top", "Science", "Astronomy"])
+
+        var buffer = ByteBuffer()
+        ltree.encode(into: &buffer, context: .default)
+
+        let decoded = try PostgresLTree(from: &buffer, type: .text, format: .text, context: .default)
+        #expect(decoded == ltree)
+    }
+
+    @Test func testDecodeFromBinary() throws {
+        var buffer = ByteBuffer()
+        buffer.writeInteger(Int8(1))
+        buffer.writeString("Top.Science.Astronomy")
+
+        let ltree = try PostgresLTree(from: &buffer, type: .text, format: .binary, context: .default)
+        #expect(ltree.labels == ["Top", "Science", "Astronomy"])
+    }
+
+    @Test func testDecodeFromText() throws {
+        var buffer = ByteBuffer()
+        buffer.writeString("Top.Science.Astronomy")
+
+        let ltree = try PostgresLTree(from: &buffer, type: .text, format: .text, context: .default)
+        #expect(ltree.labels == ["Top", "Science", "Astronomy"])
+    }
+
+    @Test func testDecodeFailureOnUnknownBinaryVersion() {
+        var buffer = ByteBuffer()
+        buffer.writeInteger(Int8(2))
+        buffer.writeString("Top.Science.Astronomy")
+
+        let error = #expect(throws: PostgresDecodingError.Code.self) {
+            try PostgresLTree(from: &buffer, type: .text, format: .binary, context: .default)
+        }
+        #expect(error == .failure)
+    }
+}


### PR DESCRIPTION
Relies on #652 

This adds a `PostgresLTree` type. Since `ltree` is used via an extension it has a dynamic OID. This means that each time the extension is installed it has a different OID, and without an OID (i.e using `0` as OID) we let Postgres infer the type in queries, rather than explicitly defining it ourselves like we do with types that have a statically known OID. This can lead to situations where the query fails when Postgres cannot infer the type correctly.
Therefore, this PR also adds a mechanism for users to define extra types they want to use. 
It does this by adding a 
```swift
clientConfig.options.additionalDataTypeNames = ["ltree"]
```
property on `PostgresClient.Configuration`. When this array is not empty, a query will run when each connection is established to resolve the OIDs for the types defined in the array. If the type can't be resolved (i.e if there's a non-existing type) or the query fails, the connection will still be created and a message will be logged. If the query succeeds, the name-OID entry will be stored on the connection, so each query using that type will have the correct OID. Also, the query runs before the connection is marked as ready to be used.
This also means that types created _after_ the connection was established won't be recorded on the connection, so users should run their extension creation before creating PostgresClient connections. 
 By default the array is empty and the extra query will not be run, so users not running any extra types won't be impacted. 
To correctly map Swift types to the types defined in the property, `PostgresThrowingDynamicTypeEncodable ` now offers a `psqlTypeName: String?` property (defaulting to `nil`) that Swift types can implement to use the extra type in queries.