### PR TITLE
ConnectionPool: fix stream accounting leaks and mislabeled idle timer

### DIFF
--- a/Sources/ConnectionPoolModule/PoolStateMachine+ConnectionGroup.swift
+++ b/Sources/ConnectionPoolModule/PoolStateMachine+ConnectionGroup.swift
@@ -587,6 +587,12 @@ extension PoolStateMachine {
             case .idle:
                 self.stats.idle -= 1
                 self.stats.closing += 1
+                // The stream used by the running keep-alive was counted in
+                // `leasedStreams` by `keepAliveIfIdle`. It must be returned here: the
+                // connection moves to `.closing`, where nobody subtracts it anymore
+                // (`closed()` from `.closing` reports usedStreams = 0), so it would
+                // stay counted forever and eventually overflow `leasedStreams`.
+                self.stats.leasedStreams -= closeAction.usedStreams
             case .leased:
                 self.stats.leased -= 1
                 self.stats.leasedStreams -= closeAction.usedStreams
@@ -654,6 +660,12 @@ extension PoolStateMachine {
 
             self.stats.runningKeepAlive -= closeAction.runningKeepAlive ? 1 : 0
             self.stats.availableStreams -= closeAction.maxStreams - closeAction.usedStreams
+            // The stream used by a running keep-alive must be returned here: the
+            // connection moves to `.closing`, where `keepAliveSucceeded`/`keepAliveFailed`
+            // are no-ops. The LEASED streams instead stay counted on purpose: they are
+            // subtracted when the outstanding lease is released.
+            let keepAliveStream: UInt16 = (closeAction.runningKeepAlive && self.keepAliveReducesAvailableStreams) ? 1 : 0
+            self.stats.leasedStreams -= keepAliveStream
 
             switch closeAction.previousConnectionState {
             case .idle:

--- a/Sources/ConnectionPoolModule/PoolStateMachine+ConnectionState.swift
+++ b/Sources/ConnectionPoolModule/PoolStateMachine+ConnectionState.swift
@@ -123,7 +123,7 @@ extension PoolStateMachine {
             /// to: `.closing`, `.closed`.
             case draining(Connection, usedStreams: UInt16)
             /// The pool has given the order to the connection to close. Valid transitions to: `.closed`
-            case closing(Connection)
+            case closing(Connection, usedStreams: UInt16)
             /// The connection is closed. Final state.
             case closed
         }
@@ -315,7 +315,12 @@ extension PoolStateMachine {
 
                 if scheduleIdleTimeoutTimer {
                     idleTimerState = self._nextTimer()
-                    idleTimer = ConnectionTimer(timerID: idleTimerState!.timerID, connectionID: self.id, usecase: .keepAlive)
+                    // This is the IDLE TIMEOUT timer: with `usecase: .keepAlive` it ran for
+                    // the keep-alive duration instead of the idle timeout, the idle timeout
+                    // never fired for these connections, and if the timer did fire it was
+                    // dispatched to `keepAliveIfIdle` on a connection that already had a
+                    // keep-alive running → preconditionFailure.
+                    idleTimer = ConnectionTimer(timerID: idleTimerState!.timerID, connectionID: self.id, usecase: .idleTimeout)
                 }
                 self.state = .idle(connection, maxStreams: maxStreams, keepAlive: .scheduled(keepAliveTimer), idleTimer: idleTimerState)
                 return Max2Sequence(idleTimer, nil)
@@ -323,7 +328,12 @@ extension PoolStateMachine {
             case .idle(let connection, let maxStreams, keepAlive: .running(let usingStream), idleTimer: .none):
                 if scheduleIdleTimeoutTimer {
                     idleTimerState = self._nextTimer()
-                    idleTimer = ConnectionTimer(timerID: idleTimerState!.timerID, connectionID: self.id, usecase: .keepAlive)
+                    // This is the IDLE TIMEOUT timer: with `usecase: .keepAlive` it ran for
+                    // the keep-alive duration instead of the idle timeout, the idle timeout
+                    // never fired for these connections, and if the timer did fire it was
+                    // dispatched to `keepAliveIfIdle` on a connection that already had a
+                    // keep-alive running → preconditionFailure.
+                    idleTimer = ConnectionTimer(timerID: idleTimerState!.timerID, connectionID: self.id, usecase: .idleTimeout)
                 }
                 self.state = .idle(connection, maxStreams: maxStreams, keepAlive: .running(usingStream), idleTimer: idleTimerState)
                 return Max2Sequence(keepAliveTimer, idleTimer)
@@ -471,14 +481,20 @@ extension PoolStateMachine {
                 precondition(usedStreams >= returnedStreams)
                 let newUsedStreams = usedStreams - returnedStreams
                 if newUsedStreams == 0 {
-                    self.state = .closing(connection)
+                    self.state = .closing(connection, usedStreams: 0)
                     return .drainingComplete(connection)
                 } else {
                     self.state = .draining(connection, usedStreams: newUsedStreams)
                     return .none
                 }
 
-            case .closing, .closed:
+            case .closing(let connection, let usedStreams):
+                // A lease comes back on a connection the pool already closed: the
+                // streams must be subtracted here too, otherwise they stay counted.
+                self.state = .closing(connection, usedStreams: usedStreams >= returnedStreams ? usedStreams - returnedStreams : 0)
+                return .none
+
+            case .closed:
                 return .none
 
             case .backingOff, .starting, .idle:
@@ -672,7 +688,7 @@ extension PoolStateMachine {
         mutating func closeIfIdle() -> CloseAction? {
             switch self.state {
             case .idle(let connection, let maxStreams, var keepAlive, let idleTimerState):
-                self.state = .closing(connection)
+                self.state = .closing(connection, usedStreams: 0)
                 return CloseAction(
                     connection: connection,
                     previousConnectionState: .idle,
@@ -717,7 +733,7 @@ extension PoolStateMachine {
                 return nil
 
             case .idle(let connection, let maxStreams, var keepAlive, let idleTimerState):
-                self.state = .closing(connection)
+                self.state = .closing(connection, usedStreams: 0)
                 return CloseAction(
                     connection: connection,
                     previousConnectionState: .idle,
@@ -731,7 +747,10 @@ extension PoolStateMachine {
                 )
 
             case .leased(let connection, usedStreams: let usedStreams, maxStreams: let maxStreams, var keepAlive):
-                self.state = .closing(connection)
+                // Streams still leased stay charged to the connection while closing:
+                // they are subtracted on release, or by `closed()` if the connection
+                // dies first. Otherwise they would be lost from the accounting.
+                self.state = .closing(connection, usedStreams: usedStreams)
                 return CloseAction(
                     connection: connection,
                     previousConnectionState: .leased,
@@ -744,7 +763,7 @@ extension PoolStateMachine {
                 )
 
             case .draining(let connection, let usedStreams):
-                self.state = .closing(connection)
+                self.state = .closing(connection, usedStreams: usedStreams)
                 return CloseAction(
                     connection: connection,
                     previousConnectionState: .leased,
@@ -835,18 +854,29 @@ extension PoolStateMachine {
                 return ClosedAction(
                     previousConnectionState: .leased,
                     cancelTimers: .init(),
-                    maxStreams: 0,
+                    // `maxStreams` must not be smaller than `usedStreams`: the group
+                    // computes `availableStreams -= maxStreams - usedStreams` in UInt16.
+                    // The free streams were already removed when the connection was
+                    // marked for close, so nothing is left to remove here: reporting
+                    // maxStreams == usedStreams makes that subtraction exactly zero.
+                    maxStreams: usedStreams,
                     usedStreams: usedStreams,
                     wasRunningKeepAlive: false
                 )
 
-            case .closing:
+            case .closing(_, let usedStreams):
                 self.state = .closed
                 return ClosedAction(
                     previousConnectionState: .closing,
                     cancelTimers: .init(),
-                    maxStreams: 0,
-                    usedStreams: 0,
+                    // Same reason as the `.draining` case above: the available streams
+                    // were already removed at close time, so `maxStreams - usedStreams`
+                    // must be zero, not a UInt16 underflow.
+                    maxStreams: usedStreams,
+                    // Streams still leased on a connection that dies before the release
+                    // must be returned to the accounting: once the connection is removed
+                    // no release will ever be able to subtract them.
+                    usedStreams: usedStreams,
                     wasRunningKeepAlive: false
                 )
             }

--- a/Tests/ConnectionPoolModuleTests/PoolStateMachine+ConnectionGroupTests.swift
+++ b/Tests/ConnectionPoolModuleTests/PoolStateMachine+ConnectionGroupTests.swift
@@ -850,4 +850,167 @@ import Testing
         #expect(info == nil)
         #expect(connections.stats == statsBeforeMaxStreamChange)
     }
+
+    // MARK: - Stream accounting regressions
+
+    /// A failing keep-alive on an idle connection must return the stream it had
+    /// taken. Before the fix the `.idle` branch of `keepAliveFailed` did not
+    /// subtract it: the connection moved to `.closing`, where `closed()` reports
+    /// `usedStreams == 0`, so `leasedStreams` stayed at 1 forever.
+    @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
+    @Test func failingKeepAliveOnIdleConnectionReturnsItsStream() {
+        var connections = TestPoolStateMachine.ConnectionGroup(
+            generator: self.idGenerator,
+            minimumConcurrentConnections: 0,
+            maximumConcurrentConnectionSoftLimit: 4,
+            maximumConcurrentConnectionHardLimit: 4,
+            keepAlive: true,
+            keepAliveReducesAvailableStreams: true
+        )
+
+        guard let request = connections.createNewDemandConnectionIfPossible() else {
+            Issue.record("Expected a connection request")
+            return
+        }
+        let connection = MockConnection(id: request.connectionID)
+        let (index, _) = connections.newConnectionEstablished(connection, maxStreams: 1)
+        _ = connections.parkConnection(at: index, hasBecomeIdle: true)
+
+        #expect(connections.keepAliveIfIdle(connection.id) != nil)
+        #expect(connections.stats == .init(idle: 1, runningKeepAlive: 1, availableStreams: 0, leasedStreams: 1))
+
+        #expect(connections.keepAliveFailed(connection.id) != nil)
+        #expect(connections.stats == .init(closing: 1))
+
+        _ = connections.connectionClosed(connection.id, shuttingDown: false)
+        #expect(connections.isEmpty)
+        #expect(connections.stats == .init())
+    }
+
+    /// Closing a connection whose keep-alive is running must return the keep-alive
+    /// stream too, otherwise it stays counted in `leasedStreams` after the
+    /// connection is gone.
+    @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
+    @Test func closingConnectionWithRunningKeepAliveReturnsItsStream() {
+        var connections = TestPoolStateMachine.ConnectionGroup(
+            generator: self.idGenerator,
+            minimumConcurrentConnections: 0,
+            maximumConcurrentConnectionSoftLimit: 4,
+            maximumConcurrentConnectionHardLimit: 4,
+            keepAlive: true,
+            keepAliveReducesAvailableStreams: true
+        )
+
+        guard let request = connections.createNewDemandConnectionIfPossible() else {
+            Issue.record("Expected a connection request")
+            return
+        }
+        let connection = MockConnection(id: request.connectionID)
+        let (index, _) = connections.newConnectionEstablished(connection, maxStreams: 1)
+        _ = connections.parkConnection(at: index, hasBecomeIdle: true)
+        #expect(connections.keepAliveIfIdle(connection.id) != nil)
+        #expect(connections.stats == .init(idle: 1, runningKeepAlive: 1, availableStreams: 0, leasedStreams: 1))
+
+        guard case .close = connections.closeConnection(at: index, deleteConnection: false) else {
+            Issue.record("Expected the connection to be closed")
+            return
+        }
+        #expect(connections.stats == .init(closing: 1))
+
+        _ = connections.connectionClosed(connection.id, shuttingDown: true)
+        #expect(connections.isEmpty)
+        #expect(connections.stats == .init())
+    }
+
+    /// A connection closed by the pool while a lease is outstanding, that then dies
+    /// before the lease comes back. The leased stream must be returned by `closed()`:
+    /// once the connection is removed from the group, the late `releaseConnection`
+    /// finds no connection and can subtract nothing.
+    @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
+    @Test func connectionDyingWhileClosingReturnsItsLeasedStreams() {
+        var connections = TestPoolStateMachine.ConnectionGroup(
+            generator: self.idGenerator,
+            minimumConcurrentConnections: 0,
+            maximumConcurrentConnectionSoftLimit: 4,
+            maximumConcurrentConnectionHardLimit: 4,
+            keepAlive: false,
+            keepAliveReducesAvailableStreams: false
+        )
+
+        guard let request = connections.createNewDemandConnectionIfPossible() else {
+            Issue.record("Expected a connection request")
+            return
+        }
+        let connection = MockConnection(id: request.connectionID)
+        let (index, _) = connections.newConnectionEstablished(connection, maxStreams: 1)
+
+        guard case .leasedConnection = connections.leaseConnectionOrSoonAvailableConnectionCount() else {
+            Issue.record("Expected to lease a connection")
+            return
+        }
+        #expect(connections.stats == .init(leased: 1, leasedStreams: 1))
+
+        // The pool closes the connection while it is still leased (force shutdown).
+        guard case .close = connections.closeConnection(at: index, deleteConnection: false) else {
+            Issue.record("Expected the connection to be closed")
+            return
+        }
+        // The leased stream is still owed: it will be returned on release, or here.
+        #expect(connections.stats == .init(closing: 1, leasedStreams: 1))
+
+        // The connection dies before the lease comes back.
+        _ = connections.connectionClosed(connection.id, shuttingDown: true)
+        #expect(connections.isEmpty)
+        #expect(connections.stats == .init())
+
+        // The late release finds no connection: nothing left to subtract.
+        guard case .none = connections.releaseConnection(connection.id, streams: 1) else {
+            Issue.record("Expected no action for a connection the group no longer knows")
+            return
+        }
+        #expect(connections.stats == .init())
+    }
+
+    /// Parking a connection whose keep-alive is running must schedule an IDLE TIMEOUT
+    /// timer. It used to be built with `usecase: .keepAlive`, which made it run for the
+    /// keep-alive duration, suppressed the idle timeout for that connection, and — if
+    /// it fired — was dispatched to `keepAliveIfIdle` on a connection that already had
+    /// a keep-alive running, tripping a precondition.
+    @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
+    @Test func parkingConnectionWithRunningKeepAliveSchedulesAnIdleTimeoutTimer() {
+        var connections = TestPoolStateMachine.ConnectionGroup(
+            generator: self.idGenerator,
+            minimumConcurrentConnections: 0,
+            maximumConcurrentConnectionSoftLimit: 4,
+            maximumConcurrentConnectionHardLimit: 4,
+            keepAlive: true,
+            keepAliveReducesAvailableStreams: true
+        )
+
+        guard let request = connections.createNewDemandConnectionIfPossible() else {
+            Issue.record("Expected a connection request")
+            return
+        }
+        let connection = MockConnection(id: request.connectionID)
+        let (index, _) = connections.newConnectionEstablished(connection, maxStreams: 2)
+
+        // Park it: keep-alive timer + idle timeout timer.
+        _ = connections.parkConnection(at: index, hasBecomeIdle: true)
+        #expect(connections.keepAliveIfIdle(connection.id) != nil)
+
+        // While the keep-alive runs, the connection is leased and released again:
+        // leasing cancels the idle timer, so the connection comes back idle with the
+        // keep-alive still running and no idle timer.
+        guard case .leasedConnection = connections.leaseConnectionOrSoonAvailableConnectionCount() else {
+            Issue.record("Expected to lease a connection")
+            return
+        }
+        guard case .available(let releasedIndex, _) = connections.releaseConnection(connection.id, streams: 1) else {
+            Issue.record("Expected the connection to be available again")
+            return
+        }
+
+        let timers = connections.parkConnection(at: releasedIndex, hasBecomeIdle: true)
+        #expect(timers.map(\.usecase) == [.idleTimeout])
+    }
 }


### PR DESCRIPTION
The pool's per-group stream counters (`availableStreams`, `leasedStreams`, both `UInt16`) can drift upwards without ever coming back, until an arithmetic operation on them traps. We hit this in production as an `EXC_BREAKPOINT` / *arithmetic overflow* inside `PoolStateMachine.ConnectionGroup.releaseConnection(_:streams:)`, on an app that had been talking to unreachable PostgreSQL servers for hours after a machine wake.

Four independent defects, each fixed in a separate hunk:

**1. `ConnectionGroup.keepAliveFailed`, `.idle` branch** — the stream used by the running keep-alive is counted by `keepAliveIfIdle` but never subtracted. The connection moves to `.closing`, where `closed()` reports `usedStreams == 0`, so the stream stays counted forever. (The `.leased` branch already subtracts it.)

**2. `ConnectionGroup.closeConnection(at:deleteConnection:)`** — same stream lost when the pool closes a connection whose keep-alive is running (force-shutdown path). Leased streams are deliberately left counted: they are subtracted when the outstanding lease is released.

**3. `ConnectionState.closing` did not carry the streams still leased on the connection.** If the connection died before the lease came back, `closed()` reported 0 streams, the connection was removed from the group, and the late `releaseConnection` found no connection to subtract from. `.closing` now carries `usedStreams`, decremented on release and reported by `closed()`. `closed()` for `.closing` and `.draining` now reports `maxStreams == usedStreams`, so the group's `availableStreams -= maxStreams - usedStreams` is zero instead of a `UInt16` underflow — the free streams were already removed at close time. (The `.draining` case could already underflow today with `usedStreams > 0`.)

**4. `ConnectionState.parkConnection`** — in two branches the *idle timeout* timer is built with `usecase: .keepAlive`. It therefore runs for the keep-alive duration instead of the idle timeout, the idle timeout never fires for those connections, and when the timer does fire it is dispatched to `keepAliveIfIdle` on a connection that already has a keep-alive running → `preconditionFailure("Invalid state")`.

### How these were found

Defects 1–3 were found with a state-machine auditor that, after every transition, compares the group counters against the sum of the individual connection states, and tracks owed streams per connection. It was driven by a fuzzer reproducing the production conditions: unreachable servers, failing keep-alives, connections dying mid-query, failing connection attempts, cancelled lease requests, pools shut down with outstanding leases, and request queues under pressure. Defect 4 was reproduced directly.

Defect 3's first attempt introduced the `maxStreams`/`usedStreams` underflow described above; it was caught by your own `testCircuitBreaker`, which is why that part of the fix is included.

### Verification

- `swift test --filter ConnectionPoolModuleTests` — 108 tests in 10 suites, all passing.
- Fuzz campaign (7 seeds × 4 failure profiles × 4 configurations, including shutdown storms and 40 concurrent leases over 5 connections) — no counter divergence.

Happy to add regression tests in the style of the existing suite if you'd like them in this PR.