### PR TITLE
Allow new connection creation to drain queue during graceful shutdown

### DIFF
--- a/Sources/ConnectionPoolModule/PoolStateMachine+ConnectionGroup.swift
+++ b/Sources/ConnectionPoolModule/PoolStateMachine+ConnectionGroup.swift
@@ -177,6 +177,14 @@ extension PoolStateMachine {
         }
 
         @inlinable
+        mutating func createReplacementConnectionIfPossible() -> ConnectionRequest? {
+            guard self.maximumConcurrentConnectionSoftLimit > self.stats.active else {
+                return nil
+            }
+            return self.createNewConnection()
+        }
+
+        @inlinable
         /*private*/ mutating func createNewConnection() -> ConnectionRequest {
             precondition(self.canGrow)
             self.stats.connecting += 1

--- a/Sources/ConnectionPoolModule/PoolStateMachine.swift
+++ b/Sources/ConnectionPoolModule/PoolStateMachine.swift
@@ -266,6 +266,14 @@ struct PoolStateMachine<
 
     @inlinable
     mutating func leaseConnection(_ request: Request) -> Action {
+        if self.gracefulShutdownTriggered {
+            // we're in the process of shutting down, reject new requests
+            return .init(
+                request: .failRequest(request, ConnectionPoolError.poolShutdown),
+                connection: .none
+            )
+        }
+
         switch self.poolState {
         case .running:
             // if requestQueue is non-empty and we cannot create more connections add
@@ -441,6 +449,20 @@ struct PoolStateMachine<
 
     @inlinable
     mutating func connectionEstablishFailed(_ error: any Error, for request: ConnectionRequest) -> Action {
+        if self.gracefulShutdownTriggered, self.requestQueue.isEmpty {
+            let timerToCancel = self.connections.destroyFailedConnection(request.connectionID)
+            let connectionAction: ConnectionAction
+
+            if self.connections.isEmpty {
+                self.poolState = .shutDown
+                connectionAction = .cancelEventStreamAndFinalCleanup(timerToCancel.flatMap { [$0] } ?? [])
+            } else {
+                connectionAction = .cancelTimers(timerToCancel.map {[$0]} ?? [])
+            }
+
+            return .init(request: .none, connection: connectionAction)
+        }
+
         switch self.poolState {
         case .running:
             self.poolState = .connectionCreationFailing(
@@ -664,11 +686,40 @@ struct PoolStateMachine<
 
     @inlinable
     mutating func connectionClosed(_ connection: Connection) -> Action {
+        if gracefulShutdownTriggered {
+            self.cacheNoMoreConnectionsAllowed = false
+
+            let closedConnectionAction = self.connections.connectionClosed(connection.id, shuttingDown: true)
+
+            let connectionAction: ConnectionAction
+            if self.connections.isEmpty {
+                if !requestQueue.isEmpty {
+                    // if the request queue is not empty we need a new connection
+                    guard let newConnection = self.connections.createReplacementConnectionIfPossible() else {
+                        // if we can't make new connections, fail the queue
+                        self.poolState = .shutDown
+                        return .init(
+                            request: .failRequests(requestQueue.removeAll(), .poolShutdown),
+                            connection: .cancelEventStreamAndFinalCleanup(.init(closedConnectionAction.timersToCancel))
+                        )
+                    }
+                    connectionAction = .makeConnection(newConnection, closedConnectionAction.timersToCancel)
+                } else {
+                    self.poolState = .shutDown
+                    connectionAction = .cancelEventStreamAndFinalCleanup(.init(closedConnectionAction.timersToCancel))
+                }
+            } else {
+                connectionAction = .cancelTimers(closedConnectionAction.timersToCancel)
+            }
+
+            return .init(request: .none, connection: connectionAction)
+        }
+
         switch self.poolState {
         case .running, .connectionCreationFailing, .circuitBreakOpen:
             self.cacheNoMoreConnectionsAllowed = false
 
-            let closedConnectionAction = self.connections.connectionClosed(connection.id, shuttingDown: self.gracefulShutdownTriggered)
+            let closedConnectionAction = self.connections.connectionClosed(connection.id, shuttingDown: false)
 
             let connectionAction: ConnectionAction
             if let newRequest = closedConnectionAction.newConnectionRequest {
@@ -717,22 +768,27 @@ struct PoolStateMachine<
 
     @usableFromInline
     mutating func triggerGracefulShutdown() -> Action {
+        if gracefulShutdownTriggered {
+            return .none()
+        }
+
         switch self.poolState {
         case .running, .connectionCreationFailing, .circuitBreakOpen:
-            self.poolState = .shuttingDown
             self.gracefulShutdownTriggered = true
 
-            var shutdown = ConnectionAction.Shutdown()
-            self.connections.triggerGracefulShutdown(&shutdown)
+            if !self.requestQueue.isEmpty {
+                return .init(request: .none, connection: .none)
+            }
 
             let requestAction: RequestAction
             let connectionAction: ConnectionAction
+
+            var shutdown = ConnectionAction.Shutdown()
+            self.connections.triggerGracefulShutdown(&shutdown)
             if self.connections.isEmpty, shutdown.connections.isEmpty {
-                // `triggerGracefulShutdown` moves closed connections out of `self.connections` into
-                // `shutdown.connections`, so both being empty means there's no more connections,
-                // so queued requests can never be served and we should fail them immediately.
+                // no more requests and no more connections. close
                 self.poolState = .shutDown
-                requestAction = .failRequests(self.requestQueue.removeAll(), ConnectionPoolError.poolShutdown)
+                requestAction = .none
                 connectionAction = .cancelEventStreamAndFinalCleanup(shutdown.timersToCancel)
             } else if shutdown.connections.isEmpty, shutdown.timersToCancel.isEmpty {
                 // Nothing to close or cancel right now: all remaining connections are leased or
@@ -755,37 +811,36 @@ struct PoolStateMachine<
 
     @usableFromInline
     mutating func triggerForceShutdown() -> Action {
-        switch self.poolState {
-        case .shutDown:
-            return .init(request: .none, connection: .none)
-        
-        case .shuttingDown where self.gracefulShutdownTriggered:
+        if gracefulShutdownTriggered {
             // Graceful shutdown is in progress, escalate to force shutdown.
             self.gracefulShutdownTriggered = false
+        }
+
+        switch self.poolState {
+        case .running, .connectionCreationFailing, .circuitBreakOpen:
+            self.poolState = .shuttingDown
+            var shutdown = ConnectionAction.Shutdown()
+            self.connections.triggerForceShutdown(&shutdown)
+
+            if self.connections.isEmpty, shutdown.connections.isEmpty {
+                self.poolState = .shutDown
+                return .init(
+                    request: .failRequests(self.requestQueue.removeAll(), ConnectionPoolError.poolShutdown),
+                    connection: .cancelEventStreamAndFinalCleanup(shutdown.timersToCancel)
+                )
+            }
+
+            return .init(
+                request: .failRequests(self.requestQueue.removeAll(), ConnectionPoolError.poolShutdown),
+                connection: .initiateShutdown(shutdown)
+            )
+
+        case .shutDown:
+            return .init(request: .none, connection: .none)
 
         case .shuttingDown:
             return .none()
-
-        case .running, .connectionCreationFailing, .circuitBreakOpen:
-            break
         }
-
-        self.poolState = .shuttingDown
-        var shutdown = ConnectionAction.Shutdown()
-        self.connections.triggerForceShutdown(&shutdown)
-
-        if self.connections.isEmpty, shutdown.connections.isEmpty {
-            self.poolState = .shutDown
-            return .init(
-                request: .failRequests(self.requestQueue.removeAll(), ConnectionPoolError.poolShutdown),
-                connection: .cancelEventStreamAndFinalCleanup(shutdown.timersToCancel)
-            )
-        }
-
-        return .init(
-            request: .failRequests(self.requestQueue.removeAll(), ConnectionPoolError.poolShutdown),
-            connection: .initiateShutdown(shutdown)
-        )
     }
 
     @inlinable
@@ -830,7 +885,7 @@ struct PoolStateMachine<
                 return .none()
 
             case .idle(_, let newIdle):
-                if case .shuttingDown = self.poolState {
+                if gracefulShutdownTriggered || self.isShuttingDown {
                     switch self.connections.closeConnection(at: index, deleteConnection: true) {
                     case .close(let closeAction):
                         return .init(
@@ -916,6 +971,12 @@ struct PoolStateMachine<
     // Is connection pool shutdown.
     public var isShutdown: Bool { 
         if case .shutDown = self.poolState { return true }
+        return false
+    }
+
+    @usableFromInline
+    var isShuttingDown: Bool {
+        if case .shuttingDown = self.poolState { return true }
         return false
     }
 }

--- a/Tests/ConnectionPoolModuleTests/PoolStateMachineTests.swift
+++ b/Tests/ConnectionPoolModuleTests/PoolStateMachineTests.swift
@@ -706,6 +706,95 @@ typealias TestPoolStateMachine = PoolStateMachine<
     }
 
     @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
+    @Test func testTriggerGracefulShutdownCreatesReplacementWhenConnectionDies() {
+        var configuration = PoolConfiguration()
+        configuration.minimumConnectionCount = 0
+        // so a second request must queue
+        configuration.maximumConnectionSoftLimit = 1
+        configuration.maximumConnectionHardLimit = 1
+        configuration.keepAliveDuration = nil
+
+        var stateMachine = TestPoolStateMachine(
+            configuration: configuration,
+            generator: .init(),
+            timerCancellationTokenType: MockTimerCancellationToken.self,
+            clock: MockClock()
+        )
+
+        // create connection and make it busy
+        let mockRequest1 = MockRequest(connectionType: MockConnection.self)
+        let leaseAction = stateMachine.leaseConnection(mockRequest1)
+        guard case .makeConnection = leaseAction.connection else {
+            Issue.record()
+            return
+        }
+        let connection = MockConnection(id: 0)
+        #expect(stateMachine.connectionEstablished(connection, maxStreams: 1).request == .leaseConnection(.init(element: mockRequest1), connection))
+
+        // add request which will be enqueued
+        let mockRequest2 = MockRequest(connectionType: MockConnection.self)
+        #expect(stateMachine.leaseConnection(mockRequest2) == .none())
+        
+        // trigger shutdown
+        #expect(stateMachine.triggerGracefulShutdown() == .none())
+
+        // kill existing connection and verify a new one is spun up
+        let closeConnectionAction = stateMachine.connectionClosed(connection)
+        #expect(closeConnectionAction.request == .none)
+        guard case .makeConnection(let newConnectionRequest, _) = closeConnectionAction.connection else {
+            Issue.record("New connection wasn't created even though there's work left to do")
+            return
+        }
+        let mockConnection2 = MockConnection(id: newConnectionRequest.connectionID)
+        #expect(stateMachine.connectionEstablished(mockConnection2, maxStreams: 1).request == .leaseConnection([mockRequest2], mockConnection2))
+        #expect(stateMachine.connections.connections.count == 1)
+        
+        // complete work and verify shutdown
+        #expect(stateMachine.releaseConnection(mockConnection2, streams: 1).connection == .closeConnection(mockConnection2, []))
+        #expect(stateMachine.connectionClosed(mockConnection2).connection == .cancelEventStreamAndFinalCleanup([]))
+        #expect(stateMachine.isShutdown)
+    }
+
+    @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
+    @Test func testTriggerGracefulShutdownRejectsNewRequests() {
+        var configuration = PoolConfiguration()
+        configuration.minimumConnectionCount = 1
+        configuration.maximumConnectionSoftLimit = 1
+        configuration.maximumConnectionHardLimit = 1
+
+        var stateMachine = TestPoolStateMachine(
+            configuration: configuration,
+            generator: .init(),
+            timerCancellationTokenType: MockTimerCancellationToken.self,
+            clock: .init()
+        )
+
+        // create connection
+        let requests = stateMachine.refillConnections()
+        #expect(requests.count == 1)
+        let connection = MockConnection(id: 0)
+        #expect(stateMachine.connectionEstablished(connection, maxStreams: 1).request == .none)
+
+        // make connection busy
+        let mockRequest1 = MockRequest(connectionType: MockConnection.self)
+        let leaseAction = stateMachine.leaseConnection(mockRequest1)
+        #expect(leaseAction.request == .leaseConnection(.init(element: mockRequest1), connection))
+        #expect(leaseAction.connection == .cancelTimers([]))
+        
+        // trigger shutdown
+        #expect(stateMachine.triggerGracefulShutdown() == .none())
+
+        // verify new request is rejected
+        let mockRequest2 = MockRequest(connectionType: MockConnection.self)
+        #expect(stateMachine.leaseConnection(mockRequest2).request == .failRequest(mockRequest2, .poolShutdown))
+        
+        // verify existing request completes and pool shuts down
+        #expect(stateMachine.releaseConnection(connection, streams: 1).connection == .closeConnection(connection, []))
+        #expect(stateMachine.connectionClosed(connection).connection == .cancelEventStreamAndFinalCleanup([]))
+        #expect(stateMachine.isShutdown)
+    }
+
+    @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
     @Test func testTriggerGracefulShutdownDoesNotInterruptOtherStreams() {
         var configuration = PoolConfiguration()
         configuration.minimumConnectionCount = 1
@@ -838,6 +927,7 @@ typealias TestPoolStateMachine = PoolStateMachine<
 
         let closedAction = stateMachine.connectionClosed(connection1)
         #expect(closedAction.request == .none)
+        #expect(closedAction.connection == .cancelTimers([]))
         #expect(!stateMachine.isShutdown)
 
         #expect(stateMachine.releaseConnection(connection2, streams: 1).request == .leaseConnection(.init(element: mockRequest3), connection2))
@@ -848,44 +938,6 @@ typealias TestPoolStateMachine = PoolStateMachine<
         #expect(stateMachine.isShutdown)
     }
 
-    @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
-    @Test func testTriggerGracefulShutdownFailsQueueWhenLastConnectionCreationFails() {
-        struct ConnectionFailed: Error {}
-        var configuration = PoolConfiguration()
-        configuration.minimumConnectionCount = 0
-        configuration.maximumConnectionSoftLimit = 2
-        configuration.maximumConnectionHardLimit = 2
-        configuration.keepAliveDuration = nil
-        configuration.idleTimeoutDuration = .seconds(3)
-
-        var stateMachine = TestPoolStateMachine(
-            configuration: configuration,
-            generator: .init(),
-            timerCancellationTokenType: MockTimerCancellationToken.self,
-            clock: MockClock()
-        )
-
-        #expect(stateMachine.refillConnections().isEmpty)
-
-        let mockRequest1 = MockRequest(connectionType: MockConnection.self)
-        guard case .makeConnection(let connectionRequest, _) = stateMachine.leaseConnection(mockRequest1).connection else {
-            Issue.record()
-            return
-        }
-
-        #expect(stateMachine.triggerGracefulShutdown() == .none())
-        #expect(!stateMachine.isShutdown)
-
-        let failedAction = stateMachine.connectionEstablishFailed(ConnectionFailed(), for: connectionRequest)
-        switch failedAction.request {
-        case .failRequests(let requests, let error):
-            #expect(Array(requests) == [mockRequest1])
-            #expect(error == .poolShutdown)
-        default:
-            Issue.record("Expected the queued request to be failed, got \(failedAction.request)")
-        }
-        #expect(stateMachine.isShutdown)
-    }
 
     @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
     @Test func testTriggerGracefulShutdownReapsBackingOffConnection() {
@@ -913,7 +965,7 @@ typealias TestPoolStateMachine = PoolStateMachine<
     }
 
     @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
-    @Test func testTriggerGracefulShutdownFailsQueuedRequestsWhenReapingLastBackingOffConnection() {
+    @Test func testTriggerGracefulShutdownKeepsRetryingWhenConnectionCreationFails() {
         struct ConnectionFailed: Error {}
         var configuration = PoolConfiguration()
         configuration.minimumConnectionCount = 0
@@ -931,12 +983,71 @@ typealias TestPoolStateMachine = PoolStateMachine<
 
         #expect(stateMachine.refillConnections().isEmpty)
 
+        // The request triggers a connection creation and is queued until the connection is up.
         let mockRequest1 = MockRequest(connectionType: MockConnection.self)
         guard case .makeConnection(let connectionRequest, _) = stateMachine.leaseConnection(mockRequest1).connection else {
             Issue.record()
             return
         }
 
+        #expect(stateMachine.triggerGracefulShutdown() == .none())
+        #expect(!stateMachine.isShutdown)
+
+        // connection failed: keep trying until either a force shutdown is triggered, or a connection succeeds
+        let failedAction = stateMachine.connectionEstablishFailed(ConnectionFailed(), for: connectionRequest)
+        #expect(failedAction.request == .none)
+        guard case .scheduleTimers(let timers) = failedAction.connection, let backoffTimer = Array(timers).first else {
+            Issue.record("Expected a backoff timer to be scheduled, got \(failedAction.connection)")
+            return
+        }
+        #expect(!stateMachine.isShutdown)
+        let backoffTimerToken = MockTimerCancellationToken(backoffTimer)
+        #expect(stateMachine.timerScheduled(backoffTimer, cancelContinuation: backoffTimerToken) == .none)
+
+        // connection is up again, use it
+        let retryAction = stateMachine.timerTriggered(backoffTimer)
+        #expect(retryAction.request == .none)
+        guard case .makeConnection(let retryRequest, let cancelledTimers) = retryAction.connection else {
+            Issue.record("Expected a retry connection attempt, got \(retryAction.connection)")
+            return
+        }
+        #expect(Array(cancelledTimers) == [backoffTimerToken])
+
+        let connection = MockConnection(id: retryRequest.connectionID)
+        let establishedAction = stateMachine.connectionEstablished(connection, maxStreams: 1)
+        #expect(establishedAction.request == .leaseConnection(.init(element: mockRequest1), connection))
+        #expect(establishedAction.connection == .none)
+
+        #expect(stateMachine.releaseConnection(connection, streams: 1).connection == .closeConnection(connection, []))
+        #expect(stateMachine.connectionClosed(connection).connection == .cancelEventStreamAndFinalCleanup([]))
+        #expect(stateMachine.isShutdown)
+    }
+
+    @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
+    @Test func testTriggerGracefulShutdownKeepsRetryingUntilForceShutdown() {
+        struct ConnectionFailed: Error {}
+        var configuration = PoolConfiguration()
+        configuration.minimumConnectionCount = 0
+        configuration.maximumConnectionSoftLimit = 1
+        configuration.maximumConnectionHardLimit = 1
+        configuration.keepAliveDuration = nil
+        configuration.idleTimeoutDuration = .seconds(3)
+
+        var stateMachine = TestPoolStateMachine(
+            configuration: configuration,
+            generator: .init(),
+            timerCancellationTokenType: MockTimerCancellationToken.self,
+            clock: MockClock()
+        )
+
+        #expect(stateMachine.refillConnections().isEmpty)
+
+        // connection requested but fails
+        let mockRequest1 = MockRequest(connectionType: MockConnection.self)
+        guard case .makeConnection(let connectionRequest, _) = stateMachine.leaseConnection(mockRequest1).connection else {
+            Issue.record()
+            return
+        }
         let failedAction = stateMachine.connectionEstablishFailed(ConnectionFailed(), for: connectionRequest)
         guard case .scheduleTimers(let timers) = failedAction.connection, let backoffTimer = Array(timers).first else {
             Issue.record()
@@ -945,9 +1056,47 @@ typealias TestPoolStateMachine = PoolStateMachine<
         let backoffTimerToken = MockTimerCancellationToken(backoffTimer)
         #expect(stateMachine.timerScheduled(backoffTimer, cancelContinuation: backoffTimerToken) == .none)
 
-        let shutdownAction = stateMachine.triggerGracefulShutdown()
-        #expect(shutdownAction.request == .failRequests(.init(element: mockRequest1), .poolShutdown))
-        #expect(shutdownAction.connection == .cancelEventStreamAndFinalCleanup([backoffTimerToken]))
+        // graceful shutdown should keep connection alive and retrying
+        #expect(stateMachine.triggerGracefulShutdown() == .none())
+        #expect(!stateMachine.isShutdown)
+
+        // new requests are rejected while the drain is in progress
+        let lateRequest = MockRequest(connectionType: MockConnection.self)
+        #expect(stateMachine.leaseConnection(lateRequest).request == .failRequest(lateRequest, .poolShutdown))
+
+        // only force shutdown can complete the shutdown
+        let forceAction = stateMachine.triggerForceShutdown()
+        #expect(forceAction.request == .failRequests(.init(element: mockRequest1), .poolShutdown))
+        #expect(forceAction.connection == .cancelEventStreamAndFinalCleanup([backoffTimerToken]))
+        #expect(stateMachine.isShutdown)
+    }
+
+    @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
+    @Test func testTriggerGracefulShutdownCompletesWhenStartingConnectionFailsWithNoQueuedRequests() {
+        struct ConnectionFailed: Error {}
+        var configuration = PoolConfiguration()
+        configuration.minimumConnectionCount = 1
+        configuration.maximumConnectionSoftLimit = 2
+        configuration.maximumConnectionHardLimit = 2
+        configuration.keepAliveDuration = nil
+        configuration.idleTimeoutDuration = .seconds(3)
+
+        var stateMachine = TestPoolStateMachine(
+            configuration: configuration,
+            generator: .init(),
+            timerCancellationTokenType: MockTimerCancellationToken.self,
+            clock: MockClock()
+        )
+
+        let requests = stateMachine.refillConnections()
+        #expect(requests.count == 1)
+        #expect(stateMachine.triggerGracefulShutdown() == .none())
+        #expect(!stateMachine.isShutdown)
+
+        // no requests to complete so the connection gets closed
+        let failedAction = stateMachine.connectionEstablishFailed(ConnectionFailed(), for: requests[0])
+        #expect(failedAction.request == .none)
+        #expect(failedAction.connection == .cancelEventStreamAndFinalCleanup([]))
         #expect(stateMachine.isShutdown)
     }
 

--- a/Tests/PostgresNIOTests/New/PostgresClientTests.swift
+++ b/Tests/PostgresNIOTests/New/PostgresClientTests.swift
@@ -41,7 +41,7 @@ import Testing
     }
 
     @Test(.timeLimit(.minutes(1)))
-    func gracefulShutdownWaitsForInFlightRequest() async throws {
+    func gracefulShutdownWaitsForInFlightConnectionAttempt() async throws {
         try await withSilentServer { port in
             var config = PostgresClient.Configuration(
                 host: "127.0.0.1",


### PR DESCRIPTION
This is a follow up to #651, in particular this attempts to fix https://github.com/vapor/postgres-nio/pull/651#discussion_r3702117041.
This allows us to open up new connections during graceful shutdown to allow draining the rest of the queue even if open connections fail