### PR TITLE
Allow subquery interpolation

### DIFF
--- a/Sources/PostgresNIO/New/PostgresQuery+PlaceholderLexer.swift
+++ b/Sources/PostgresNIO/New/PostgresQuery+PlaceholderLexer.swift
@@ -5,6 +5,10 @@ extension PostgresQuery {
     }
 
     enum PlaceholderLexer {
+        /// Finds every top-level bind placeholder (`$1`, `$2`, ...) in the query,
+        /// returning the UTF-8 offset of each placeholder's `$` and its number
+        /// in order of finding. Placeholder-like text inside string literals, quoted
+        /// identifiers, comments, and dollar-quoted strings is not matched.
         static func placeholders(in query: String) -> [Placeholder] {
             let utf8 = query.utf8
             var placeholders: [Placeholder] = []

--- a/Sources/PostgresNIO/New/PostgresQuery+PlaceholderLexer.swift
+++ b/Sources/PostgresNIO/New/PostgresQuery+PlaceholderLexer.swift
@@ -1,0 +1,271 @@
+extension PostgresQuery {
+    struct Placeholder {
+        let position: Int
+        let number: Int
+    }
+
+    enum PlaceholderLexer {
+        static func placeholders(in query: String) -> [Placeholder] {
+            let utf8 = query.utf8
+            var placeholders: [Placeholder] = []
+            var index = utf8.startIndex
+
+            while index < utf8.endIndex {
+                switch utf8[index] {
+                // String literal
+                case UInt8(ascii: "'"):
+                    index = self.consumeStringLiteral(utf8, from: utf8.index(after: index))
+
+                // Bit/Hex string
+                case UInt8(ascii: "B") where utf8[index...].starts(with: "B'".utf8),
+                    UInt8(ascii: "b") where utf8[index...].starts(with: "b'".utf8),
+                    UInt8(ascii: "X") where utf8[index...].starts(with: "X'".utf8),
+                    UInt8(ascii: "x") where utf8[index...].starts(with: "x'".utf8):
+                    index = self.consumeStringLiteral(utf8, from: utf8.index(index, offsetBy: 2))
+
+                // Unicode string
+                case UInt8(ascii: "U") where utf8[index...].starts(with: "U&'".utf8),
+                    UInt8(ascii: "u") where utf8[index...].starts(with: "u&'".utf8):
+                    index = self.consumeStringLiteral(utf8, from: utf8.index(index, offsetBy: 3))
+
+                // Escape string
+                case UInt8(ascii: "E") where utf8[index...].starts(with: "E'".utf8),
+                    UInt8(ascii: "e") where utf8[index...].starts(with: "e'".utf8):
+                    index = self.consumeEscapeString(utf8, from: utf8.index(index, offsetBy: 2))
+
+                // Quoted identifier
+                case UInt8(ascii: "\""):
+                    index = self.consumeQuotedIdentifier(utf8, from: utf8.index(after: index))
+
+                // Unicode identifier
+                case UInt8(ascii: "U") where utf8[index...].starts(with: "U&\"".utf8),
+                    UInt8(ascii: "u") where utf8[index...].starts(with: "u&\"".utf8):
+                    index = self.consumeQuotedIdentifier(utf8, from: utf8.index(index, offsetBy: 3))
+
+                // Line comment
+                case UInt8(ascii: "-") where utf8[index...].starts(with: "--".utf8):
+                    index = self.consumeLineComment(utf8, from: utf8.index(index, offsetBy: 2))
+
+                // Block comment
+                case UInt8(ascii: "/") where utf8[index...].starts(with: "/*".utf8):
+                    index = self.consumeBlockComment(utf8, from: utf8.index(index, offsetBy: 2))
+
+                // Placeholder
+                case UInt8(ascii: "$") where utf8[index...].dropFirst().first?.isDigit == true:
+                    let (newIndex, placeholder) = self.consumePlaceholder(utf8, from: index)
+                    if let placeholder {
+                        placeholders.append(placeholder)
+                    }
+                    index = newIndex
+
+                // Dollar quoted string
+                case UInt8(ascii: "$") where utf8[index...].dropFirst().first?.isDollarQuoteStart == true:
+                    index = consumeDollarQuotedString(utf8, from: index)
+
+                default:
+                    index = utf8.index(after: index)
+                }
+            }
+
+            return placeholders
+        }
+
+        static func consumeBlockComment(_ utf8: String.UTF8View, from start: String.Index) -> String.Index {
+            var openComments = 1
+            var index = start
+            while index < utf8.endIndex, openComments > 0 {
+                if utf8[index...].starts(with: "/*".utf8) {
+                    openComments += 1
+                    index = utf8.index(index, offsetBy: 2)
+                } else if utf8[index...].starts(with: "*/".utf8) {
+                    openComments -= 1
+                    index = utf8.index(index, offsetBy: 2)
+                } else {
+                    index = utf8.index(after: index)
+                }
+            }
+            return index
+        }
+
+        static func consumeDollarQuotedString(_ utf8: String.UTF8View, from start: String.Index) -> String.Index {
+            if start != utf8.startIndex, utf8[utf8.index(before: start)].isIdentifierContinuation {
+                // `foo$$bar$$` is part of an identifier, not a dollar quote
+                return utf8.index(after: start)
+            }
+
+            var index = utf8.index(after: start)
+            while index < utf8.endIndex, utf8[index].isDollarQuoteTagCharacter {
+                index = utf8.index(after: index)
+            }
+            guard index < utf8.endIndex, utf8[index] == UInt8(ascii: "$") else {
+                // invalid tag character or end of input before a second `$`
+                return utf8.index(after: start)
+            }
+            index = utf8.index(after: index)
+
+            let delimiter = utf8[start..<index]  // the whole "$tag$"
+            while let candidate = utf8[index...].firstIndex(of: UInt8(ascii: "$")) {
+                guard utf8[candidate...].starts(with: delimiter) else {
+                    index = utf8.index(after: candidate)
+                    continue
+                }
+                return utf8.index(candidate, offsetBy: delimiter.count)
+            }
+            return utf8.endIndex
+        }
+
+        static func consumePlaceholder(_ utf8: String.UTF8View, from start: String.Index) -> (String.Index, Placeholder?) {
+            var index = start
+            if index != utf8.startIndex {
+                let before = utf8[utf8.index(before: index)]
+                guard !before.isIdentifierContinuation else {
+                    // `foo$1` is an identifier, not a placeholder
+                    index = utf8.index(after: index)
+                    return (index, nil)
+                }
+            }
+            var placeholderEnd = utf8.index(after: index)
+            guard utf8[placeholderEnd].isDigit else {
+                index = utf8.index(after: index)
+                return (index, nil)
+            }
+            var number = 0
+            while placeholderEnd < utf8.endIndex, utf8[placeholderEnd].isDigit {
+                number = number * 10 + Int(utf8[placeholderEnd] - UInt8(ascii: "0"))
+                placeholderEnd = utf8.index(after: placeholderEnd)
+            }
+            return (
+                placeholderEnd,
+                .init(
+                    position: utf8.distance(from: utf8.startIndex, to: index),
+                    number: number
+                )
+            )
+        }
+
+        static func consumeLineComment(_ utf8: String.UTF8View, from start: String.Index) -> String.Index {
+            var index = start
+            while index < utf8.endIndex,
+                utf8[index] != UInt8(ascii: "\n"),
+                utf8[index] != UInt8(ascii: "\r")
+            {
+                index = utf8.index(after: index)
+            }
+            return index
+        }
+
+        // E'...'
+        static func consumeEscapeString(_ utf8: String.UTF8View, from start: String.Index) -> String.Index {
+            var index = start
+            while index < utf8.endIndex {
+                if utf8[index] == UInt8(ascii: "\\") {
+                    index = utf8.index(index, offsetBy: 2, limitedBy: utf8.endIndex) ?? utf8.endIndex
+                } else if utf8[index] == UInt8(ascii: "'") {
+                    break
+                } else {
+                    index = utf8.index(after: index)
+                }
+            }
+            guard index < utf8.endIndex else {
+                // query finished without closing the string literal
+                return utf8.endIndex
+            }
+            return utf8.index(after: index)
+        }
+
+        // '...'
+        static func consumeStringLiteral(_ utf8: String.UTF8View, from start: String.Index) -> String.Index {
+            var index = start
+            while index < utf8.endIndex, utf8[index] != UInt8(ascii: "'") {
+                index = utf8.index(after: index)
+            }
+            guard index < utf8.endIndex else {
+                // query finished without closing the string literal
+                return utf8.endIndex
+            }
+            return utf8.index(after: index)
+        }
+
+        // "..."
+        static func consumeQuotedIdentifier(_ utf8: String.UTF8View, from start: String.Index) -> String.Index {
+            var index = start
+            while index < utf8.endIndex, utf8[index] != UInt8(ascii: "\"") {
+                index = utf8.index(after: index)
+            }
+            guard index < utf8.endIndex else {
+                // query finished without closing the quoted identifier
+                return utf8.endIndex
+            }
+            return utf8.index(after: index)
+        }
+    }
+
+    /// Returns `sql` with every top-level `$n` placeholder shifted by `offset`,
+    /// skipping `$n`-looking identifiers that are not actually placeholders.
+    static func renumberPlaceholders(in sql: String, by offset: Int) -> String {
+        let placeholders = PlaceholderLexer.placeholders(in: sql)
+        let utf8 = sql.utf8
+        var consumed = utf8.startIndex
+        var result = ""
+        var consumedOffset = 0
+
+        for placeholder in placeholders {
+            let dollar = utf8.index(consumed, offsetBy: placeholder.position - consumedOffset)
+            // copy everything since the last placeholder up to the '$'
+            result.append(contentsOf: sql[consumed..<dollar])
+            result.append(contentsOf: "$\(offset + placeholder.number)")
+            // skip the '$' and the old digits in the source
+            var index = utf8.index(after: dollar)
+            var skipped = 1
+            while index < utf8.endIndex, utf8[index].isDigit
+            {
+                index = utf8.index(after: index)
+                skipped += 1
+            }
+            consumed = index
+            consumedOffset = placeholder.position + skipped
+        }
+        result.append(contentsOf: sql[consumed...])
+
+        return result
+    }
+}
+
+extension UInt8 {
+    /// `0-9`
+    fileprivate var isDigit: Bool {
+        UInt8(ascii: "0") <= self && self <= UInt8(ascii: "9")
+    }
+
+    /// A byte that continues an identifier, matching postgres' `scan.l`
+    /// `ident_cont` class: `[A-Za-z\200-\377_0-9\$]`.
+    fileprivate var isIdentifierContinuation: Bool {
+        UInt8(ascii: "a") <= self && self <= UInt8(ascii: "z")
+            || UInt8(ascii: "A") <= self && self <= UInt8(ascii: "Z")
+            || self.isDigit
+            || self == UInt8(ascii: "_")
+            || self == UInt8(ascii: "$")
+            || self >= 0x80
+    }
+
+    /// A byte that may follow the opening `$` of a dollar-quote delimiter:
+    /// the tag's first character, matching postgres' `scan.l` `dolq_start`
+    /// class (`[A-Za-z\200-\377_]`), or a second `$` for the `$$` form.
+    fileprivate var isDollarQuoteStart: Bool {
+        UInt8(ascii: "a") <= self && self <= UInt8(ascii: "z")
+            || UInt8(ascii: "A") <= self && self <= UInt8(ascii: "Z")
+            || self == UInt8(ascii: "_")
+            || self == UInt8(ascii: "$")
+            || self >= 0x80
+    }
+
+    /// A byte that continues a dollar-quote tag, matching postgres' `scan.l`
+    /// `dolq_cont` class: `[A-Za-z\200-\377_0-9]`.
+    fileprivate var isDollarQuoteTagCharacter: Bool {
+        UInt8(ascii: "a") <= self && self <= UInt8(ascii: "z")
+            || UInt8(ascii: "A") <= self && self <= UInt8(ascii: "Z")
+            || self.isDigit
+            || self == UInt8(ascii: "_")
+            || self >= 0x80
+    }
+}

--- a/Sources/PostgresNIO/New/PostgresQuery.swift
+++ b/Sources/PostgresNIO/New/PostgresQuery.swift
@@ -6,14 +6,10 @@ public struct PostgresQuery: Sendable, Hashable {
     public var sql: String
     /// The query binds.
     public var binds: PostgresBindings
-    // UTF-8 offsets of the `$` of each interpolation-written placeholder in `sql`.
-    @usableFromInline
-    var placeHolderPositions: [Int]
 
     public init(unsafeSQL sql: String, binds: PostgresBindings = PostgresBindings()) {
         self.sql = sql
         self.binds = binds
-        self.placeHolderPositions = []
     }
 }
 
@@ -21,13 +17,11 @@ extension PostgresQuery: ExpressibleByStringInterpolation {
     public init(stringInterpolation: StringInterpolation) {
         self.sql = stringInterpolation.sql
         self.binds = stringInterpolation.binds
-        self.placeHolderPositions = stringInterpolation.placeHolderPositions
     }
 
     public init(stringLiteral value: String) {
         self.sql = value
         self.binds = PostgresBindings()
-        self.placeHolderPositions = []
     }
 }
 
@@ -39,13 +33,10 @@ extension PostgresQuery {
         var sql: String
         @usableFromInline
         var binds: PostgresBindings
-        @usableFromInline
-        var placeHolderPositions: [Int]
 
         public init(literalCapacity: Int, interpolationCount: Int) {
             self.sql = ""
             self.binds = PostgresBindings(capacity: interpolationCount)
-            self.placeHolderPositions = []
         }
 
         public mutating func appendLiteral(_ literal: String) {
@@ -55,7 +46,6 @@ extension PostgresQuery {
         @inlinable
         public mutating func appendInterpolation<Value: PostgresThrowingDynamicTypeEncodable>(_ value: Value) throws {
             try self.binds.append(value, context: .default)
-            self.placeHolderPositions.append(self.sql.utf8.count)
             self.sql.append(contentsOf: "$\(self.binds.count)")
         }
 
@@ -68,14 +58,12 @@ extension PostgresQuery {
                 try self.binds.append(value, context: .default)
             }
 
-            self.placeHolderPositions.append(self.sql.utf8.count)
             self.sql.append(contentsOf: "$\(self.binds.count)")
         }
 
         @inlinable
         public mutating func appendInterpolation<Value: PostgresDynamicTypeEncodable>(_ value: Value) {
             self.binds.append(value, context: .default)
-            self.placeHolderPositions.append(self.sql.utf8.count)
             self.sql.append(contentsOf: "$\(self.binds.count)")
         }
 
@@ -88,7 +76,6 @@ extension PostgresQuery {
                 self.binds.append(value, context: .default)
             }
 
-            self.placeHolderPositions.append(self.sql.utf8.count)
             self.sql.append(contentsOf: "$\(self.binds.count)")
         }
 
@@ -98,37 +85,11 @@ extension PostgresQuery {
             context: PostgresEncodingContext<JSONEncoder>
         ) throws {
             try self.binds.append(value, context: context)
-            self.placeHolderPositions.append(self.sql.utf8.count)
             self.sql.append(contentsOf: "$\(self.binds.count)")
         }
 
-        @inlinable
         public mutating func appendInterpolation(_ query: PostgresQuery) {
-            let offset = self.binds.count
-            let utf8 = query.sql.utf8
-            self.sql.reserveCapacity(self.sql.utf8.count + utf8.count)
-            var consumed = utf8.startIndex
-            var consumedOffset = 0
-            for (i, position) in query.placeHolderPositions.enumerated() {
-                let dollar = utf8.index(consumed, offsetBy: position - consumedOffset)
-                // copy everything since the last placeholder up to the '$'
-                self.sql.append(contentsOf: query.sql[consumed..<dollar])
-                self.placeHolderPositions.append(self.sql.utf8.count)
-                self.sql.append(contentsOf: "$\(offset + i + 1)")
-                // skip the '$' and the old digits in the source
-                var index = utf8.index(after: dollar)
-                var skipped = 1
-                while 
-                    index < utf8.endIndex, 
-                    UInt8(ascii: "0") <= utf8[index], utf8[index] <= UInt8(ascii: "9") // is a number
-                {
-                    index = utf8.index(after: index)
-                    skipped += 1
-                }
-                consumed = index
-                consumedOffset = position + skipped
-            }
-            self.sql.append(contentsOf: query.sql[consumed...])
+            self.sql.append(contentsOf: PostgresQuery.renumberPlaceholders(in: query.sql, by: self.binds.count))
             self.binds.metadata.append(contentsOf: query.binds.metadata)
             var bytes = query.binds.bytes
             self.binds.bytes.writeBuffer(&bytes)

--- a/Sources/PostgresNIO/New/PostgresQuery.swift
+++ b/Sources/PostgresNIO/New/PostgresQuery.swift
@@ -6,10 +6,14 @@ public struct PostgresQuery: Sendable, Hashable {
     public var sql: String
     /// The query binds.
     public var binds: PostgresBindings
+    // UTF-8 offsets of the `$` of each interpolation-written placeholder in `sql`.
+    @usableFromInline
+    var placeHolderPositions: [Int]
 
     public init(unsafeSQL sql: String, binds: PostgresBindings = PostgresBindings()) {
         self.sql = sql
         self.binds = binds
+        self.placeHolderPositions = []
     }
 }
 
@@ -17,11 +21,13 @@ extension PostgresQuery: ExpressibleByStringInterpolation {
     public init(stringInterpolation: StringInterpolation) {
         self.sql = stringInterpolation.sql
         self.binds = stringInterpolation.binds
+        self.placeHolderPositions = stringInterpolation.placeHolderPositions
     }
 
     public init(stringLiteral value: String) {
         self.sql = value
         self.binds = PostgresBindings()
+        self.placeHolderPositions = []
     }
 }
 
@@ -33,10 +39,13 @@ extension PostgresQuery {
         var sql: String
         @usableFromInline
         var binds: PostgresBindings
+        @usableFromInline
+        var placeHolderPositions: [Int]
 
         public init(literalCapacity: Int, interpolationCount: Int) {
             self.sql = ""
             self.binds = PostgresBindings(capacity: interpolationCount)
+            self.placeHolderPositions = []
         }
 
         public mutating func appendLiteral(_ literal: String) {
@@ -46,6 +55,7 @@ extension PostgresQuery {
         @inlinable
         public mutating func appendInterpolation<Value: PostgresThrowingDynamicTypeEncodable>(_ value: Value) throws {
             try self.binds.append(value, context: .default)
+            self.placeHolderPositions.append(self.sql.utf8.count)
             self.sql.append(contentsOf: "$\(self.binds.count)")
         }
 
@@ -58,12 +68,14 @@ extension PostgresQuery {
                 try self.binds.append(value, context: .default)
             }
 
+            self.placeHolderPositions.append(self.sql.utf8.count)
             self.sql.append(contentsOf: "$\(self.binds.count)")
         }
 
         @inlinable
         public mutating func appendInterpolation<Value: PostgresDynamicTypeEncodable>(_ value: Value) {
             self.binds.append(value, context: .default)
+            self.placeHolderPositions.append(self.sql.utf8.count)
             self.sql.append(contentsOf: "$\(self.binds.count)")
         }
 
@@ -76,6 +88,7 @@ extension PostgresQuery {
                 self.binds.append(value, context: .default)
             }
 
+            self.placeHolderPositions.append(self.sql.utf8.count)
             self.sql.append(contentsOf: "$\(self.binds.count)")
         }
 
@@ -85,7 +98,40 @@ extension PostgresQuery {
             context: PostgresEncodingContext<JSONEncoder>
         ) throws {
             try self.binds.append(value, context: context)
+            self.placeHolderPositions.append(self.sql.utf8.count)
             self.sql.append(contentsOf: "$\(self.binds.count)")
+        }
+
+        @inlinable
+        public mutating func appendInterpolation(_ query: PostgresQuery) {
+            let offset = self.binds.count
+            let utf8 = query.sql.utf8
+            self.sql.reserveCapacity(self.sql.utf8.count + utf8.count)
+            var consumed = utf8.startIndex
+            var consumedOffset = 0
+            for (i, position) in query.placeHolderPositions.enumerated() {
+                let dollar = utf8.index(consumed, offsetBy: position - consumedOffset)
+                // copy everything since the last placeholder up to the '$'
+                self.sql.append(contentsOf: query.sql[consumed..<dollar])
+                self.placeHolderPositions.append(self.sql.utf8.count)
+                self.sql.append(contentsOf: "$\(offset + i + 1)")
+                // skip the '$' and the old digits in the source
+                var index = utf8.index(after: dollar)
+                var skipped = 1
+                while 
+                    index < utf8.endIndex, 
+                    UInt8(ascii: "0") <= utf8[index], utf8[index] <= UInt8(ascii: "9") // is a number
+                {
+                    index = utf8.index(after: index)
+                    skipped += 1
+                }
+                consumed = index
+                consumedOffset = position + skipped
+            }
+            self.sql.append(contentsOf: query.sql[consumed...])
+            self.binds.metadata.append(contentsOf: query.binds.metadata)
+            var bytes = query.binds.bytes
+            self.binds.bytes.writeBuffer(&bytes)
         }
 
         @inlinable

--- a/Tests/PostgresNIOTests/New/PostgresQueryRenumberingTests.swift
+++ b/Tests/PostgresNIOTests/New/PostgresQueryRenumberingTests.swift
@@ -1,0 +1,218 @@
+import NIOCore
+import Testing
+
+@testable import PostgresNIO
+
+@Suite struct PostgresQueryRenumberingTests {
+    @Test func renumbersTopLevelPlaceholders() {
+        #expect(
+            PostgresQuery.renumberPlaceholders(in: "SELECT * FROM t WHERE a = $1 AND b = $2", by: 2)
+                == "SELECT * FROM t WHERE a = $3 AND b = $4"
+        )
+    }
+
+    @Test func offsetZeroLeavesQueryUnchanged() {
+        let sql = "SELECT * FROM t WHERE a = $1 AND note = 'costs $1'"
+        #expect(PostgresQuery.renumberPlaceholders(in: sql, by: 0) == sql)
+    }
+
+    @Test func renumbersPlaceholderAtStartAndEndOfString() {
+        #expect(PostgresQuery.renumberPlaceholders(in: "$1 = $2", by: 1) == "$2 = $3")
+        #expect(PostgresQuery.renumberPlaceholders(in: "a = $1", by: 9) == "a = $10")
+    }
+
+    @Test func renumbersMultiDigitPlaceholders() {
+        #expect(PostgresQuery.renumberPlaceholders(in: "($9, $10, $12)", by: 1) == "($10, $11, $13)")
+    }
+
+    @Test func queryWithoutPlaceholdersIsUnchanged() {
+        let sql = "SELECT * FROM t WHERE deleted_at IS NULL"
+        #expect(PostgresQuery.renumberPlaceholders(in: sql, by: 5) == sql)
+    }
+
+    @Test func stringLiteral() {
+        #expect(
+            PostgresQuery.renumberPlaceholders(in: "note = 'costs $1' AND a = $1", by: 1)
+                == "note = 'costs $1' AND a = $2"
+        )
+    }
+
+    @Test func stringLiteralWithEscapedQuote() {
+        #expect(
+            PostgresQuery.renumberPlaceholders(in: "note = 'it''s $1 worth' AND a = $1", by: 1)
+                == "note = 'it''s $1 worth' AND a = $2"
+        )
+    }
+
+    @Test func escapeStringConstant() {
+        // In E'...' a backslash escapes the quote, so \' does not end the string
+        #expect(
+            PostgresQuery.renumberPlaceholders(in: #"note = E'\' $1' AND a = $1"#, by: 1)
+                == #"note = E'\' $1' AND a = $2"#
+        )
+    }
+
+    @Test func dollarQuotedString() {
+        #expect(
+            PostgresQuery.renumberPlaceholders(in: "body = $$ $1 $$ AND a = $1", by: 1)
+                == "body = $$ $1 $$ AND a = $2"
+        )
+    }
+
+    @Test func taggedDollarQuotedString() {
+        #expect(
+            PostgresQuery.renumberPlaceholders(in: "body = $fn$ SELECT $$ $1 $$ $fn$ AND a = $1", by: 1)
+                == "body = $fn$ SELECT $$ $1 $$ $fn$ AND a = $2"
+        )
+    }
+
+    @Test func bitString() {
+        #expect(
+            PostgresQuery.renumberPlaceholders(in: "note = B'1 $1' AND a = $1", by: 1)
+                == "note = B'1 $1' AND a = $2"
+        )
+    }
+
+    @Test func quotedIdentifier() {
+        #expect(
+            PostgresQuery.renumberPlaceholders(in: #""weird$1name" = $1"#, by: 1)
+                == #""weird$1name" = $2"#
+        )
+    }
+
+    @Test func lineComment() {
+        #expect(
+            PostgresQuery.renumberPlaceholders(in: "a = $1 -- not $2 here\nAND b = $2", by: 1)
+                == "a = $2 -- not $2 here\nAND b = $3"
+        )
+    }
+
+    @Test func blockComment() {
+        #expect(
+            PostgresQuery.renumberPlaceholders(in: "/* $1 */ a = $1", by: 1)
+                == "/* $1 */ a = $2"
+        )
+    }
+
+    @Test func nestedBlockComment() {
+        #expect(
+            PostgresQuery.renumberPlaceholders(in: "/* $1 /* $2 */ still $3 */ a = $1", by: 1)
+                == "/* $1 /* $2 */ still $3 */ a = $2"
+        )
+    }
+
+    @Test func dollarInsideUnquotedIdentifier() {
+        #expect(
+            PostgresQuery.renumberPlaceholders(in: "foo$1 = $1", by: 1)
+                == "foo$1 = $2"
+        )
+    }
+
+    @Test func loneDollarSign() {
+        #expect(
+            PostgresQuery.renumberPlaceholders(in: "a $ b = $1", by: 1)
+                == "a $ b = $2"
+        )
+    }
+
+    @Test func unterminatedStringIsLeftAlone() {
+        let sql = "note = 'oops $1"
+        #expect(PostgresQuery.renumberPlaceholders(in: sql, by: 1) == sql)
+    }
+
+    @Test func functionBody() {
+        let sql = "CREATE FUNCTION add(int, int) RETURNS int AS $$ SELECT $1 + $2 $$ LANGUAGE sql; SELECT add(a, $1)"
+        #expect(
+            PostgresQuery.renumberPlaceholders(in: sql, by: 3)
+                == "CREATE FUNCTION add(int, int) RETURNS int AS $$ SELECT $1 + $2 $$ LANGUAGE sql; SELECT add(a, $4)"
+        )
+    }
+
+    @Test func trailingDollarSign() {
+        // `$` as the very last byte is not a placeholder
+        let sql = "a = $"
+        #expect(PostgresQuery.renumberPlaceholders(in: sql, by: 1) == sql)
+    }
+
+    @Test func unterminatedEscapeStringWithTrailingBackslash() {
+        let sql = #"note = E'\"#
+        #expect(PostgresQuery.renumberPlaceholders(in: sql, by: 1) == sql)
+    }
+
+    @Test func emptyLineComment() {
+        #expect(
+            PostgresQuery.renumberPlaceholders(in: "--\n$1 = a", by: 1)
+                == "--\n$2 = a"
+        )
+    }
+
+    @Test func emptyBlockComment() {
+        #expect(
+            PostgresQuery.renumberPlaceholders(in: "/**/ $1", by: 1)
+                == "/**/ $2"
+        )
+    }
+
+    @Test func dollarFollowedByOperator() {
+        // `$+` cannot open a dollar quote: `+` is not a valid tag character
+        #expect(
+            PostgresQuery.renumberPlaceholders(in: "a $+ b = $1", by: 1)
+                == "a $+ b = $2"
+        )
+    }
+
+    @Test func unicodeString() {
+        #expect(
+            PostgresQuery.renumberPlaceholders(in: "note = U&'x $1' AND a = $1", by: 1)
+                == "note = U&'x $1' AND a = $2"
+        )
+    }
+
+    @Test func emptyUnicodeString() {
+        #expect(
+            PostgresQuery.renumberPlaceholders(in: "note = U&'' AND a = $1", by: 1)
+                == "note = U&'' AND a = $2"
+        )
+    }
+
+    @Test func invalidDollarQuoteTag() {
+        // `$x y$` is not a dollar quote — tags cannot contain spaces
+        #expect(
+            PostgresQuery.renumberPlaceholders(in: "a $x y$ = $1", by: 1)
+                == "a $x y$ = $2"
+        )
+    }
+
+    @Test func dollarQuoteAfterIdentifier() {
+        // `foo$$bar$$` is a single identifier, not a dollar quote
+        #expect(
+            PostgresQuery.renumberPlaceholders(in: "foo$$bar$$ = $1", by: 1)
+                == "foo$$bar$$ = $2"
+        )
+    }
+
+    @Test func nonASCIIDollarQuoteTag() {
+        #expect(
+            PostgresQuery.renumberPlaceholders(in: "body = $é$ $1 $é$ AND a = $1", by: 1)
+                == "body = $é$ $1 $é$ AND a = $2"
+        )
+    }
+
+    @Test func unsafeSQLFragmentComposes() {
+        var binds = PostgresBindings()
+        binds.append(1, context: .default)
+        let fragment = PostgresQuery(unsafeSQL: "a = $1", binds: binds)
+        let b = 2
+
+        let query: PostgresQuery = "SELECT * FROM t WHERE b = \(b) AND \(fragment)"
+
+        #expect(query.sql == "SELECT * FROM t WHERE b = $1 AND a = $2")
+
+        var expected = ByteBuffer()
+        for value in [b, 1] {
+            expected.writeInteger(UInt32(8))
+            expected.writeInteger(value)
+        }
+        #expect(query.binds.bytes == expected)
+    }
+}

--- a/Tests/PostgresNIOTests/New/PostgresQueryTests.swift
+++ b/Tests/PostgresNIOTests/New/PostgresQueryTests.swift
@@ -109,7 +109,7 @@ import Foundation
         #expect(query.binds.bytes == Self.intBinds([a, b]))
     }
 
-    func testQueryInterpolationAfterParentBind() {
+    @Test func queryInterpolationAfterParentBind() {
         let a = 1
         let b = 2
         let subQuery: PostgresQuery = "SELECT id FROM sub WHERE a = \(a)"
@@ -120,7 +120,7 @@ import Foundation
         #expect(query.binds.bytes == Self.intBinds([b, a]))
     }
 
-    func testQueryInterpolationBetweenParentBinds() {
+    @Test func queryInterpolationBetweenParentBinds() {
         let a = 10
         let b = 20
         let c = 1
@@ -133,7 +133,7 @@ import Foundation
         #expect(query.binds.bytes == Self.intBinds([c, a, b, d]))
     }
 
-    func testQueryInterpolationWithEmptyQuery() {
+    @Test func queryInterpolationWithEmptyQuery() {
         let condition: PostgresQuery = ""
 
         let query: PostgresQuery = "SELECT * FROM t \(condition)"
@@ -142,7 +142,7 @@ import Foundation
         #expect(query.binds.count == 0)
     }
 
-    func testQueryInterpolationWithBindlessQuery() {
+    @Test func queryInterpolationWithBindlessQuery() {
         let condition: PostgresQuery = "WHERE deleted_at IS NULL"
 
         let query: PostgresQuery = "SELECT * FROM t \(condition)"
@@ -151,7 +151,7 @@ import Foundation
         #expect(query.binds.count == 0)
     }
 
-    func testNestedQueryInterpolation() {
+    @Test func nestedQueryInterpolation() {
         let x = 1
         let y = 2
         let z = 3
@@ -164,7 +164,7 @@ import Foundation
         #expect(query.binds.bytes == Self.intBinds([z, y, x]))
     }
 
-    func testQueryInterpolatedTwice() {
+    @Test func queryInterpolatedTwice() {
         let a = 1
         let fragment: PostgresQuery = "a = \(a)"
 
@@ -174,7 +174,7 @@ import Foundation
         #expect(query.binds.bytes == Self.intBinds([a, a]))
     }
 
-    func testQueryInterpolationRenumbersMultiDigitPlaceholders() {
+    @Test func queryInterpolationRenumbersMultiDigitPlaceholders() {
         let ids = Array(1...12)
         let a = 0
         let fragment: PostgresQuery = "ids IN (\(ids[0]), \(ids[1]), \(ids[2]), \(ids[3]), \(ids[4]), \(ids[5]), \(ids[6]), \(ids[7]), \(ids[8]), \(ids[9]), \(ids[10]), \(ids[11]))"
@@ -186,7 +186,7 @@ import Foundation
         #expect(query.binds.bytes == Self.intBinds([a] + ids))
     }
 
-    func testQueryInterpolationLeavesQuotedPlaceholderTextAlone() {
+    @Test func queryInterpolationLeavesQuotedPlaceholderTextAlone() {
         let a = 1
         let b = 2
         let fragment: PostgresQuery = "note = 'costs $1' AND a = \(a)"

--- a/Tests/PostgresNIOTests/New/PostgresQueryTests.swift
+++ b/Tests/PostgresNIOTests/New/PostgresQueryTests.swift
@@ -97,6 +97,106 @@ final class PostgresQueryTests: XCTestCase {
         XCTAssertEqual(query.binds.bytes, expected)
     }
 
+    func testQueryInterpolationBeforeParentBinds() {
+        let a = 1
+        let b = 2
+        let subQuery: PostgresQuery = "SELECT id FROM sub WHERE a = \(a)"
+
+        let query: PostgresQuery = "SELECT (\(subQuery)) FROM table WHERE b = \(b)"
+
+        XCTAssertEqual(query.sql, "SELECT (SELECT id FROM sub WHERE a = $1) FROM table WHERE b = $2")
+        XCTAssertEqual(query.binds.bytes, Self.intBinds([a, b]))
+    }
+
+    func testQueryInterpolationAfterParentBind() {
+        let a = 1
+        let b = 2
+        let subQuery: PostgresQuery = "SELECT id FROM sub WHERE a = \(a)"
+
+        let query: PostgresQuery = "SELECT * FROM table WHERE b = \(b) AND id IN (\(subQuery))"
+
+        XCTAssertEqual(query.sql, "SELECT * FROM table WHERE b = $1 AND id IN (SELECT id FROM sub WHERE a = $2)")
+        XCTAssertEqual(query.binds.bytes, Self.intBinds([b, a]))
+    }
+
+    func testQueryInterpolationBetweenParentBinds() {
+        let a = 10
+        let b = 20
+        let c = 1
+        let d = 2
+        let fragment: PostgresQuery = "a = \(a) AND b = \(b)"
+
+        let query: PostgresQuery = "SELECT * FROM t WHERE c = \(c) AND (\(fragment)) AND d = \(d)"
+
+        XCTAssertEqual(query.sql, "SELECT * FROM t WHERE c = $1 AND (a = $2 AND b = $3) AND d = $4")
+        XCTAssertEqual(query.binds.bytes, Self.intBinds([c, a, b, d]))
+    }
+
+    func testQueryInterpolationWithEmptyQuery() {
+        let condition: PostgresQuery = ""
+
+        let query: PostgresQuery = "SELECT * FROM t \(condition)"
+
+        XCTAssertEqual(query.sql, "SELECT * FROM t ")
+        XCTAssertEqual(query.binds.count, 0)
+    }
+
+    func testQueryInterpolationWithBindlessQuery() {
+        let condition: PostgresQuery = "WHERE deleted_at IS NULL"
+
+        let query: PostgresQuery = "SELECT * FROM t \(condition)"
+
+        XCTAssertEqual(query.sql, "SELECT * FROM t WHERE deleted_at IS NULL")
+        XCTAssertEqual(query.binds.count, 0)
+    }
+
+    func testNestedQueryInterpolation() {
+        let x = 1
+        let y = 2
+        let z = 3
+        let inner: PostgresQuery = "x = \(x)"
+        let middle: PostgresQuery = "y = \(y) AND (\(inner))"
+
+        let query: PostgresQuery = "SELECT * FROM t WHERE z = \(z) AND (\(middle))"
+
+        XCTAssertEqual(query.sql, "SELECT * FROM t WHERE z = $1 AND (y = $2 AND (x = $3))")
+        XCTAssertEqual(query.binds.bytes, Self.intBinds([z, y, x]))
+    }
+
+    func testQueryInterpolatedTwice() {
+        let a = 1
+        let fragment: PostgresQuery = "a = \(a)"
+
+        let query: PostgresQuery = "SELECT * FROM t WHERE \(fragment) OR \(fragment)"
+
+        XCTAssertEqual(query.sql, "SELECT * FROM t WHERE a = $1 OR a = $2")
+        XCTAssertEqual(query.binds.bytes, Self.intBinds([a, a]))
+    }
+
+    func testQueryInterpolationRenumbersMultiDigitPlaceholders() {
+        let ids = Array(1...12)
+        let a = 0
+        let fragment: PostgresQuery = "ids IN (\(ids[0]), \(ids[1]), \(ids[2]), \(ids[3]), \(ids[4]), \(ids[5]), \(ids[6]), \(ids[7]), \(ids[8]), \(ids[9]), \(ids[10]), \(ids[11]))"
+        XCTAssertEqual(fragment.sql, "ids IN ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)")
+
+        let query: PostgresQuery = "SELECT * FROM t WHERE a = \(a) AND \(fragment)"
+
+        XCTAssertEqual(query.sql, "SELECT * FROM t WHERE a = $1 AND ids IN ($2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)")
+        XCTAssertEqual(query.binds.bytes, Self.intBinds([a] + ids))
+    }
+
+    func testQueryInterpolationLeavesQuotedPlaceholderTextAlone() {
+        let a = 1
+        let b = 2
+        let fragment: PostgresQuery = "note = 'costs $1' AND a = \(a)"
+        XCTAssertEqual(fragment.sql, "note = 'costs $1' AND a = $1")
+
+        let query: PostgresQuery = "SELECT * FROM t WHERE b = \(b) AND \(fragment)"
+
+        XCTAssertEqual(query.sql, "SELECT * FROM t WHERE b = $1 AND note = 'costs $1' AND a = $2")
+        XCTAssertEqual(query.binds.bytes, Self.intBinds([b, a]))
+    }
+
     func testUnescapedSQL() {
         let tableName = UUID().uuidString.uppercased()
         let value = 1
@@ -112,6 +212,15 @@ final class PostgresQueryTests: XCTestCase {
 }
 
 extension PostgresQueryTests {
+    private static func intBinds(_ values: [Int]) -> ByteBuffer {
+        var buffer = ByteBuffer()
+        for value in values {
+            buffer.writeInteger(UInt32(8))
+            buffer.writeInteger(value)
+        }
+        return buffer
+    }
+
     struct DynamicString: PostgresDynamicTypeEncodable {
         let value: String
 


### PR DESCRIPTION
This implements `PostgresQuery` subquery interpolation by analysing the query and renumbering all binds depending on the existing ones in the base query. Implements a lexer based on [postgres' `scan.l`](https://github.com/postgres/postgres/blob/master/src/backend/parser/scan.l)