### PR TITLE
feat(PostgresConnection): Add 'prepareChannel' for freeform channel usage

### DIFF
--- a/Sources/PostgresNIO/Connection/PostgresConnection.swift
+++ b/Sources/PostgresNIO/Connection/PostgresConnection.swift
@@ -58,11 +58,61 @@ public final class PostgresConnection: @unchecked Sendable {
         assert(self.isClosed, "PostgresConnection deinitialized before being closed.")
     }
 
+    /// Connect to the Postgres server described by `configuration` — negotiate
+    /// TLS (if configured), send the startup message, and authenticate — then
+    /// remove PostgresNIO's handlers, returning the authenticated channel for the
+    /// caller to drive with its own pipeline. Any TLS handler and the socket are
+    /// left in place; only PostgresNIO's own protocol handlers are removed. This
+    /// lets a caller reuse PostgresNIO's TCP/TLS/startup/authentication (including
+    /// SCRAM-SHA-256) and then speak a protocol PostgresNIO does not implement —
+    /// for example, streaming replication.
+    public static func establishAndAuthChannelWithoutPostgresHandler(
+        using configuration: Configuration,
+        on eventLoop: any EventLoop,
+        logger: Logger
+    ) -> EventLoopFuture<any Channel> {
+        let configuration = InternalConfiguration(configuration)
+        return eventLoop.flatSubmit {
+            Self.makeChannel(on: eventLoop, configuration: configuration).flatMap { channel in
+                Self.installHandlersAndStartup(
+                    on: channel,
+                    configuration: configuration,
+                    logger: logger
+                ).flatMap { () -> EventLoopFuture<any Channel> in
+                    do {
+                        let pipeline = channel.pipeline.syncOperations
+                        let channelHandler = try pipeline.context(handlerType: PostgresChannelHandler.self)
+                        let eventsHandler = try pipeline.context(handlerType: PSQLEventsHandler.self)
+                        return pipeline.removeHandler(context: channelHandler)
+                            .and(pipeline.removeHandler(context: eventsHandler))
+                            .map { _ in channel }
+                    } catch {
+                        return channel.eventLoop.makeFailedFuture(error)
+                    }
+                }
+            }
+        }
+    }
+
     func start(configuration: InternalConfiguration) -> EventLoopFuture<Void> {
+        Self.installHandlersAndStartup(on: self.channel, configuration: configuration, logger: self.logger)
+    }
+
+    /// Install PostgresNIO's channel handlers on `channel` (a TLS handler first,
+    /// if configured), send the startup message, and authenticate; the returned
+    /// future succeeds once the connection reaches `ReadyForQuery`.
+    ///
+    /// Must be called on `channel.eventLoop`. Shared bring-up for
+    /// ``start(configuration:)`` and ``establishAndAuthChannelWithoutPostgresHandler(using:on:logger:)``.
+    static func installHandlersAndStartup(
+        on channel: any Channel,
+        configuration: InternalConfiguration,
+        logger: Logger
+    ) -> EventLoopFuture<Void> {
         // 1. configure handlers
 
         let configureSSLCallback: ((any Channel, PostgresChannelHandler) throws -> ())?
-        
+
         switch configuration.tls.base {
         case .prefer(let context), .require(let context):
             configureSSLCallback = { channel, postgresChannelHandler in
@@ -90,10 +140,10 @@ public final class PostgresConnection: @unchecked Sendable {
         // 2. add handlers
 
         do {
-            try self.channel.pipeline.syncOperations.addHandler(eventHandler)
-            try self.channel.pipeline.syncOperations.addHandler(channelHandler, position: .before(eventHandler))
+            try channel.pipeline.syncOperations.addHandler(eventHandler)
+            try channel.pipeline.syncOperations.addHandler(channelHandler, position: .before(eventHandler))
         } catch {
-            return self.eventLoop.makeFailedFuture(error)
+            return channel.eventLoop.makeFailedFuture(error)
         }
 
         let startupFuture: EventLoopFuture<Void>
@@ -109,7 +159,7 @@ public final class PostgresConnection: @unchecked Sendable {
             // in case of an startup error, the connection must be closed and after that
             // the originating error should be surfaced
 
-            self.channel.closeFuture.flatMapThrowing { _ in
+            channel.closeFuture.flatMapThrowing { _ in
                 throw error
             }
         }
@@ -161,26 +211,7 @@ public final class PostgresConnection: @unchecked Sendable {
         // on and the EventLoop. In addition, it eliminates all potential races between the creating
         // thread and the EventLoop.
         let future = eventLoop.flatSubmit { () -> EventLoopFuture<PostgresConnection> in
-            let connectFuture: EventLoopFuture<any Channel>
-
-            switch configuration.connection {
-            case .resolved(let address):
-                let bootstrap = self.makeBootstrap(on: eventLoop, configuration: configuration)
-                connectFuture = bootstrap.connect(to: address)
-            case .unresolvedTCP(let host, let port):
-                let bootstrap = self.makeBootstrap(on: eventLoop, configuration: configuration)
-                connectFuture = bootstrap.connect(host: host, port: port)
-            case .unresolvedUDS(let path):
-                let bootstrap = self.makeBootstrap(on: eventLoop, configuration: configuration)
-                connectFuture = bootstrap.connect(unixDomainSocketPath: path)
-            case .bootstrapped(let channel):
-                guard channel.isActive else {
-                    return eventLoop.makeFailedFuture(PSQLError.connectionError(underlying: ChannelError.alreadyClosed))
-                }
-                connectFuture = eventLoop.makeSucceededFuture(channel)
-            }
-
-            return connectFuture.flatMap { channel -> EventLoopFuture<PostgresConnection> in
+            return self.makeChannel(on: eventLoop, configuration: configuration).flatMap { channel -> EventLoopFuture<PostgresConnection> in
                 // 1. check if the connection request was cancelled in the mean time.
                 if let closeFuture = cancelHandler.channelConnected(channel) {
                     return closeFuture.flatMapThrowing { throw CancellationError() }
@@ -240,6 +271,25 @@ public final class PostgresConnection: @unchecked Sendable {
         }
 
         fatalError("No matching bootstrap found")
+    }
+
+    private static func makeChannel(
+        on eventLoop: any EventLoop,
+        configuration: InternalConfiguration
+    ) -> EventLoopFuture<any Channel> {
+        switch configuration.connection {
+        case .resolved(let address):
+            return self.makeBootstrap(on: eventLoop, configuration: configuration).connect(to: address)
+        case .unresolvedTCP(let host, let port):
+            return self.makeBootstrap(on: eventLoop, configuration: configuration).connect(host: host, port: port)
+        case .unresolvedUDS(let path):
+            return self.makeBootstrap(on: eventLoop, configuration: configuration).connect(unixDomainSocketPath: path)
+        case .bootstrapped(let channel):
+            guard channel.isActive else {
+                return eventLoop.makeFailedFuture(PSQLError.connectionError(underlying: ChannelError.alreadyClosed))
+            }
+            return eventLoop.makeSucceededFuture(channel)
+        }
     }
 
     // MARK: Query

--- a/Sources/PostgresNIO/New/PSQLEventsHandler.swift
+++ b/Sources/PostgresNIO/New/PSQLEventsHandler.swift
@@ -21,7 +21,7 @@ enum PSQLEvent {
 }
 
 
-final class PSQLEventsHandler: ChannelInboundHandler {
+final class PSQLEventsHandler: ChannelInboundHandler, RemovableChannelHandler {
     typealias InboundIn = Never
     
     let logger: Logger

--- a/Sources/PostgresNIO/New/PostgresChannelHandler.swift
+++ b/Sources/PostgresNIO/New/PostgresChannelHandler.swift
@@ -3,7 +3,7 @@ import NIOTLS
 import Crypto
 import Logging
 
-final class PostgresChannelHandler: ChannelDuplexHandler {
+final class PostgresChannelHandler: ChannelDuplexHandler, RemovableChannelHandler {
     typealias OutboundIn = HandlerTask
     typealias InboundIn = ByteBuffer
     typealias OutboundOut = ByteBuffer

--- a/Tests/PostgresNIOTests/New/PostgresConnectionTests.swift
+++ b/Tests/PostgresNIOTests/New/PostgresConnectionTests.swift
@@ -85,6 +85,43 @@ import Synchronization
         try await connection.close()
     }
 
+    @Test func testEstablishAndAuthChannelWithoutPostgresHandlerRemovesPostgresHandlers() async throws {
+        let eventLoop = NIOAsyncTestingEventLoop()
+        let channel = try await NIOAsyncTestingChannel(loop: eventLoop) { channel in
+            try channel.pipeline.syncOperations.addHandlers(ReverseByteToMessageHandler(PSQLFrontendMessageDecoder()))
+            try channel.pipeline.syncOperations.addHandlers(ReverseMessageToByteHandler(PSQLBackendMessageEncoder()))
+        }
+        try await channel.connect(to: .makeAddressResolvingHost("localhost", port: 5432))
+
+        let configuration = PostgresConnection.Configuration(
+            establishedChannel: channel,
+            username: "username",
+            password: "postgres",
+            database: "database"
+        )
+
+        async let preparedChannelPromise = PostgresConnection.establishAndAuthChannelWithoutPostgresHandler(using: configuration, on: eventLoop, logger: self.logger).get()
+        let message = try await channel.waitForOutboundWrite(as: PostgresFrontendMessage.self)
+        #expect(message == .startup(.versionThree(parameters: .init(user: "username", database: "database", options: [], replication: .false))))
+        try await channel.writeInbound(PostgresBackendMessage.authentication(.ok))
+        try await channel.writeInbound(PostgresBackendMessage.backendKeyData(.init(processID: 1234, secretKey: 5678)))
+        try await channel.writeInbound(PostgresBackendMessage.readyForQuery(.idle))
+
+        let preparedChannel = try await preparedChannelPromise
+        #expect(preparedChannel === channel)
+
+        // The whole point of `establishAndAuthChannelWithoutPostgresHandler` is to hand back an authenticated channel
+        // with PostgresNIO's own protocol handlers removed, so the caller can drive it with a pipeline of their own.
+        await #expect(throws: (any Error).self) {
+            try await channel.pipeline.context(handlerType: PostgresChannelHandler.self).map { _ in }.get()
+        }
+        await #expect(throws: (any Error).self) {
+            try await channel.pipeline.context(handlerType: PSQLEventsHandler.self).map { _ in }.get()
+        }
+
+        try await channel.close()
+    }
+
     @available(*, deprecated, message: "Deprecated, as it tests a deprecated method.")
     @Test func testSimpleListen() async throws {
         try await self.withAsyncTestingChannel { connection, channel in


### PR DESCRIPTION
This allows users to piggyback on PostgresConnection's channel setup/initialization so that they don't have to reimplement TCP/TLS/startup/authentication/etc in order to make a custom channel handler over a Postgres connection. 

At the time of this writing, the specific use case this is intended to enable is streaming replication.

This is in-line with the suggestion made [here](https://github.com/vapor/postgres-nio/issues/522) (specifically, that replication doesn't belong within postgres-nio and should instead be implemented as a separate library or fork).

These changes are meant to support my implementation of a separate library for streaming replication while making as much reuse as possible from prior art.