### PR TITLE
Do not close connections when receiving a server error with a 28xxx SQL state

### DIFF
--- a/Sources/PostgresNIO/New/Connection State Machine/ConnectionStateMachine.swift
+++ b/Sources/PostgresNIO/New/Connection State Machine/ConnectionStateMachine.swift
@@ -1088,12 +1088,6 @@ extension ConnectionStateMachine {
                 // any error message that doesn't have a sql state field, is unexpected by default.
                 return true
             }
-            
-            if sqlState.starts(with: "28") {
-                // these are authentication errors
-                return true
-            }
-            
             return false
         case .clientClosedConnection, .poolClosed:
             preconditionFailure("A pure client error was thrown directly in PostgresConnection, this shouldn't happen")

--- a/Sources/PostgresNIO/New/Connection State Machine/ConnectionStateMachine.swift
+++ b/Sources/PostgresNIO/New/Connection State Machine/ConnectionStateMachine.swift
@@ -1084,7 +1084,7 @@ extension ConnectionStateMachine {
         case .queryCancelled:
             return false
         case .server, .listenFailed:
-            guard let sqlState = error.serverInfo?[.sqlState] else {
+            guard error.serverInfo?[.sqlState] != nil else {
                 // any error message that doesn't have a sql state field, is unexpected by default.
                 return true
             }

--- a/Tests/PostgresNIOTests/New/Connection State Machine/ExtendedQueryStateMachineTests.swift
+++ b/Tests/PostgresNIOTests/New/Connection State Machine/ExtendedQueryStateMachineTests.swift
@@ -274,6 +274,29 @@ import Logging
         #expect(state.readyForQueryReceived(.idle) == .fireEventReadyForQuery)
     }
 
+    @Test func test28xxxSQLStateQueryErrorDoesNotKillConnection() throws {
+        var state = try ConnectionStateMachine.makeReadyForQuery()
+
+        let logger = Logger.psqlTest
+        let promise = EmbeddedEventLoop().makePromise(of: PSQLRowStream.self)
+        promise.fail(PSQLError.uncleanShutdown) // we don't care about the error at all.
+        let query: PostgresQuery = "SELECT raises_invalid_authorization()"
+        let queryContext = ExtendedQueryContext(query: query, logger: logger, promise: promise)
+
+        #expect(state.enqueue(task: .extendedQuery(queryContext)) == .sendParseDescribeBindExecuteSync(query))
+        #expect(state.parseCompleteReceived() == .wait)
+        #expect(state.parameterDescriptionReceived(.init(dataTypes: [.int8])) == .wait)
+
+        // a stored procedure may RAISE an exception with a 28xxx sql state, without the
+        // connection itself having become invalid.
+        let serverError = PostgresBackendMessage.ErrorResponse(fields: [.severity: "ERROR", .sqlState: "28000"])
+        #expect(
+            state.errorReceived(serverError) == .failQuery(promise, with: .server(serverError), cleanupContext: .none)
+        )
+
+        #expect(state.readyForQueryReceived(.idle) == .fireEventReadyForQuery)
+    }
+
     @Test func testQueryErrorAfterCancelDoesNotKillConnection() throws {
         var state = try ConnectionStateMachine.makeReadyForQuery()
 


### PR DESCRIPTION
In the current implementation, 28xxx SQL state errors from the server, which are listed as "Class 28 - Invalid Authorization Specification" are treated as connection-fatal. This PR removes that behavior, as there are conditions under which such errors can be generated without meaning that the connection is no longer valid. The most obvious example is the case where a stored procedure `RAISE`s an exception with a 28xxx SQL state to indicate specific error conditions. An actual authentication failure still results in connection closure without this check, and by not closing the connection in case of error, such stored procedures—and other cases where 28xxx SQL states are use—can operate as designed.