### PR TITLE
Clamp Date instead of crashing

### DIFF
--- a/Sources/PostgresNIO/Data/PostgresData+Date.swift
+++ b/Sources/PostgresNIO/Data/PostgresData+Date.swift
@@ -4,8 +4,7 @@ import NIOCore
 extension PostgresData {
     public init(date: Date) {
         var buffer = ByteBufferAllocator().buffer(capacity: 0)
-        let seconds = date.timeIntervalSince(_psqlDateStart) * Double(_microsecondsPerSecond)
-        buffer.writeInteger(Int64(seconds))
+        buffer.writeInteger(date._psqlMicroseconds)
         self.init(type: .timestamptz, value: buffer)
     }
     

--- a/Sources/PostgresNIO/New/Data/Date+PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/Data/Date+PostgresCodable.swift
@@ -15,8 +15,25 @@ extension Date: PostgresNonThrowingEncodable {
         into byteBuffer: inout ByteBuffer,
         context: PostgresEncodingContext<JSONEncoder>
     ) {
-        let seconds = self.timeIntervalSince(Self._psqlDateStart) * Double(Self._microsecondsPerSecond)
-        byteBuffer.writeInteger(Int64(seconds))
+        byteBuffer.writeInteger(self._psqlMicroseconds)
+    }
+
+    /// The number of microseconds between ``_psqlDateStart`` and this `Date`, in PostgreSQL's
+    /// timestamp representation.
+    ///
+    /// This clamps to `MIN_TIMESTAMP` - 1 for underflow and to `END_TIMESTAMP` for overflow,
+    /// allowing Postgres to reject the value. We cannot reject it ourselves because 
+    /// of the `PostgresNonThrowingEncodable` conformance.
+    @usableFromInline
+    var _psqlMicroseconds: Int64 {
+        let microseconds = self.timeIntervalSince(Self._psqlDateStart) * Double(Self._microsecondsPerSecond)
+        guard 
+            let exact = Int64(exactly: microseconds.rounded(.towardZero)),
+            exact >= Self._minTimestamp, exact < Self._endTimestamp
+        else {
+            return microseconds < 0 ? Self._minTimestamp - 1 : Self._endTimestamp
+        }
+        return exact
     }
 
     // MARK: Private Constants
@@ -25,6 +42,12 @@ extension Date: PostgresNonThrowingEncodable {
     static let _microsecondsPerSecond: Int64 = 1_000_000
     @usableFromInline
     static let _secondsInDay: Int64 = 24 * 60 * 60
+    /// PostgreSQL's `END_TIMESTAMP`.
+    @usableFromInline
+    static let _endTimestamp: Int64 = 9_223_371_331_200_000_000
+    /// PostgreSQL's `MIN_TIMESTAMP`.
+    @usableFromInline
+    static let _minTimestamp: Int64 = -211_813_488_000_000_000
 
     /// values are stored as seconds before or after midnight 2000-01-01
     @usableFromInline

--- a/Tests/IntegrationTests/DateIntegrationTests.swift
+++ b/Tests/IntegrationTests/DateIntegrationTests.swift
@@ -10,16 +10,18 @@ struct DateIntegrationTests {
     @Test(
         .bug("https://github.com/vapor/postgres-nio/issues/632"),
         arguments: [
-            Date(timeIntervalSince1970: .greatestFiniteMagnitude),
-            Date(timeIntervalSince1970: -.greatestFiniteMagnitude),
-            Date(timeIntervalSince1970: .infinity),
-            Date(timeIntervalSince1970: -.infinity),
-            Date(timeIntervalSince1970: .nan),
+            Double.greatestFiniteMagnitude,
+            -.greatestFiniteMagnitude,
+            .infinity,
+            -.infinity,
+            .nan,
             // Int64.min, which would become -infinity
-            Date(timeInterval: -9_223_372_036_854.775390625, since: Date(timeIntervalSince1970: 946_684_800)),
+            -9_223_372_036_854.775390625,
         ]
     )
-    func outOfRangeDatesAreRejectedByTheServer(date: Date) async throws {
+    func outOfRangeDatesAreRejectedByTheServer(secondsSincePSQLDateStart: Double) async throws {
+        let date = Date(timeInterval: secondsSincePSQLDateStart, since: Date(timeIntervalSince1970: 946_684_800))
+
         try await withTestConnection(on: MultiThreadedEventLoopGroup.singleton.any()) { connection in
             do {
                 let rows = try await connection.query("SELECT \(date)::timestamptz", logger: .psqlTest)

--- a/Tests/IntegrationTests/DateIntegrationTests.swift
+++ b/Tests/IntegrationTests/DateIntegrationTests.swift
@@ -1,0 +1,38 @@
+import Foundation
+import Logging
+import NIOCore
+import NIOPosix
+import PostgresNIO
+import Testing
+
+@Suite
+struct DateIntegrationTests {
+    @Test(
+        .bug("https://github.com/vapor/postgres-nio/issues/632"),
+        arguments: [
+            Date(timeIntervalSince1970: .greatestFiniteMagnitude),
+            Date(timeIntervalSince1970: -.greatestFiniteMagnitude),
+            Date(timeIntervalSince1970: .infinity),
+            Date(timeIntervalSince1970: -.infinity),
+            Date(timeIntervalSince1970: .nan),
+            // Int64.min, which would become -infinity
+            Date(timeInterval: -9_223_372_036_854.775390625, since: Date(timeIntervalSince1970: 946_684_800)),
+        ]
+    )
+    func outOfRangeDatesAreRejectedByTheServer(date: Date) async throws {
+        try await withTestConnection(on: MultiThreadedEventLoopGroup.singleton.any()) { connection in
+            do {
+                let rows = try await connection.query("SELECT \(date)::timestamptz", logger: .psqlTest)
+                for try await row in rows {
+                    Issue.record("Expected the server to reject the date, got \(row)")
+                }
+                Issue.record("Expected the server to reject the date")
+            } catch let error as PSQLError {
+                #expect(error.code == .server)
+                // PostgresError.Code.datetimeFieldOverflow
+                #expect(error.serverInfo?[.sqlState] == "22008")
+                #expect(error.serverInfo?[.message] == "timestamp out of range")
+            }
+        }
+    }
+}

--- a/Tests/PostgresNIOTests/New/Data/Date+PSQLCodableTests.swift
+++ b/Tests/PostgresNIOTests/New/Data/Date+PSQLCodableTests.swift
@@ -1,89 +1,112 @@
-import XCTest
+import Foundation
 import NIOCore
+import Testing
+
 @testable import PostgresNIO
 
-class Date_PSQLCodableTests: XCTestCase {
+@Suite
+struct Date_PSQLCodableTests {
 
-    func testNowRoundTrip() {
+    @Test func nowRoundTrip() throws {
         let value = Date()
 
         var buffer = ByteBuffer()
         value.encode(into: &buffer, context: .default)
-        XCTAssertEqual(Date.psqlType, .timestamptz)
-        XCTAssertEqual(buffer.readableBytes, 8)
+        #expect(Date.psqlType == .timestamptz)
+        #expect(buffer.readableBytes == 8)
 
-        var result: Date?
-        XCTAssertNoThrow(result = try Date(from: &buffer, type: .timestamptz, format: .binary, context: .default))
-        XCTAssertEqual(value.timeIntervalSince1970, result?.timeIntervalSince1970 ?? 0, accuracy: 0.001)
+        let result = try Date(from: &buffer, type: .timestamptz, format: .binary, context: .default)
+        #expect(abs(value.timeIntervalSince1970 - result.timeIntervalSince1970) < 0.001)
     }
 
-    func testDecodeRandomDate() {
+    @Test func decodeRandomDate() {
         var buffer = ByteBuffer()
         buffer.writeInteger(Int64.random(in: Int64.min...Int64.max))
 
         var result: Date?
-        XCTAssertNoThrow(result = try Date(from: &buffer, type: .timestamptz, format: .binary, context: .default))
-        XCTAssertNotNil(result)
+        #expect(throws: Never.self) { 
+            result = try Date(from: &buffer, type: .timestamptz, format: .binary, context: .default) 
+        }
+        #expect(result != nil)
     }
 
-    func testDecodeFailureInvalidLength() {
+    @Test func decodeFailureInvalidLength() {
         var buffer = ByteBuffer()
         buffer.writeInteger(Int64.random(in: Int64.min...Int64.max))
         buffer.writeInteger(Int64.random(in: Int64.min...Int64.max))
 
-        XCTAssertThrowsError(try Date(from: &buffer, type: .timestamptz, format: .binary, context: .default)) {
-            XCTAssertEqual($0 as? PostgresDecodingError.Code, .failure)
+        #expect(throws: PostgresDecodingError.Code.failure) { 
+            try Date(from: &buffer, type: .timestamptz, format: .binary, context: .default) 
         }
     }
 
-    func testDecodeDate() {
+    @Test func decodeDate() {
         var firstDateBuffer = ByteBuffer()
         firstDateBuffer.writeInteger(Int32.min)
 
         var firstDate: Date?
-        XCTAssertNoThrow(firstDate = try Date(from: &firstDateBuffer, type: .date, format: .binary, context: .default))
-        XCTAssertNotNil(firstDate)
+        #expect(throws: Never.self) { 
+            firstDate = try Date(from: &firstDateBuffer, type: .date, format: .binary, context: .default) 
+        }
+        #expect(firstDate != nil)
 
         var lastDateBuffer = ByteBuffer()
         lastDateBuffer.writeInteger(Int32.max)
 
         var lastDate: Date?
-        XCTAssertNoThrow(lastDate = try Date(from: &lastDateBuffer, type: .date, format: .binary, context: .default))
-        XCTAssertNotNil(lastDate)
+        #expect(throws: Never.self) { 
+            lastDate = try Date(from: &lastDateBuffer, type: .date, format: .binary, context: .default) 
+        }
+        #expect(lastDate != nil)
     }
 
-    func testDecodeDateFromTimestamp() {
-        var firstDateBuffer = ByteBuffer()
-        firstDateBuffer.writeInteger(Int32.min)
-
-        var firstDate: Date?
-        XCTAssertNoThrow(firstDate = try Date(from: &firstDateBuffer, type: .date, format: .binary, context: .default))
-        XCTAssertNotNil(firstDate)
-
-        var lastDateBuffer = ByteBuffer()
-        lastDateBuffer.writeInteger(Int32.max)
-
-        var lastDate: Date?
-        XCTAssertNoThrow(lastDate = try Date(from: &lastDateBuffer, type: .date, format: .binary, context: .default))
-        XCTAssertNotNil(lastDate)
-    }
-
-    func testDecodeDateFailsWithTooMuchData() {
+    @Test func decodeDateFailsWithTooMuchData() {
         var buffer = ByteBuffer()
         buffer.writeInteger(Int64(0))
 
-        XCTAssertThrowsError(try Date(from: &buffer, type: .date, format: .binary, context: .default)) {
-            XCTAssertEqual($0 as? PostgresDecodingError.Code, .failure)
+        #expect(throws: PostgresDecodingError.Code.failure) {
+            try Date(from: &buffer, type: .date, format: .binary, context: .default)
         }
     }
 
-    func testDecodeDateFailsWithWrongDataType() {
+    @Test func decodeDateFailsWithWrongDataType() {
         var buffer = ByteBuffer()
         buffer.writeInteger(Int64(0))
 
-        XCTAssertThrowsError(try Date(from: &buffer, type: .int8, format: .binary, context: .default)) {
-            XCTAssertEqual($0 as? PostgresDecodingError.Code, .typeMismatch)
+        #expect(throws: PostgresDecodingError.Code.typeMismatch) {
+            try Date(from: &buffer, type: .int8, format: .binary, context: .default)
         }
     }
 
+    @Test(
+        .bug("https://github.com/vapor/postgres-nio/issues/632"),
+        arguments: [
+            (Date(timeIntervalSince1970: .greatestFiniteMagnitude), Date._endTimestamp),
+            (Date(timeIntervalSince1970: -.greatestFiniteMagnitude), Date._minTimestamp - 1),
+            (Date(timeIntervalSince1970: .infinity), Date._endTimestamp),
+            (Date(timeIntervalSince1970: -.infinity), Date._minTimestamp - 1),
+            (Date(timeIntervalSince1970: .nan), Date._endTimestamp),
+            (Date(timeInterval: 9_300_000_000_000, since: Date(timeIntervalSince1970: 946_684_800)), Date._endTimestamp),
+            (Date(timeInterval: -9_300_000_000_000, since: Date(timeIntervalSince1970: 946_684_800)), Date._minTimestamp - 1)
+        ])
+    func encodeDatesOutsideOfInt64MicrosecondRange(value: Date, expected: Int64) {
+        var buffer = ByteBuffer()
+        value.encode(into: &buffer, context: .default)
+        #expect(buffer.readInteger(as: Int64.self) == expected)
+    }
+
+    @Test(.bug("https://github.com/vapor/postgres-nio/issues/632"))
+    func encodeDateLandingExactlyOnNegativeInfinity() {
+        let value = Date(
+            timeInterval: -9_223_372_036_854.775390625,
+            since: Date(timeIntervalSince1970: 946_684_800)
+        )
+        // Precondition for this test to be meaningful: the naive conversion does produce `Int64.min`.
+        let naive = value.timeIntervalSince(Date(timeIntervalSince1970: 946_684_800)) * 1_000_000
+        #expect(Int64(exactly: naive.rounded(.towardZero)) == Int64.min)
+
+        var buffer = ByteBuffer()
+        value.encode(into: &buffer, context: .default)
+        #expect(buffer.readInteger(as: Int64.self) == Date._minTimestamp - 1)
+    }
 }

--- a/Tests/PostgresNIOTests/New/Data/Date+PSQLCodableTests.swift
+++ b/Tests/PostgresNIOTests/New/Data/Date+PSQLCodableTests.swift
@@ -81,15 +81,17 @@ struct Date_PSQLCodableTests {
     @Test(
         .bug("https://github.com/vapor/postgres-nio/issues/632"),
         arguments: [
-            (Date(timeIntervalSince1970: .greatestFiniteMagnitude), Date._endTimestamp),
-            (Date(timeIntervalSince1970: -.greatestFiniteMagnitude), Date._minTimestamp - 1),
-            (Date(timeIntervalSince1970: .infinity), Date._endTimestamp),
-            (Date(timeIntervalSince1970: -.infinity), Date._minTimestamp - 1),
-            (Date(timeIntervalSince1970: .nan), Date._endTimestamp),
-            (Date(timeInterval: 9_300_000_000_000, since: Date(timeIntervalSince1970: 946_684_800)), Date._endTimestamp),
-            (Date(timeInterval: -9_300_000_000_000, since: Date(timeIntervalSince1970: 946_684_800)), Date._minTimestamp - 1)
+            (Double.greatestFiniteMagnitude, Date._endTimestamp),
+            (-.greatestFiniteMagnitude, Date._minTimestamp - 1),
+            (.infinity, Date._endTimestamp),
+            (-.infinity, Date._minTimestamp - 1),
+            (.nan, Date._endTimestamp),
+            (9_300_000_000_000, Date._endTimestamp),
+            (-9_300_000_000_000, Date._minTimestamp - 1)
         ])
-    func encodeDatesOutsideOfInt64MicrosecondRange(value: Date, expected: Int64) {
+    func encodeDatesOutsideOfInt64MicrosecondRange(secondsSincePSQLDateStart: Double, expected: Int64) {
+        let value = Date(timeInterval: secondsSincePSQLDateStart, since: Date(timeIntervalSince1970: 946_684_800))
+
         var buffer = ByteBuffer()
         value.encode(into: &buffer, context: .default)
         #expect(buffer.readInteger(as: Int64.self) == expected)


### PR DESCRIPTION
Fixes #632 

If we tried encoding a date > Int64.max or < Int64.min we crashed. This avoids the crash by clamping to PSQL's `END_TIMESTAMP` and `MIN_TIMESTAMP`. We cannot throw since `Date` is `PostgresNonThrowingEncodable`, so we convert to one of `END_TIMESTAMP` or `MIN_TIMESTAMP - 1` so it's Postgres who returns an error, instead of silently using a different value. Also updates the `Date_PSQLCodableTests` to Swift Testing
