### PR TITLE
Fix replacement after connection closes with queued request

### DIFF
--- a/Sources/ConnectionPoolModule/PoolStateMachine+ConnectionGroup.swift
+++ b/Sources/ConnectionPoolModule/PoolStateMachine+ConnectionGroup.swift
@@ -782,7 +782,11 @@ extension PoolStateMachine {
         ///            supplied index after this. If nil is returned the connection was closed by the state machine and was
         ///            therefore already removed.
         @inlinable
-        mutating func connectionClosed(_ connectionID: Connection.ID, shuttingDown: Bool) -> ClosedAction {
+        mutating func connectionClosed(
+            _ connectionID: Connection.ID,
+            shuttingDown: Bool,
+            createConnectionForQueuedRequest: Bool
+        ) -> ClosedAction {
             guard let index = self.connections.firstIndex(where: { $0.id == connectionID }) else {
                 preconditionFailure("All connections that have been created should say goodbye exactly once!")
             }
@@ -814,6 +818,9 @@ extension PoolStateMachine {
             let newConnectionRequest: ConnectionRequest?
             if !shuttingDown, self.connections.count < self.minimumConcurrentConnections {
                 newConnectionRequest = self.createNewConnection()
+            } else if !shuttingDown, createConnectionForQueuedRequest {
+                newConnectionRequest = self.createNewDemandConnectionIfPossible()
+                    ?? self.createNewOverflowConnectionIfPossible()
             } else {
                 newConnectionRequest = .none
             }

--- a/Sources/ConnectionPoolModule/PoolStateMachine.swift
+++ b/Sources/ConnectionPoolModule/PoolStateMachine.swift
@@ -659,7 +659,19 @@ struct PoolStateMachine<
         case .running, .connectionCreationFailing, .circuitBreakOpen:
             self.cacheNoMoreConnectionsAllowed = false
 
-            let closedConnectionAction = self.connections.connectionClosed(connection.id, shuttingDown: self.gracefulShutdownTriggered)
+            let createConnectionForQueuedRequest: Bool
+            if case .running = self.poolState {
+                createConnectionForQueuedRequest = !self.requestQueue.isEmpty
+                    && self.connections.stats.connecting < self.configuration.maximumConcurrentConnectionRequests
+            } else {
+                createConnectionForQueuedRequest = false
+            }
+
+            let closedConnectionAction = self.connections.connectionClosed(
+                connection.id,
+                shuttingDown: self.gracefulShutdownTriggered,
+                createConnectionForQueuedRequest: createConnectionForQueuedRequest
+            )
 
             let connectionAction: ConnectionAction
             if let newRequest = closedConnectionAction.newConnectionRequest {
@@ -671,7 +683,11 @@ struct PoolStateMachine<
             return .init(request: .none, connection: connectionAction)
 
         case .shuttingDown:
-            let closedConnectionAction = self.connections.connectionClosed(connection.id, shuttingDown: true)
+            let closedConnectionAction = self.connections.connectionClosed(
+                connection.id,
+                shuttingDown: true,
+                createConnectionForQueuedRequest: false
+            )
 
             let connectionAction: ConnectionAction
             if self.connections.isEmpty {

--- a/Tests/ConnectionPoolModuleTests/PoolStateMachine+ConnectionGroupTests.swift
+++ b/Tests/ConnectionPoolModuleTests/PoolStateMachine+ConnectionGroupTests.swift
@@ -122,7 +122,11 @@ import Testing
         #expect(closeAction.connection === newConnection)
         #expect(connections.stats == .init(closing: 1, availableStreams: 0))
 
-        let closeContext = connections.connectionClosed(newConnection.id, shuttingDown: false)
+        let closeContext = connections.connectionClosed(
+            newConnection.id,
+            shuttingDown: false,
+            createConnectionForQueuedRequest: false
+        )
         #expect(closeContext.connectionsStarting == 0)
         #expect(connections.isEmpty)
         #expect(connections.stats == .init())
@@ -727,7 +731,11 @@ import Testing
 
         // When the draining connection closes, it's in the overflow slot,
         // so no replacement connection should be created.
-        let closedAction = connections.connectionClosed(persistedConn.id, shuttingDown: false)
+        let closedAction = connections.connectionClosed(
+            persistedConn.id,
+            shuttingDown: false,
+            createConnectionForQueuedRequest: false
+        )
         #expect(closedAction.newConnectionRequest == nil)
         #expect(connections.stats == .init(leased: 1, leasedStreams: 1))
 

--- a/Tests/ConnectionPoolModuleTests/PoolStateMachineTests.swift
+++ b/Tests/ConnectionPoolModuleTests/PoolStateMachineTests.swift
@@ -247,6 +247,49 @@ typealias TestPoolStateMachine = PoolStateMachine<
     }
 
     @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
+    @Test func testLastConnectionDyingWithQueuedRequestCreatesReplacement() {
+        var configuration = PoolConfiguration()
+        configuration.minimumConnectionCount = 0
+        configuration.maximumConnectionSoftLimit = 1
+        configuration.maximumConnectionHardLimit = 1
+        configuration.keepAliveDuration = nil
+
+        var stateMachine = TestPoolStateMachine(
+            configuration: configuration,
+            generator: .init(),
+            timerCancellationTokenType: MockTimerCancellationToken.self,
+            clock: MockClock()
+        )
+
+        let request1 = MockRequest(connectionType: MockConnection.self)
+        guard case .makeConnection = stateMachine.leaseConnection(request1).connection else {
+            Issue.record()
+            return
+        }
+        let connection1 = MockConnection(id: 0)
+        #expect(
+            stateMachine.connectionEstablished(connection1, maxStreams: 1).request
+                == .leaseConnection(.init(element: request1), connection1)
+        )
+
+        let request2 = MockRequest(connectionType: MockConnection.self)
+        #expect(stateMachine.leaseConnection(request2) == .none())
+
+        let closedAction = stateMachine.connectionClosed(connection1)
+        #expect(closedAction.request == .none)
+        guard case .makeConnection(let replacementRequest, _) = closedAction.connection else {
+            Issue.record("Expected a replacement connection for the queued request, got \(closedAction.connection)")
+            return
+        }
+
+        let connection2 = MockConnection(id: replacementRequest.connectionID)
+        #expect(
+            stateMachine.connectionEstablished(connection2, maxStreams: 1).request
+                == .leaseConnection(.init(element: request2), connection2)
+        )
+    }
+
+    @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
     @Test func testReleaseLoosesRaceAgainstClosed() {
         var configuration = PoolConfiguration()
         configuration.minimumConnectionCount = 0


### PR DESCRIPTION
Fixes #657.

When the last connection closed with `minimumConnectionCount` set to zero, the pool only considered its configured minimum and ignored queued lease requests. This left the request stranded when no later request arrived to trigger another connection attempt.

Create a replacement connection when the pool is running, work remains queued, and the existing connection-attempt and hard limits permit it. Backoff and shutdown behavior remain unchanged.

Added a regression test covering the reported sequence.

Tests:

- `testLastConnectionDyingWithQueuedRequestCreatesReplacement`
- `PoolStateMachineTests`: 30 passed
- `ConnectionPoolModuleTests`: 109 passed
- `PostgresNIOTests`: 172 passed
