### PR TITLE
Conform `buffer` parameter name to rest of the codebase

### DIFF
--- a/Sources/PostgresNIO/New/Data/PostgresDataType+PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/Data/PostgresDataType+PostgresCodable.swift
@@ -3,7 +3,7 @@ import NIOCore
 extension PostgresDataType: PostgresDecodable {
     @inlinable
     public init<JSONDecoder>(
-        from byteBuffer: inout ByteBuffer,
+        from buffer: inout ByteBuffer,
         type: PostgresDataType,
         format: PostgresFormat,
         context: PostgresDecodingContext<JSONDecoder>
@@ -11,16 +11,16 @@ extension PostgresDataType: PostgresDecodable {
         switch (format, type) {
         case (.binary, .oid), (.binary, .regproc), (.binary, .regclass), (.binary, .regtype):
             guard
-                byteBuffer.readableBytes == 4,
-                let value = byteBuffer.readInteger(as: UInt32.self)
+                buffer.readableBytes == 4,
+                let value = buffer.readInteger(as: UInt32.self)
             else {
                 throw PostgresDecodingError.Code.failure
             }
             self.rawValue = value
         case (.binary, .int4):
             guard
-                byteBuffer.readableBytes == 4,
-                let value = byteBuffer.readInteger(as: Int32.self).flatMap(UInt32.init(exactly:))
+                buffer.readableBytes == 4,
+                let value = buffer.readInteger(as: Int32.self).flatMap(UInt32.init(exactly:))
             else {
                 throw PostgresDecodingError.Code.failure
             }
@@ -29,7 +29,7 @@ extension PostgresDataType: PostgresDecodable {
         // In text form they're a string containing a name and so cannot be decoded into a PostgresDataType.
         case (.text, .oid), (.text, .int4):
             guard
-                let string = byteBuffer.readString(length: byteBuffer.readableBytes),
+                let string = buffer.readString(length: buffer.readableBytes),
                 let value = UInt32(string)
             else {
                 throw PostgresDecodingError.Code.failure

--- a/Sources/PostgresNIO/New/Data/Range+PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/Data/Range+PostgresCodable.swift
@@ -99,7 +99,7 @@ struct PostgresRangeFlag {
 extension PostgresRange: PostgresDecodable where Bound: PostgresRangeDecodable {
     @inlinable
     init<JSONDecoder: PostgresJSONDecoder>(
-        from byteBuffer: inout ByteBuffer,
+        from buffer: inout ByteBuffer,
         type: PostgresDataType,
         format: PostgresFormat,
         context: PostgresDecodingContext<JSONDecoder>
@@ -113,7 +113,7 @@ extension PostgresRange: PostgresDecodable where Bound: PostgresRangeDecodable {
         }
 
         // flags byte contains certain properties of the range
-        guard let flags: UInt8 = byteBuffer.readInteger(as: UInt8.self) else {
+        guard let flags: UInt8 = buffer.readInteger(as: UInt8.self) else {
             throw PostgresDecodingError.Code.failure
         }
 
@@ -128,18 +128,18 @@ extension PostgresRange: PostgresDecodable where Bound: PostgresRangeDecodable {
             return
         }
 
-        guard let lowerBoundSize: Int32 = byteBuffer.readInteger(as: Int32.self),
+        guard let lowerBoundSize: Int32 = buffer.readInteger(as: Int32.self),
             Int(lowerBoundSize) == MemoryLayout<Bound>.size,
-            var lowerBoundBytes: ByteBuffer = byteBuffer.readSlice(length: Int(lowerBoundSize))
+            var lowerBoundBytes: ByteBuffer = buffer.readSlice(length: Int(lowerBoundSize))
         else {
             throw PostgresDecodingError.Code.failure
         }
 
         let lowerBound = try Bound(from: &lowerBoundBytes, type: boundType, format: format, context: context)
 
-        guard let upperBoundSize = byteBuffer.readInteger(as: Int32.self),
+        guard let upperBoundSize = buffer.readInteger(as: Int32.self),
             Int(upperBoundSize) == MemoryLayout<Bound>.size,
-            var upperBoundBytes: ByteBuffer = byteBuffer.readSlice(length: Int(upperBoundSize))
+            var upperBoundBytes: ByteBuffer = buffer.readSlice(length: Int(upperBoundSize))
         else {
             throw PostgresDecodingError.Code.failure
         }

--- a/Sources/PostgresNIO/New/PostgresCodable.swift
+++ b/Sources/PostgresNIO/New/PostgresCodable.swift
@@ -82,7 +82,7 @@ public protocol PostgresDecodable {
     ///              to use when decoding JSON and metadata to create better errors.
     /// - Returns: A decoded object.
     init<JSONDecoder: PostgresJSONDecoder>(
-        from byteBuffer: inout ByteBuffer,
+        from buffer: inout ByteBuffer,
         type: PostgresDataType,
         format: PostgresFormat,
         context: PostgresDecodingContext<JSONDecoder>
@@ -91,7 +91,7 @@ public protocol PostgresDecodable {
     /// Decode an entity from the `buffer` in Postgres wire format. This method has a default implementation and
     /// is only overridden for `Optional`s.
     static func _decodeRaw<JSONDecoder: PostgresJSONDecoder>(
-        from byteBuffer: inout ByteBuffer?,
+        from buffer: inout ByteBuffer?,
         type: PostgresDataType,
         format: PostgresFormat,
         context: PostgresDecodingContext<JSONDecoder>
@@ -101,12 +101,12 @@ public protocol PostgresDecodable {
 extension PostgresDecodable {
     @inlinable
     public static func _decodeRaw<JSONDecoder: PostgresJSONDecoder>(
-        from byteBuffer: inout ByteBuffer?,
+        from buffer: inout ByteBuffer?,
         type: PostgresDataType,
         format: PostgresFormat,
         context: PostgresDecodingContext<JSONDecoder>
     ) throws -> Self {
-        guard var buffer = byteBuffer else {
+        guard var buffer = buffer else {
             throw PostgresDecodingError.Code.missingData
         }
         return try self.init(from: &buffer, type: type, format: format, context: context)
@@ -210,7 +210,7 @@ extension Optional: PostgresDecodable where Wrapped: PostgresDecodable, Wrapped.
     public typealias _DecodableType = Wrapped
 
     public init<JSONDecoder: PostgresJSONDecoder>(
-        from byteBuffer: inout ByteBuffer,
+        from buffer: inout ByteBuffer,
         type: PostgresDataType,
         format: PostgresFormat,
         context: PostgresDecodingContext<JSONDecoder>
@@ -220,12 +220,12 @@ extension Optional: PostgresDecodable where Wrapped: PostgresDecodable, Wrapped.
 
     @inlinable
     public static func _decodeRaw<JSONDecoder : PostgresJSONDecoder>(
-        from byteBuffer: inout ByteBuffer?,
+        from buffer: inout ByteBuffer?,
         type: PostgresDataType,
         format: PostgresFormat,
         context: PostgresDecodingContext<JSONDecoder>
     ) throws -> Optional<Wrapped> {
-        switch byteBuffer {
+        switch buffer {
         case .some(var buffer):
             return try Wrapped(from: &buffer, type: type, format: format, context: context)
         case .none:


### PR DESCRIPTION
Fixes #629 

Most of the codebase uses `buffer` as ByteBuffer parameter name, as the documentation tells these are outliers
