### PR TITLE
Correctly filter out tests for Swift Testing <6.3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@v7
       - name: Run unit tests with Thread Sanitizer
         run: |
-          swift test --filter='^(PostgresNIOTests|ConnectionPoolModuleTests)' --sanitize=thread --enable-code-coverage
+          swift test --filter '^(PostgresNIOTests|ConnectionPoolModuleTests)' --sanitize=thread --enable-code-coverage
       - name: Submit code coverage
         uses: vapor/swift-codecov-action@2f478f2fd22e06ca363967d0fb6c6593a8548cee # v0.3.5
         with:
@@ -77,7 +77,7 @@ jobs:
         uses: actions/checkout@v7
         with: { path: 'postgres-nio' }
       - name: Run integration tests
-        run: swift test --package-path postgres-nio --filter=^IntegrationTests
+        run: swift test --package-path postgres-nio --filter ^IntegrationTests
       - name: Check out postgres-kit dependent
         uses: actions/checkout@v7
         with: { repository: 'vapor/postgres-kit', path: 'postgres-kit' }


### PR DESCRIPTION
Support for `--filter=x` was added in 6.3 (https://github.com/swiftlang/swift-testing/pull/1357) so until then Swift Testing tests don't get filtered out correctly and fail. This is the reason CI for 6.1 and 6.2 in https://github.com/vapor/postgres-nio/pull/666 is failing