### PR TITLE
Fix prepared statement result format

### DIFF
--- a/Sources/PostgresNIO/New/Connection State Machine/ExtendedQueryStateMachine.swift
+++ b/Sources/PostgresNIO/New/Connection State Machine/ExtendedQueryStateMachine.swift
@@ -267,7 +267,7 @@ struct ExtendedQueryStateMachine {
             return .wait
 
         case .prepareStatement(_, _, _, let eventLoopPromise):
-            return .succeedPreparedStatementCreation(eventLoopPromise, with: rowDescription)
+            return .succeedPreparedStatementCreation(eventLoopPromise, with: RowDescription(columns: columns))
         }
     }
     

--- a/Tests/IntegrationTests/PreparedQueryIntegrationTests.swift
+++ b/Tests/IntegrationTests/PreparedQueryIntegrationTests.swift
@@ -1,0 +1,58 @@
+import Logging
+import NIOCore
+import NIOPosix
+import PostgresNIO
+import Testing
+
+@Suite
+struct PreparedQueryIntegrationTests {
+    @Test(.bug("https://github.com/vapor/postgres-nio/issues/303"))
+    func selectPlain() async throws {
+        try await withTestConnection(on: MultiThreadedEventLoopGroup.singleton.any()) { connection in
+            let result = try await connection.query("SELECT 10, 20", logger: .psqlTest).collect()
+
+            #expect(result.count == 1)
+            let values = try #require(result.first).decode((Int, Int).self)
+            #expect(values == (10, 20))
+        }
+    }
+
+    @Test(.bug("https://github.com/vapor/postgres-nio/issues/303"))
+    func selectPlainPrepared() async throws {
+        try await withTestConnection(on: MultiThreadedEventLoopGroup.singleton.any()) { connection in
+            let prepared = try await connection.prepare(query: "SELECT 10, 20").get()
+            let rows = try await prepared.execute().get()
+
+            #expect(rows.count == 1)
+            let values = try #require(rows.first).decode((Int, Int).self)
+            #expect(values == (10, 20))
+
+            try await prepared.deallocate().get()
+        }
+    }
+
+    @Test(.bug("https://github.com/vapor/postgres-nio/issues/303"))
+    func selectBound() async throws {
+        try await withTestConnection(on: MultiThreadedEventLoopGroup.singleton.any()) { connection in
+            let result = try await connection.query("SELECT \(10)::int8, \(20)::int8", logger: .psqlTest).collect()
+
+            #expect(result.count == 1)
+            let values = try #require(result.first).decode((Int, Int).self)
+            #expect(values == (10, 20))
+        }
+    }
+
+    @Test(.bug("https://github.com/vapor/postgres-nio/issues/303"))
+    func selectBoundPrepared() async throws {
+        try await withTestConnection(on: MultiThreadedEventLoopGroup.singleton.any()) { connection in
+            let prepared = try await connection.prepare(query: "SELECT $1::int8, $2::int8").get()
+            let rows = try await prepared.execute([PostgresData(int: 10), PostgresData(int: 20)]).get()
+
+            #expect(rows.count == 1)
+            let values = try #require(rows.first).decode((Int, Int).self)
+            #expect(values == (10, 20))
+
+            try await prepared.deallocate().get()
+        }
+    }
+}

--- a/Tests/IntegrationTests/PreparedQueryIntegrationTests.swift
+++ b/Tests/IntegrationTests/PreparedQueryIntegrationTests.swift
@@ -7,17 +7,6 @@ import Testing
 @Suite
 struct PreparedQueryIntegrationTests {
     @Test(.bug("https://github.com/vapor/postgres-nio/issues/303"))
-    func selectPlain() async throws {
-        try await withTestConnection(on: MultiThreadedEventLoopGroup.singleton.any()) { connection in
-            let result = try await connection.query("SELECT 10, 20", logger: .psqlTest).collect()
-
-            #expect(result.count == 1)
-            let values = try #require(result.first).decode((Int, Int).self)
-            #expect(values == (10, 20))
-        }
-    }
-
-    @Test(.bug("https://github.com/vapor/postgres-nio/issues/303"))
     func selectPlainPrepared() async throws {
         try await withTestConnection(on: MultiThreadedEventLoopGroup.singleton.any()) { connection in
             let prepared = try await connection.prepare(query: "SELECT 10, 20").get()
@@ -28,17 +17,6 @@ struct PreparedQueryIntegrationTests {
             #expect(values == (10, 20))
 
             try await prepared.deallocate().get()
-        }
-    }
-
-    @Test(.bug("https://github.com/vapor/postgres-nio/issues/303"))
-    func selectBound() async throws {
-        try await withTestConnection(on: MultiThreadedEventLoopGroup.singleton.any()) { connection in
-            let result = try await connection.query("SELECT \(10)::int8, \(20)::int8", logger: .psqlTest).collect()
-
-            #expect(result.count == 1)
-            let values = try #require(result.first).decode((Int, Int).self)
-            #expect(values == (10, 20))
         }
     }
 

--- a/Tests/PostgresNIOTests/New/Connection State Machine/PrepareStatementStateMachineTests.swift
+++ b/Tests/PostgresNIOTests/New/Connection State Machine/PrepareStatementStateMachineTests.swift
@@ -28,6 +28,39 @@ import NIOEmbedded
                        .succeedPreparedStatementCreation(promise, with: .init(columns: columns)))
         #expect(state.readyForQueryReceived(.idle) == .fireEventReadyForQuery)
     }
+
+    @Test(.bug("https://github.com/vapor/postgres-nio/issues/303")) 
+    func testCreatePreparedStatementReturnsBinaryFormattedRowDescription() throws {
+        var state = try ConnectionStateMachine.makeReadyForQuery()
+
+        let promise = EmbeddedEventLoop().makePromise(of: RowDescription?.self)
+        promise.fail(PSQLError.uncleanShutdown) // we don't care about the error at all.
+
+        let name = "haha"
+        let query = #"SELECT id FROM users WHERE id = $1 "#
+        let prepareStatementContext = ExtendedQueryContext(
+            name: name, query: query, bindingDataTypes: [], logger: .psqlTest, promise: promise
+        )
+
+        #expect(state.enqueue(task: .extendedQuery(prepareStatementContext)) ==
+                       .sendParseDescribeSync(name: name, query: query, bindingDataTypes: []))
+        #expect(state.parseCompleteReceived() == .wait)
+        #expect(state.parameterDescriptionReceived(.init(dataTypes: [.int8])) == .wait)
+
+        let textColumns: [RowDescription.Column] = [
+            .init(name: "id", tableOID: 0, columnAttributeNumber: 0, dataType: .int8, dataTypeSize: 8, dataTypeModifier: -1, format: .text
+        )
+        ]
+        let binaryColumns = textColumns.map { column -> RowDescription.Column in
+            var column = column
+            column.format = .binary
+            return column
+        }
+
+        #expect(state.rowDescriptionReceived(.init(columns: textColumns)) ==
+                       .succeedPreparedStatementCreation(promise, with: .init(columns: binaryColumns)))
+        #expect(state.readyForQueryReceived(.idle) == .fireEventReadyForQuery)
+    }
     
     @Test func testCreatePreparedStatementReturningNoData() throws {
         var state = try ConnectionStateMachine.makeReadyForQuery()


### PR DESCRIPTION
Fixes #303 

We're not correctly parsing metadata, parsing it as text instead of binary. This isn't hit by the new prepared statement APIs but since it's a one line fix we might as well add it